### PR TITLE
Fix "too many connections" error

### DIFF
--- a/cmd/walletlinkd/walletlinkd.go
+++ b/cmd/walletlinkd/walletlinkd.go
@@ -32,7 +32,14 @@ func main() {
 		st = store.NewMemoryStore()
 	} else {
 		var err error
-		st, err = store.NewPostgresStore(config.PostgresURL, "store")
+		st, err = store.NewPostgresStore(
+			config.PostgresURL,
+			"store",
+			int(config.PGMaxIdelConns),
+			int(config.PGMaxOpenConns),
+			config.PGConnMaxLifetime,
+		)
+
 		if err != nil {
 			log.Panicln(err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,17 @@ var (
 
 	// WebhookTimeout - Timeout for webhook
 	WebhookTimeout time.Duration
+
+	// PGMaxIdelConns - maximum number of idle connections to postgres
+	PGMaxIdelConns, _ = strconv.ParseUint(
+		getEnv("PG_MAX_IDLE_CONNS", "10"), 10, 16)
+
+	// PGMaxOpenConns - maximum number of open connections to postgres
+	PGMaxOpenConns, _ = strconv.ParseUint(
+		getEnv("PG_MAX_OPEN_CONNS", "30"), 10, 16)
+
+	// PGConnMaxLifetime - maximum amount of time a connection may be reused
+	PGConnMaxLifetime time.Duration
 )
 
 func init() {
@@ -73,6 +84,9 @@ func init() {
 
 	webhookTimeoutSecs, _ := strconv.Atoi(getEnv("WEBHOOK_TIMEOUT_SECS", "10"))
 	WebhookTimeout = time.Second * time.Duration(webhookTimeoutSecs)
+
+	pgConnMaxLifetimeSecs, _ := strconv.Atoi(getEnv("PG_CONN_MAX_LIFETIME", "600"))
+	PGConnMaxLifetime = time.Second * time.Duration(pgConnMaxLifetimeSecs)
 }
 
 func getEnv(name string, defaultValue string) string {

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,9 @@ var (
 
 	// ReadDeadline - Deadline for reading messages
 	ReadDeadline time.Duration
+
+	// WebhookTimeout - Timeout for webhook
+	WebhookTimeout time.Duration
 )
 
 func init() {
@@ -67,6 +70,9 @@ func init() {
 
 	readDeadlineSecs, _ := strconv.Atoi(getEnv("READ_DEADLINE_SECS", "30"))
 	ReadDeadline = time.Second * time.Duration(readDeadlineSecs)
+
+	webhookTimeoutSecs, _ := strconv.Atoi(getEnv("WEBHOOK_TIMEOUT_SECS", "10"))
+	WebhookTimeout = time.Second * time.Duration(webhookTimeoutSecs)
 }
 
 func getEnv(name string, defaultValue string) string {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -44,9 +44,14 @@ func (srv *Server) rpcHandler(w http.ResponseWriter, r *http.Request) {
 
 	go func() {
 		for {
+			isClosed := false
+
 			res, ok := <-sendCh
 			if !ok {
 				return
+			}
+			if isClosed {
+				continue
 			}
 			if v, ok := res.(rune); ok && v == 'h' {
 				ws.WriteMessage(websocket.TextMessage, []byte("h"))
@@ -55,7 +60,7 @@ func (srv *Server) rpcHandler(w http.ResponseWriter, r *http.Request) {
 			if err := ws.WriteJSON(res); err != nil {
 				log.Println(errors.Wrap(err, "websocket write failed"))
 				ws.Close()
-				return
+				isClosed = true
 			}
 		}
 	}()

--- a/server/rpc/pub_sub.go
+++ b/server/rpc/pub_sub.go
@@ -15,12 +15,17 @@ type Subscriber chan<- interface{}
 
 type subscriberSet map[Subscriber]struct{}
 
+type subscriberLock struct {
+	IsUnsubcribed bool
+	Lock          *sync.Mutex
+}
+
 // PubSub - pub/sub interface for message senders
 type PubSub struct {
 	lock     *sync.Mutex
-	subMap   map[string]subscriberSet      // Subscription ID -> Subscribers
-	idMap    map[Subscriber]util.StringSet // Subscriber -> Subscription IDs
-	subLocks map[Subscriber]*sync.Mutex    // Subscriber -> mutex lock
+	subMap   map[string]subscriberSet       // Subscription ID -> Subscribers
+	idMap    map[Subscriber]util.StringSet  // Subscriber -> Subscription IDs
+	subLocks map[Subscriber]*subscriberLock // Subscriber -> mutex lock
 }
 
 // NewPubSub - construct a PubSub
@@ -29,7 +34,7 @@ func NewPubSub() *PubSub {
 		lock:     &sync.Mutex{},
 		subMap:   map[string]subscriberSet{},
 		idMap:    map[Subscriber]util.StringSet{},
-		subLocks: map[Subscriber]*sync.Mutex{},
+		subLocks: map[Subscriber]*subscriberLock{},
 	}
 }
 
@@ -54,7 +59,10 @@ func (cm *PubSub) Subscribe(id string, subscriber Subscriber) {
 	}
 
 	if _, ok := cm.subLocks[subscriber]; !ok {
-		cm.subLocks[subscriber] = &sync.Mutex{}
+		cm.subLocks[subscriber] = &subscriberLock{
+			IsUnsubcribed: false,
+			Lock:          &sync.Mutex{},
+		}
 	}
 
 	subscribers[subscriber] = struct{}{}
@@ -137,8 +145,12 @@ func (cm *PubSub) Publish(id string, msg interface{}) int {
 				return
 			}
 
-			subLock.Lock()
-			defer subLock.Unlock()
+			subLock.Lock.Lock()
+			defer subLock.Lock.Unlock()
+
+			if subLock.IsUnsubcribed {
+				return
+			}
 
 			subscriber <- msg
 		}()
@@ -152,8 +164,11 @@ func (cm *PubSub) unsubscribeOne(id string, subscriber Subscriber) {
 		return
 	}
 
-	subLock.Lock()
-	defer subLock.Unlock()
+	subLock.Lock.Lock()
+	defer func() {
+		subLock.IsUnsubcribed = true
+		subLock.Lock.Unlock()
+	}()
 
 	subSet, ok := cm.subMap[id]
 	if !ok {

--- a/store/postgres_store.go
+++ b/store/postgres_store.go
@@ -25,11 +25,19 @@ var _ Store = (*PostgresStore)(nil)
 
 // NewPostgresStore - make a connection to a PostgreSQL instance, and return
 // a PostgresStore
-func NewPostgresStore(url, tableName string) (*PostgresStore, error) {
+func NewPostgresStore(
+	url, tableName string,
+	maxIdleConns, maxOpenConns int,
+	maxConnMaxLifetime time.Duration,
+) (*PostgresStore, error) {
 	db, err := sql.Open("postgres", url)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open a postgres connection")
 	}
+
+	db.SetMaxIdleConns(maxIdleConns)
+	db.SetMaxOpenConns(maxOpenConns)
+	db.SetConnMaxLifetime(maxConnMaxLifetime)
 
 	return &PostgresStore{
 		db:        db,

--- a/store/postgres_store_test.go
+++ b/store/postgres_store_test.go
@@ -34,7 +34,7 @@ func TestPostgresStoreNonExisting(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	ps, err := NewPostgresStore(config.PostgresURL, "store")
+	ps, err := NewPostgresStore(config.PostgresURL, "store", 5, 5, time.Minute)
 	require.Nil(t, err)
 	defer ps.Close()
 
@@ -48,7 +48,7 @@ func TestPostgresStoreGetSet(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	ps, err := NewPostgresStore(config.PostgresURL, "store")
+	ps, err := NewPostgresStore(config.PostgresURL, "store", 5, 5, time.Minute)
 	require.Nil(t, err)
 	defer ps.Close()
 
@@ -91,7 +91,7 @@ func TestPosgresStoreOverwrite(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	ps, err := NewPostgresStore(config.PostgresURL, "store")
+	ps, err := NewPostgresStore(config.PostgresURL, "store", 5, 5, time.Minute)
 	require.Nil(t, err)
 	defer ps.Close()
 
@@ -121,7 +121,7 @@ func TestPostgresStoreRemove(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	ps, err := NewPostgresStore(config.PostgresURL, "store")
+	ps, err := NewPostgresStore(config.PostgresURL, "store", 5, 5, time.Minute)
 	require.Nil(t, err)
 	defer ps.Close()
 
@@ -147,7 +147,7 @@ func TestPostgresStoreFindByPrefix(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	ps, err := NewPostgresStore(config.PostgresURL, "store")
+	ps, err := NewPostgresStore(config.PostgresURL, "store", 5, 5, time.Minute)
 	require.Nil(t, err)
 	defer ps.Close()
 
@@ -191,7 +191,7 @@ func TestPostgresStoreMarkSeen(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	ps, err := NewPostgresStore(config.PostgresURL, "store")
+	ps, err := NewPostgresStore(config.PostgresURL, "store", 5, 5, time.Minute)
 	require.Nil(t, err)
 	defer ps.Close()
 

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"github.com/walletlink/walletlink/config"
 )
 
 // Caller - Interface for calling webhooks
@@ -22,6 +23,7 @@ var _ Caller = (*Webhook)(nil)
 // Webhook - used to broadcast push notifications
 type Webhook struct {
 	serverURL string
+	client    *http.Client
 }
 
 type callParams struct {
@@ -33,7 +35,15 @@ type callParams struct {
 
 // NewWebhook - returns a new Webhook instance
 func NewWebhook(serverURL string) *Webhook {
-	return &Webhook{serverURL: serverURL}
+	return &Webhook{
+		serverURL: serverURL,
+		client: &http.Client{
+			Transport: &http.Transport{
+				ResponseHeaderTimeout: config.WebhookTimeout,
+			},
+			Timeout: config.WebhookTimeout,
+		},
+	}
 }
 
 // Call - call webhook to notify about a new event
@@ -52,7 +62,7 @@ func (a *Webhook) Call(eventID, sessionID, webhookID, webhookURL string) error {
 		json.NewEncoder(pw).Encode(notification)
 	}()
 
-	res, err := http.Post(webhookURL, "application/json", pr)
+	res, err := a.client.Post(webhookURL, "application/json", pr)
 	if err != nil {
 		return errors.Wrap(err, "failed to call webhook")
 	}


### PR DESCRIPTION
1. Set timeout for webhook. This could leak file descriptors
2. Wait for a channel to be closed in a goroutine for handling publishing messages. This is to prevent blocking at https://github.com/walletlink/walletlink/blob/2.0.2/server/rpc/pub_sub.go#L124
3. Don't publish a message to an unsubscribed channel.
4. Configure a PG connection pool. This could open a lot of connections when db is too slow