### PR TITLE
feat: add wallet_watchAsset ethereum request support

### DIFF
--- a/src/provider/JSONRPC.ts
+++ b/src/provider/JSONRPC.ts
@@ -27,6 +27,7 @@ export enum JSONRPCMethod {
   walletlink_arbitrary = "walletlink_arbitrary",
   wallet_addEthereumChain = "wallet_addEthereumChain",
   wallet_switchEthereumChain = "wallet_switchEthereumChain",
+  wallet_watchAsset = "wallet_watchAsset",
 
   // asynchronous pub/sub
   eth_subscribe = "eth_subscribe",
@@ -40,7 +41,7 @@ export enum JSONRPCMethod {
   eth_getFilterLogs = "eth_getFilterLogs"
 }
 
-export interface JSONRPCRequest<T = any[]> {
+export interface JSONRPCRequest<T = any> {
   jsonrpc: "2.0"
   id: number
   method: string

--- a/src/provider/WalletLinkProvider.ts
+++ b/src/provider/WalletLinkProvider.ts
@@ -240,7 +240,6 @@ export class WalletLinkProvider
     decimals?: number,
     image?: string
   ): Promise<boolean> {
-    console.log("private watchAsset Method")
     const relay = await this.initializeRelay()
     const result = await relay.watchAsset(
       type,

--- a/src/provider/WalletLinkProvider.ts
+++ b/src/provider/WalletLinkProvider.ts
@@ -5,7 +5,6 @@
 import SafeEventEmitter from "@metamask/safe-event-emitter"
 import BN from "bn.js"
 import { ethErrors } from "eth-rpc-errors"
-
 import { WalletLinkAnalytics } from "../connection/WalletLinkAnalytics"
 import { EVENTS, WalletLinkAnalyticsAbstract } from "../init"
 import { ScopedLocalStorage } from "../lib/ScopedLocalStorage"
@@ -232,6 +231,26 @@ export class WalletLinkProvider
       this.emit("chainChanged", this.getChainId())
       this.hasMadeFirstChainChangedEmission = true
     }
+  }
+
+  private async watchAsset(
+    type: string,
+    address: string,
+    symbol?: string,
+    decimals?: number,
+    image?: string
+  ): Promise<boolean> {
+    console.log("private watchAsset Method")
+    const relay = await this.initializeRelay()
+    const result = await relay.watchAsset(
+      type,
+      address,
+      symbol,
+      decimals,
+      image
+    ).promise
+
+    return !!result.result
   }
 
   private async addEthereumChain(
@@ -643,6 +662,9 @@ export class WalletLinkProvider
 
       case JSONRPCMethod.wallet_switchEthereumChain:
         return this._wallet_switchEthereumChain(params)
+
+      case JSONRPCMethod.wallet_watchAsset:
+        return this._wallet_watchAsset(params)
     }
 
     const relay = await this.initializeRelay()
@@ -690,7 +712,9 @@ export class WalletLinkProvider
   private _isKnownAddress(addressString: string): boolean {
     try {
       const address = ensureAddressString(addressString)
-      const lowercaseAddresses = this._addresses.map(address => ensureAddressString(address))
+      const lowercaseAddresses = this._addresses.map(address =>
+        ensureAddressString(address)
+      )
       return lowercaseAddresses.includes(address)
     } catch {}
     return false
@@ -1066,6 +1090,50 @@ export class WalletLinkProvider
     return { jsonrpc: "2.0", id: 0, result: null }
   }
 
+  private async _wallet_watchAsset(params: unknown): Promise<JSONRPCResponse> {
+    const request = params as WatchAssetParams
+
+    if (request.type?.length === 0) {
+      throw ethErrors.provider.custom({
+        code: 0,
+        message: "type is a required field"
+      })
+    }
+
+    if (request.type !== "ERC20") {
+      throw ethErrors.provider.custom({
+        code: 0,
+        message: `Asset of type '${request.type}' not supported`
+      })
+    }
+
+    if (!request?.options) {
+      throw ethErrors.provider.custom({
+        code: 0,
+        message: "options is a required field"
+      })
+    }
+
+    if (!request.options.address) {
+      throw ethErrors.provider.custom({
+        code: 0,
+        message: "option address is a required option"
+      })
+    }
+
+    const { address, symbol, image, decimals } = request.options
+
+    const res = await this.watchAsset(
+      request.type,
+      address,
+      symbol,
+      decimals,
+      image
+    )
+
+    return { jsonrpc: "2.0", id: 0, result: res }
+  }
+
   private _eth_uninstallFilter(params: unknown[]): boolean {
     const filterId = ensureHexString(params[0])
     return this._filterPolyfill.uninstallFilter(filterId)
@@ -1128,4 +1196,14 @@ interface AddEthereumChainParams {
 
 interface SwitchEthereumChainParams {
   chainId: string
+}
+
+interface WatchAssetParams {
+  type: string
+  options: {
+    address: string
+    symbol?: string
+    decimals?: number
+    image?: string
+  }
 }

--- a/src/provider/WalletLinkSdkUI.ts
+++ b/src/provider/WalletLinkSdkUI.ts
@@ -64,14 +64,27 @@ export class WalletLinkSdkUI extends WalletLinkUI {
     onApprove: () => void
     chainId: string
     rpcUrls: string[]
-    blockExplorerUrls?: string[],
-    chainName?: string,
-    iconUrls?: string[],
+    blockExplorerUrls?: string[]
+    chainName?: string
+    iconUrls?: string[]
     nativeCurrency?: {
-      name: string;
-      symbol: string;
-      decimals: number;
+      name: string
+      symbol: string
+      decimals: number
     }
+  }) {
+    // no-op
+  }
+
+  // @ts-ignore
+  watchAsset(options: {
+    onCancel: () => void
+    onApprove: () => void
+    type: string
+    address: string
+    symbol?: string
+    decimals?: number
+    image?: string
   }) {
     // no-op
   }
@@ -125,7 +138,7 @@ export class WalletLinkSdkUI extends WalletLinkUI {
   }
 
   showConnecting(options: {
-    isUnlinkedErrorState?: boolean,
+    isUnlinkedErrorState?: boolean
     onCancel: () => void
     onResetConnection: () => void
   }): () => void {
@@ -140,8 +153,7 @@ export class WalletLinkSdkUI extends WalletLinkUI {
             info: "Reset connection",
             svgWidth: "10",
             svgHeight: "11",
-            path:
-              "M5.00008 0.96875C6.73133 0.96875 8.23758 1.94375 9.00008 3.375L10.0001 2.375V5.5H9.53133H7.96883H6.87508L7.80633 4.56875C7.41258 3.3875 6.31258 2.53125 5.00008 2.53125C3.76258 2.53125 2.70633 3.2875 2.25633 4.36875L0.812576 3.76875C1.50008 2.125 3.11258 0.96875 5.00008 0.96875ZM2.19375 6.43125C2.5875 7.6125 3.6875 8.46875 5 8.46875C6.2375 8.46875 7.29375 7.7125 7.74375 6.63125L9.1875 7.23125C8.5 8.875 6.8875 10.0312 5 10.0312C3.26875 10.0312 1.7625 9.05625 1 7.625L0 8.625V5.5H0.46875H2.03125H3.125L2.19375 6.43125Z",
+            path: "M5.00008 0.96875C6.73133 0.96875 8.23758 1.94375 9.00008 3.375L10.0001 2.375V5.5H9.53133H7.96883H6.87508L7.80633 4.56875C7.41258 3.3875 6.31258 2.53125 5.00008 2.53125C3.76258 2.53125 2.70633 3.2875 2.25633 4.36875L0.812576 3.76875C1.50008 2.125 3.11258 0.96875 5.00008 0.96875ZM2.19375 6.43125C2.5875 7.6125 3.6875 8.46875 5 8.46875C6.2375 8.46875 7.29375 7.7125 7.74375 6.63125L9.1875 7.23125C8.5 8.875 6.8875 10.0312 5 10.0312C3.26875 10.0312 1.7625 9.05625 1 7.625L0 8.625V5.5H0.46875H2.03125H3.125L2.19375 6.43125Z",
             defaultFillRule: "evenodd",
             defaultClipRule: "evenodd",
             onClick: options.onResetConnection
@@ -157,8 +169,7 @@ export class WalletLinkSdkUI extends WalletLinkUI {
             info: "Cancel transaction",
             svgWidth: "11",
             svgHeight: "11",
-            path:
-              "M10.3711 1.52346L9.21775 0.370117L5.37109 4.21022L1.52444 0.370117L0.371094 1.52346L4.2112 5.37012L0.371094 9.21677L1.52444 10.3701L5.37109 6.53001L9.21775 10.3701L10.3711 9.21677L6.53099 5.37012L10.3711 1.52346Z",
+            path: "M10.3711 1.52346L9.21775 0.370117L5.37109 4.21022L1.52444 0.370117L0.371094 1.52346L4.2112 5.37012L0.371094 9.21677L1.52444 10.3701L5.37109 6.53001L9.21775 10.3701L10.3711 9.21677L6.53099 5.37012L10.3711 1.52346Z",
             defaultFillRule: "inherit",
             defaultClipRule: "inherit",
             onClick: options.onCancel
@@ -168,8 +179,7 @@ export class WalletLinkSdkUI extends WalletLinkUI {
             info: "Reset connection",
             svgWidth: "10",
             svgHeight: "11",
-            path:
-              "M5.00008 0.96875C6.73133 0.96875 8.23758 1.94375 9.00008 3.375L10.0001 2.375V5.5H9.53133H7.96883H6.87508L7.80633 4.56875C7.41258 3.3875 6.31258 2.53125 5.00008 2.53125C3.76258 2.53125 2.70633 3.2875 2.25633 4.36875L0.812576 3.76875C1.50008 2.125 3.11258 0.96875 5.00008 0.96875ZM2.19375 6.43125C2.5875 7.6125 3.6875 8.46875 5 8.46875C6.2375 8.46875 7.29375 7.7125 7.74375 6.63125L9.1875 7.23125C8.5 8.875 6.8875 10.0312 5 10.0312C3.26875 10.0312 1.7625 9.05625 1 7.625L0 8.625V5.5H0.46875H2.03125H3.125L2.19375 6.43125Z",
+            path: "M5.00008 0.96875C6.73133 0.96875 8.23758 1.94375 9.00008 3.375L10.0001 2.375V5.5H9.53133H7.96883H6.87508L7.80633 4.56875C7.41258 3.3875 6.31258 2.53125 5.00008 2.53125C3.76258 2.53125 2.70633 3.2875 2.25633 4.36875L0.812576 3.76875C1.50008 2.125 3.11258 0.96875 5.00008 0.96875ZM2.19375 6.43125C2.5875 7.6125 3.6875 8.46875 5 8.46875C6.2375 8.46875 7.29375 7.7125 7.74375 6.63125L9.1875 7.23125C8.5 8.875 6.8875 10.0312 5 10.0312C3.26875 10.0312 1.7625 9.05625 1 7.625L0 8.625V5.5H0.46875H2.03125H3.125L2.19375 6.43125Z",
             defaultFillRule: "evenodd",
             defaultClipRule: "evenodd",
             onClick: options.onResetConnection
@@ -191,6 +201,10 @@ export class WalletLinkSdkUI extends WalletLinkUI {
 
   // @ts-ignore
   inlineAddEthereumChain(chainId: string): boolean {
+    return false
+  }
+
+  inlineWatchAsset(): boolean {
     return false
   }
 

--- a/src/provider/WalletLinkUI.ts
+++ b/src/provider/WalletLinkUI.ts
@@ -14,7 +14,6 @@ import {
 } from "../relay/Web3Response"
 import { AddressString } from "../types"
 
-
 export interface WalletLinkUIOptions {
   walletLinkUrl: string
   version: string
@@ -24,7 +23,7 @@ export interface WalletLinkUIOptions {
 }
 
 export abstract class WalletLinkUI {
-  constructor(_: Readonly<WalletLinkUIOptions>) { }
+  constructor(_: Readonly<WalletLinkUIOptions>) {}
   abstract attach(): void
 
   /**
@@ -42,14 +41,24 @@ export abstract class WalletLinkUI {
     onApprove: (rpcUrl: string) => void
     chainId: string
     rpcUrls: string[]
-    blockExplorerUrls?: string[],
-    chainName?: string,
-    iconUrls?: string[],
+    blockExplorerUrls?: string[]
+    chainName?: string
+    iconUrls?: string[]
     nativeCurrency?: {
-      name: string;
-      symbol: string;
-      decimals: number;
+      name: string
+      symbol: string
+      decimals: number
     }
+  }): void
+
+  abstract watchAsset(options: {
+    onCancel: () => void
+    onApprove: () => void
+    type: string
+    address: string
+    symbol?: string
+    decimals?: number
+    image?: string
   }): void
 
   abstract switchEthereumChain(options: {
@@ -118,6 +127,12 @@ export abstract class WalletLinkUI {
   abstract inlineAddEthereumChain(chainId: string): boolean
 
   /**
+   * If the extension is available, it can handle the watch asset request without
+   * having to send a request over walletlink
+   */
+  abstract inlineWatchAsset(): boolean
+
+  /**
    * If the extension is available, it can handle the switch ethereum chain request without
    * having to send a request over walletlink
    */
@@ -131,5 +146,5 @@ export abstract class WalletLinkUI {
   /**
    * We want to disable showing the qr code for in-page walletlink if the dapp hasn't provided a json rpc url
    */
-  setConnectDisabled(_: boolean) { }
+  setConnectDisabled(_: boolean) {}
 }

--- a/src/relay/WalletLinkRelayAbstract.ts
+++ b/src/relay/WalletLinkRelayAbstract.ts
@@ -1,5 +1,4 @@
 import { ethErrors, serializeError } from "eth-rpc-errors"
-
 import { JSONRPCRequest, JSONRPCResponse } from "../provider/JSONRPC"
 import { AddressString, IntNumber, RegExpString } from "../types"
 import { EthereumTransactionParams } from "./EthereumTransactionParams"
@@ -15,6 +14,7 @@ import {
   SignEthereumTransactionResponse,
   SubmitEthereumTransactionResponse,
   SwitchEthereumChainResponse,
+  WatchAssetResponse,
   Web3Response
 } from "./Web3Response"
 
@@ -44,6 +44,14 @@ export abstract class WalletLinkRelayAbstract {
       decimals: number
     }
   ): CancelablePromise<AddEthereumChainResponse>
+
+  abstract watchAsset(
+    type: string,
+    address: string,
+    symbol?: string,
+    decimals?: number,
+    image?: string
+  ): CancelablePromise<WatchAssetResponse>
 
   abstract switchEthereumChain(
     chainId: string

--- a/src/relay/Web3Method.ts
+++ b/src/relay/Web3Method.ts
@@ -13,5 +13,6 @@ export enum Web3Method {
   childRequestEthereumAccounts = "childRequestEthereumAccounts",
   addEthereumChain = "addEthereumChain",
   switchEthereumChain = "switchEthereumChain",
-  makeEthereumJSONRPCRequest = "makeEthereumJSONRPCRequest"
+  makeEthereumJSONRPCRequest = "makeEthereumJSONRPCRequest",
+  watchAsset = "watchAsset"
 }

--- a/src/relay/Web3Request.ts
+++ b/src/relay/Web3Request.ts
@@ -118,6 +118,19 @@ export type MakeEthereumJSONRPCRequest = BaseWeb3Request<
   }
 >
 
+export type WatchAssetRequest = BaseWeb3Request<
+  Web3Method.watchAsset,
+  {
+    type: string
+    options: {
+      address: string
+      symbol?: string
+      decimals?: number
+      image?: string
+    }
+  }
+>
+
 export type Web3Request =
   | RequestEthereumAccountsRequest
   | SignEthereumMessageRequest
@@ -129,3 +142,4 @@ export type Web3Request =
   | AddEthereumChainRequest
   | SwitchEthereumChainRequest
   | MakeEthereumJSONRPCRequest
+  | WatchAssetRequest

--- a/src/relay/Web3Response.ts
+++ b/src/relay/Web3Response.ts
@@ -30,6 +30,8 @@ export type RequestEthereumAccountsResponse = BaseWeb3Response<
 
 export type AddEthereumChainResponse = BaseWeb3Response<AddResponse> // was request approved
 
+export type WatchAssetResponse = BaseWeb3Response<boolean>
+
 export type AddResponse = {
   isApproved: boolean
   rpcUrl: string
@@ -64,6 +66,10 @@ export function RequestEthereumAccountsResponse(
   addresses: AddressString[]
 ): RequestEthereumAccountsResponse {
   return { method: Web3Method.requestEthereumAccounts, result: addresses }
+}
+
+export function WatchAssetReponse(success: boolean): WatchAssetResponse {
+  return { method: Web3Method.watchAsset, result: success }
 }
 
 export function isRequestEthereumAccountsResponse(


### PR DESCRIPTION
Today, one of the major uses of Ethereum wallets is to acquire and track assets. Currently, each wallet either needs to pre-load a list of approved assets, or users need to be stepped through a tedious process of adding an asset for their given wallet.

In the first case, wallets are burdened with both the security of managing this list, as well as the bandwidth of mass polling for known assets on their wallet.

In the second case, the user experience is terrible.

The [wallet_watchAsset](https://eips.ethereum.org/EIPS/eip-747) is a RPC method for allowing users to easily track new assets with a suggestion from sites they are visiting.