### PR TITLE
Make clients send specific chainupdate message for changing chain

### DIFF
--- a/js/src/connection/ServerMessage.ts
+++ b/js/src/connection/ServerMessage.ts
@@ -46,6 +46,12 @@ export interface ServerMessageLinked extends ServerMessage {
   onlineGuests: number
 }
 
+export interface ChainUpdate extends ServerMessage {
+  type: "ChainUpdate",
+  chainId: string,
+  rpcUrl: string
+}
+
 export interface ServerMessageGetSessionConfigOK extends ServerMessage {
   type: "GetSessionConfigOK"
   id: IntNumber

--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -111,7 +111,10 @@ export class WalletLinkProvider
 
     this.isCoinbaseWallet = options.overrideIsCoinbaseWallet ?? true
 
-    const chainId = this.getChainId()
+    const chainId = options.chainId || this.getChainId()
+    if (options.chainId) {
+      this._storage.setItem(DEFAULT_CHAIN_ID_KEY, options.chainId.toString(10))
+    }
     const chainIdStr = prepend0x(chainId.toString(16))
     // indicate that we've connected, for EIP-1193 compliance
     this.emit("connect", { chainIdStr })

--- a/js/src/relay/WalletLinkRelay.ts
+++ b/js/src/relay/WalletLinkRelay.ts
@@ -222,35 +222,14 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
     )
 
     this.subscriptions.add(
-      this.connection.sessionConfig$
-        .pipe(
-          filter(
-            c =>
-              c.metadata &&
-              c.metadata.ChainId !== undefined &&
-              c.metadata.JsonRpcUrl !== undefined
-          )
-        )
-        .pipe(
-          mergeMap(c =>
-            zip(
-              aes256gcm.decrypt(c.metadata.ChainId!, this._session.secret),
-              aes256gcm.decrypt(c.metadata.JsonRpcUrl!, this._session.secret)
-            )
-          )
-        )
-        .pipe(distinctUntilChanged())
+      this.connection.chainUpdate$
         .subscribe({
-          next: ([chainId, jsonRpcUrl]) => {
+          next: chainUpdate => {
+            //TODO: where is decryption handled (don't actually need to encrypt these props)
+            //TODO: need error logging
             if (this.chainCallback) {
-              this.chainCallback(chainId, jsonRpcUrl)
+              this.chainCallback(chainUpdate.chainId, chainUpdate.rpcUrl)
             }
-          },
-          error: () => {
-            this.walletLinkAnalytics?.sendEvent(EVENTS.GENERAL_ERROR, {
-              message: "Had error decrypting",
-              value: "chainId|jsonRpcUrl"
-            })
           }
         })
     )

--- a/js/src/relay/Web3Response.ts
+++ b/js/src/relay/Web3Response.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2018-2020 Coinbase, Inc. <https://www.coinbase.com/>
 // Licensed under the Apache License, version 2.0
 
-import { AddressString, HexString } from "../types"
+import {AddressString, HexString, IntNumber} from "../types"
 import { Web3Method } from "./Web3Method"
 
 interface BaseWeb3Response<Result> {


### PR DESCRIPTION
Fixes https://github.com/walletlink/coinbase-wallet-sdk/issues/306

WalletLinkProvider receives metadata updates from the server on a regular cadence. This makes bidirectional chain changes difficult. The correct approach is the clients send a dedicated `ChainUpdate` event over the relay. This PR changes to that approach and will require client updates.

Note: should consider designing ChainUpdate event such that clients can change chains for individual dapps