### PR TITLE
fix: fix deeplink url

### DIFF
--- a/src/relay/WalletLinkRelay.ts
+++ b/src/relay/WalletLinkRelay.ts
@@ -769,7 +769,7 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
             userAgent
           )
         ) {
-          window.location.href = `https://go.cb-w.com/xoXnYwQimhb?cb_url=${window.location.href}`
+          window.location.href = `https://go.cb-w.com/xoXnYwQimhb?cb_url=${encodeURIComponent(window.location.href)}`
           return
         }
 


### PR DESCRIPTION
#323 The current Deeplink jump loses hash and query params.