### PR TITLE
add endpoint to query for all events after a given date

### DIFF
--- a/server/common.go
+++ b/server/common.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 Coinbase, Inc. See LICENSE
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/CoinbaseWallet/walletlinkd/store/models"
+	"github.com/pkg/errors"
+)
+
+const (
+	responseErrorInvalidSessionCredentials = "invalid session credentials"
+	responseErrorInternalError             = "internal error"
+)
+
+func (srv *Server) getSessionByBasicAuth(
+	r *http.Request,
+) (session *models.Session, statusCode int, err error) {
+	sessionID, sessionKey, ok := r.BasicAuth()
+	if !ok {
+		return nil, 401, errors.New(responseErrorInvalidSessionCredentials)
+	}
+
+	session, err = models.LoadSession(srv.store, sessionID)
+	if err != nil {
+		return nil, 500, errors.New(responseErrorInternalError)
+	}
+
+	if session == nil || session.Key != sessionKey {
+		return nil, 401, errors.New(responseErrorInvalidSessionCredentials)
+	}
+
+	return session, 200, nil
+}
+
+func writeResponse(
+	w http.ResponseWriter,
+	statusCode int,
+	response interface{},
+) {
+	if statusCode == 401 {
+		w.Header().Set("WWW-Authenticate", `Basic realm="walletlinkd"`)
+	}
+	w.WriteHeader(statusCode)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		fmt.Println(errors.Wrap(err, "failed to write response json"))
+	}
+}

--- a/server/get_event.go
+++ b/server/get_event.go
@@ -3,81 +3,47 @@
 package server
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/CoinbaseWallet/walletlinkd/store/models"
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 )
 
-const (
-	getEventResponseErrorInvalidSessionCredentials = "invalid session credentials"
-	getEventResponseErrorInternalError             = "internal error"
-	getEventResponseErrorEventNotFound             = "event not found"
-)
+const getEventResponseErrorEventNotFound = "event not found"
+
+type getEventError struct {
+	statusCode  int
+	description string
+}
 
 type getEventResponse struct {
 	Event *models.Event `json:"event,omitempty"`
 	Error string        `json:"error,omitempty"`
 }
 
-func (srv *Server) getEventHandler(w http.ResponseWriter, r *http.Request) {
+func (srv *Server) getEventByIDHandler(w http.ResponseWriter, r *http.Request) {
 	eventID := mux.Vars(r)["id"]
 
-	sessionID, sessionKey, ok := r.BasicAuth()
-	if !ok {
-		writeGetEventResponse(w, 401, &getEventResponse{
-			Error: getEventResponseErrorInvalidSessionCredentials,
-		})
-		return
-	}
-
-	session, err := models.LoadSession(srv.store, sessionID)
+	session, statusCode, err := srv.getSessionByBasicAuth(r)
 	if err != nil {
-		writeGetEventResponse(w, 500, &getEventResponse{
-			Error: getEventResponseErrorInternalError,
-		})
+		writeResponse(w, statusCode, &getEventResponse{Error: err.Error()})
 		return
 	}
 
-	if session == nil || session.Key != sessionKey {
-		writeGetEventResponse(w, 401, &getEventResponse{
-			Error: getEventResponseErrorInvalidSessionCredentials,
-		})
-		return
-	}
-
-	event, err := models.LoadEvent(srv.store, sessionID, eventID)
+	event, err := models.LoadEvent(srv.store, session.ID, eventID)
 	if err != nil {
-		writeGetEventResponse(w, 500, &getEventResponse{
-			Error: getEventResponseErrorInternalError,
+		writeResponse(w, 500, &getEventResponse{
+			Error: responseErrorInternalError,
 		})
 		return
 	}
 
 	if event == nil {
-		writeGetEventResponse(w, 404, &getEventResponse{
+		writeResponse(w, 404, &getEventResponse{
 			Error: getEventResponseErrorEventNotFound,
 		})
 		return
 	}
 
-	writeGetEventResponse(w, 200, &getEventResponse{Event: event})
-}
-
-func writeGetEventResponse(
-	w http.ResponseWriter,
-	statusCode int,
-	response *getEventResponse,
-) {
-	if statusCode == 401 {
-		w.Header().Set("WWW-Authenticate", `Basic realm="walletlinkd"`)
-	}
-	w.WriteHeader(statusCode)
-
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		fmt.Println(errors.Wrap(err, "failed to write response json"))
-	}
+	writeResponse(w, 200, &getEventResponse{Event: event})
 }

--- a/server/get_event_test.go
+++ b/server/get_event_test.go
@@ -32,7 +32,7 @@ func TestGetEventNoSession(t *testing.T) {
 	body := getEventResponse{}
 	err = json.NewDecoder(resp.Body).Decode(&body)
 	require.Nil(t, err)
-	require.Equal(t, getEventResponseErrorInvalidSessionCredentials, body.Error)
+	require.Equal(t, responseErrorInvalidSessionCredentials, body.Error)
 	require.Nil(t, body.Event)
 }
 
@@ -58,7 +58,7 @@ func TestGetEventInvalidSessionKey(t *testing.T) {
 	body := getEventResponse{}
 	err = json.NewDecoder(resp.Body).Decode(&body)
 	require.Nil(t, err)
-	require.Equal(t, getEventResponseErrorInvalidSessionCredentials, body.Error)
+	require.Equal(t, responseErrorInvalidSessionCredentials, body.Error)
 	require.Nil(t, body.Event)
 }
 

--- a/server/get_events.go
+++ b/server/get_events.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2019 Coinbase, Inc. See LICENSE
+
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/CoinbaseWallet/walletlinkd/store/models"
+)
+
+type getEventsResponse struct {
+	Timestamp int64          `json:"timestamp,omitempty"`
+	Events    []models.Event `json:"events,omitempty"`
+	Error     string         `json:"error,omitempty"`
+}
+
+func (srv *Server) getEventsSinceHandler(
+	w http.ResponseWriter, r *http.Request,
+) {
+	session, statusCode, err := srv.getSessionByBasicAuth(r)
+	if err != nil {
+		writeResponse(w, statusCode, &getEventsResponse{Error: err.Error()})
+		return
+	}
+
+	seconds := int64(0)
+	timestamps, ok := r.URL.Query()["timestamp"]
+	if ok && len(timestamps) > 0 {
+		seconds, _ = strconv.ParseInt(timestamps[0], 10, 64)
+	}
+
+	events, err := models.LoadEventsForSession(srv.store, seconds, session.ID)
+	if err != nil {
+		writeResponse(w, 500, &getEventsResponse{Error: responseErrorInternalError})
+		return
+	}
+
+	writeResponse(w, 200, &getEventsResponse{
+		Timestamp: time.Now().Unix(),
+		Events:    events,
+	})
+}

--- a/server/get_events_test.go
+++ b/server/get_events_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2019 Coinbase, Inc. See LICENSE
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/CoinbaseWallet/walletlinkd/store/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEventsNoSession(t *testing.T) {
+	srv := NewServer(nil)
+
+	req, err := http.NewRequest("GET", "/events?timestamp=1559952410", nil)
+	require.Nil(t, err)
+
+	sessionID := "456"
+	sessionKey := "789"
+	req.SetBasicAuth(sessionID, sessionKey)
+
+	rr := httptest.NewRecorder()
+	srv.router.ServeHTTP(rr, req)
+
+	resp := rr.Result()
+	require.Equal(t, 401, resp.StatusCode)
+
+	body := getEventsResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.Nil(t, err)
+	require.Equal(t, responseErrorInvalidSessionCredentials, body.Error)
+	require.Nil(t, body.Events)
+}
+
+func TestGetEventsInvalidSessionKey(t *testing.T) {
+	srv := NewServer(nil)
+	sessionID := "456"
+
+	s := models.Session{ID: sessionID, Key: "correctKey"}
+	s.Save(srv.store)
+
+	req, err := http.NewRequest("GET", "/events?timestamp=1559952410", nil)
+	require.Nil(t, err)
+
+	sessionKey := "incorrectKey"
+	req.SetBasicAuth(sessionID, sessionKey)
+
+	rr := httptest.NewRecorder()
+	srv.router.ServeHTTP(rr, req)
+
+	resp := rr.Result()
+	require.Equal(t, 401, resp.StatusCode)
+
+	body := getEventsResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.Nil(t, err)
+	require.Equal(t, responseErrorInvalidSessionCredentials, body.Error)
+	require.Nil(t, body.Events)
+}
+
+func TestGetEventsNoEvent(t *testing.T) {
+	srv := NewServer(nil)
+	sessionID := "123"
+	sessionKey := "456"
+
+	s := models.Session{ID: sessionID, Key: sessionKey}
+	err := s.Save(srv.store)
+	require.Nil(t, err)
+
+	req, err := http.NewRequest("GET", "/events?timestamp=1559952410", nil)
+	require.Nil(t, err)
+
+	req.SetBasicAuth(sessionID, sessionKey)
+
+	rr := httptest.NewRecorder()
+	srv.router.ServeHTTP(rr, req)
+
+	resp := rr.Result()
+	require.Equal(t, 200, resp.StatusCode)
+
+	body := getEventsResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.Nil(t, err)
+	require.Empty(t, body.Error)
+	require.Len(t, body.Events, 0)
+}
+
+func TestGetEvents(t *testing.T) {
+	srv := NewServer(nil)
+	sessionID := "123"
+	sessionKey := "456"
+	timestamp := time.Now().Unix() - 1
+
+	s := models.Session{ID: sessionID, Key: sessionKey}
+	err := s.Save(srv.store)
+	require.Nil(t, err)
+
+	name := "name"
+	data := "data"
+
+	e1 := models.Event{ID: "abc", Event: name, Data: data}
+	err = e1.Save(srv.store, sessionID)
+	require.Nil(t, err)
+
+	e2 := models.Event{ID: "def", Event: name, Data: data}
+	err = e2.Save(srv.store, sessionID)
+	require.Nil(t, err)
+
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("/events?timestamp=%d", timestamp),
+		nil,
+	)
+	require.Nil(t, err)
+
+	req.SetBasicAuth(sessionID, sessionKey)
+
+	rr := httptest.NewRecorder()
+	srv.router.ServeHTTP(rr, req)
+
+	resp := rr.Result()
+	require.Equal(t, 200, resp.StatusCode)
+
+	body := getEventsResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.Nil(t, err)
+	require.Empty(t, body.Error)
+	require.Len(t, body.Events, 2)
+	require.Contains(t, body.Events, e1)
+	require.Contains(t, body.Events, e2)
+}
+
+func TestGetEventsBadTimestamp(t *testing.T) {
+	srv := NewServer(nil)
+	sessionID := "123"
+	sessionKey := "456"
+
+	s := models.Session{ID: sessionID, Key: sessionKey}
+	err := s.Save(srv.store)
+	require.Nil(t, err)
+
+	name := "name"
+	data := "data"
+
+	e1 := models.Event{ID: "abc", Event: name, Data: data}
+	err = e1.Save(srv.store, sessionID)
+	require.Nil(t, err)
+
+	e2 := models.Event{ID: "def", Event: name, Data: data}
+	err = e2.Save(srv.store, sessionID)
+	require.Nil(t, err)
+
+	req, err := http.NewRequest(
+		"GET",
+		"/events?timestamp=abdasd",
+		nil,
+	)
+	require.Nil(t, err)
+
+	req.SetBasicAuth(sessionID, sessionKey)
+
+	rr := httptest.NewRecorder()
+	srv.router.ServeHTTP(rr, req)
+
+	resp := rr.Result()
+	require.Equal(t, 200, resp.StatusCode)
+
+	body := getEventsResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.Nil(t, err)
+	require.Empty(t, body.Error)
+	require.Len(t, body.Events, 2)
+	require.Contains(t, body.Events, e1)
+	require.Contains(t, body.Events, e2)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -60,7 +60,8 @@ func NewServer(options *NewServerOptions) *Server {
 	}
 
 	router.HandleFunc("/rpc", srv.rpcHandler).Methods("GET")
-	router.HandleFunc("/events/{id}", srv.getEventHandler).Methods("GET")
+	router.HandleFunc("/events", srv.getEventsSinceHandler).Methods("GET")
+	router.HandleFunc("/events/{id}", srv.getEventByIDHandler).Methods("GET")
 
 	if len(options.WebRoot) > 0 {
 		router.PathPrefix("/").Methods("GET").Handler(

--- a/store/memory_store.go
+++ b/store/memory_store.go
@@ -4,7 +4,10 @@ package store
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -12,7 +15,12 @@ import (
 // MemoryStore - in-memory store
 type MemoryStore struct {
 	lock sync.Mutex
-	db   map[string][]byte
+	db   map[string]storeValue
+}
+
+type storeValue struct {
+	value     []byte
+	timestamp int64
 }
 
 var _ Store = (*MemoryStore)(nil)
@@ -20,7 +28,7 @@ var _ Store = (*MemoryStore)(nil)
 // NewMemoryStore - construct a MemoryStore
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		db: map[string][]byte{},
+		db: map[string]storeValue{},
 	}
 }
 
@@ -34,7 +42,7 @@ func (ms *MemoryStore) Set(key string, value interface{}) error {
 		return errors.Wrap(err, "could not serialize value")
 	}
 
-	ms.db[key] = j
+	ms.db[key] = storeValue{j, time.Now().Unix()}
 	return nil
 }
 
@@ -49,11 +57,51 @@ func (ms *MemoryStore) Get(key string, value interface{}) (bool, error) {
 		return false, nil
 	}
 
-	if err := json.Unmarshal(j, value); err != nil {
+	if err := json.Unmarshal(j.value, value); err != nil {
 		return false, errors.Wrap(err, "could not deserialize value")
 	}
 
 	return true, nil
+}
+
+// FindByPrefix - load all values whose key starts with the given prefix that
+// were updated after since.
+func (ms *MemoryStore) FindByPrefix(
+	prefix string,
+	since int64,
+	values interface{},
+) error {
+	valuesValue := reflect.ValueOf(values)
+	if valuesValue.Kind() != reflect.Ptr ||
+		valuesValue.Elem().Kind() != reflect.Slice {
+		return errors.New("values must be a pointer to a slice")
+	}
+
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	sliceType := reflect.TypeOf(values).Elem()
+	elemType := sliceType.Elem()
+
+	vs := reflect.New(sliceType).Elem()
+
+	for k, v := range ms.db {
+		if !strings.HasPrefix(k, prefix) || v.timestamp <= since {
+			continue
+		}
+
+		value := reflect.New(elemType).Interface()
+
+		if err := json.Unmarshal(v.value, value); err != nil {
+			continue
+		}
+
+		vs = reflect.Append(vs, reflect.ValueOf(value).Elem())
+	}
+
+	reflect.ValueOf(values).Elem().Set(vs)
+
+	return nil
 }
 
 // Remove - remove a key. does not return an error if key does not exist

--- a/store/memory_store_test.go
+++ b/store/memory_store_test.go
@@ -4,6 +4,7 @@ package store
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -84,4 +85,43 @@ func TestMemoryStoreRemove(t *testing.T) {
 	ok, err := ms.Get("foo", &loadedFoo)
 	require.False(t, ok)
 	require.Nil(t, err)
+}
+
+func TestMemoryStoreFindByPrefix(t *testing.T) {
+	ms := NewMemoryStore()
+
+	startTime := time.Now().Unix() - 1
+
+	foo := dummy{X: 123, Y: 20}
+	err := ms.Set("prefix_foo", &foo)
+	require.Nil(t, err)
+
+	bar := dummy{X: 546, Y: 23}
+	err = ms.Set("prefix_bar", &bar)
+	require.Nil(t, err)
+
+	values := []dummy{}
+	err = ms.FindByPrefix("prefix", startTime, &values)
+	require.Nil(t, err)
+	require.Len(t, values, 2)
+	require.Contains(t, values, foo)
+	require.Contains(t, values, bar)
+
+	values = []dummy{}
+	err = ms.FindByPrefix("prefid", startTime, &values)
+	require.Nil(t, err)
+	require.Len(t, values, 0)
+
+	values = []dummy{}
+	err = ms.FindByPrefix("prefix_f", startTime, &values)
+	require.Nil(t, err)
+	require.Len(t, values, 1)
+	require.Equal(t, foo, values[0])
+
+	intValue := 1234
+	err = ms.FindByPrefix("prefix", startTime, intValue)
+	require.NotNil(t, err)
+
+	err = ms.FindByPrefix("prefix", startTime, &intValue)
+	require.NotNil(t, err)
 }

--- a/store/models/event.go
+++ b/store/models/event.go
@@ -34,6 +34,16 @@ func LoadEvent(
 	return e, nil
 }
 
+// LoadEventsForSession - load all events from the store for the session with the given ID
+func LoadEventsForSession(st store.Store, since int64, sessionID string) ([]Event, error) {
+	e := []Event{}
+	err := st.FindByPrefix(sessionKeyPrefix(sessionID), since, &e)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load events")
+	}
+	return e, nil
+}
+
 // Save - save event in the store
 func (e *Event) Save(st store.Store, sessionID string) error {
 	storeKey := eventStoreKey(e.ID, sessionID)
@@ -50,5 +60,9 @@ func eventStoreKey(eventID string, sessionID string) string {
 	if len(eventID) == 0 || len(sessionID) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("session:%s:event:%s", sessionID, eventID)
+	return fmt.Sprintf("%s%s", sessionKeyPrefix(sessionID), eventID)
+}
+
+func sessionKeyPrefix(sessionID string) string {
+	return fmt.Sprintf("session:%s:event:", sessionID)
 }

--- a/store/postgres_store.go
+++ b/store/postgres_store.go
@@ -6,6 +6,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"time"
 
 	_ "github.com/lib/pq" // register postgres adapter
 	"github.com/pkg/errors"
@@ -16,6 +18,8 @@ type PostgresStore struct {
 	db        *sql.DB
 	tableName string
 }
+
+var _ Store = (*PostgresStore)(nil)
 
 // NewPostgresStore - make a connection to a PostgreSQL instance, and return
 // a PostgresStore
@@ -80,6 +84,55 @@ func (ps *PostgresStore) Get(key string, value interface{}) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// FindByPrefix - load all values whose key starts with the given prefix that
+// were updated after since.
+func (ps *PostgresStore) FindByPrefix(
+	prefix string,
+	since int64,
+	values interface{},
+) error {
+	valuesValue := reflect.ValueOf(values)
+	if valuesValue.Kind() != reflect.Ptr ||
+		valuesValue.Elem().Kind() != reflect.Slice {
+		return errors.New("values must be a pointer to a slice")
+	}
+
+	query := fmt.Sprintf(
+		`SELECT value
+		FROM %s
+		WHERE key LIKE $1 || '%%' AND updated_at > $2 ORDER BY updated_at DESC`,
+		ps.tableName,
+	)
+	rows, err := ps.db.Query(query, prefix, time.Unix(since, 0))
+	if err != nil {
+		return errors.Wrap(err, "failed to load values from postgres store")
+	}
+	defer rows.Close()
+
+	sliceType := reflect.TypeOf(values).Elem()
+	elemType := sliceType.Elem()
+
+	vs := reflect.New(sliceType).Elem()
+
+	for rows.Next() {
+		var j string
+		if err = rows.Scan(&j); err != nil {
+			return errors.Wrap(err, "failed to scan row")
+		}
+
+		value := reflect.New(elemType).Interface()
+		if err = json.Unmarshal([]byte(j), value); err != nil {
+			continue
+		}
+
+		vs = reflect.Append(vs, reflect.ValueOf(value).Elem())
+	}
+
+	reflect.ValueOf(values).Elem().Set(vs)
+
+	return nil
 }
 
 // Remove - remove a key. does not return an error if key does not exist

--- a/store/store.go
+++ b/store/store.go
@@ -6,5 +6,6 @@ package store
 type Store interface {
 	Set(key string, value interface{}) error
 	Get(key string, value interface{}) (ok bool, err error)
+	FindByPrefix(prefix string, since int64, values interface{}) error
 	Remove(key string) error
 }


### PR DESCRIPTION
* `memory_store` now saves a timestamp when adding to the store
* add a function to store to find by prefix since a given timestamp
* add endpoint to query for all events after a given date