### PR TITLE
feat: add wallet_watchAsset eht request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ Use [EIP-1102](https://eips.ethereum.org/EIPS/eip-1102) to obtain authorization 
 The following code runs in response to a user-initiated action such as clicking a button to ensure the pop up is not blocked by the browser.
 
 ```typescript
-// Use eth_RequestAccounts
-ethereum.request('eth_requestAccounts').then((accounts: string[]) => {
+// Use eth_requestAccounts
+ethereum.send('eth_requestAccounts').then((accounts: string[]) => {
   console.log(`User's address is ${accounts[0]}`)
 
   // Optionally, have the default account set for web3.js
@@ -263,7 +263,78 @@ supported. Here's an example:
     }
 ```
 
-## Disconnecting / Disestablishing a Link
+### Suggest client wallet track a specific token with EIP-747
+
+Calling `wallet_watchAsset` method returns true/false if the asset was accepted/denied by the user, or an error if there is something wrong with the request.
+Unlike other methods, the default definition of `wallet_watchAsset` params is not an array, however, in order to keep it compatible with code conventions of other dapps walletlink supports both array and object format.
+
+```typescript
+interface WatchAssetParameters {
+  type: string // The asset's interface, e.g. 'ERC20'
+  options: {
+    address: string // The hexadecimal Ethereum address of the token contract
+    symbol?: string // A ticker symbol or shorthand, up to 5 alphanumerical characters
+    decimals?: number // The number of asset decimals
+    image?: string // A string url of the token logo
+  }
+}
+```
+
+Here's an example of how to suggest the client wallet add a custom token:
+
+```typescript
+function onApproveWatchAsset() {
+  // your approval callback implementation
+}
+
+function onDenyWatchAsset() {
+  // your denying callback implementation
+}
+
+function onError(message: string) {
+  // your error callback implementation
+}
+
+// Use wallet_watchAsset
+ethereum.request({
+  method: "wallet_watchAsset",
+  params: {
+    type: "ERC20",
+    options: {
+      address: "0xcf664087a5bb0237a0bad6742852ec6c8d69a27a",
+      symbol: "WONE",
+      decimals: 18,
+      image:
+        "https://s2.coinmarketcap.com/static/img/coins/64x64/11696.png",
+    },
+  },
+  ,
+})
+.then((result: boolean) =>
+  result ? onApproveWatchAsset() : onDenyWatchAsset()
+)
+.catch(err => onError(err.message));
+
+
+// Alternatively, you can use ethereum.send
+ethereum
+  .send("wallet_watchAsset", {
+    type: "ERC20",
+    options: {
+      address: "0xcf664087a5bb0237a0bad6742852ec6c8d69a27a",
+      symbol: "WONE",
+      decimals: 18,
+      image: "https://s2.coinmarketcap.com/static/img/coins/64x64/11696.png"
+    }
+  })
+  .then((result: boolean) =>
+    result ? onApproveWatchAsset() : onDenyWatchAsset()
+  )
+  .catch(err => onError(err.message))
+})
+```
+
+### Disconnecting / De-establishing a link
 
 To disconnect, call the instance method `disconnect()` on the WalletLink object,
 or the instance method `close()` on the WalletLink Web3 Provider object. This

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ supported. Here's an example:
 ### Suggest client wallet track a specific token with EIP-747
 
 Calling `wallet_watchAsset` method returns true/false if the asset was accepted/denied by the user, or an error if there is something wrong with the request.
+
 Unlike other methods, the default definition of `wallet_watchAsset` params is not an array, however, in order to keep it compatible with code conventions of other dapps walletlink supports both array and object format.
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The following code runs in response to a user-initiated action such as clicking 
 
 ```typescript
 // Use eth_requestAccounts
-ethereum.send('eth_requestAccounts').then((accounts: string[]) => {
+ethereum.request('eth_requestAccounts').then((accounts: string[]) => {
   console.log(`User's address is ${accounts[0]}`)
 
   // Optionally, have the default account set for web3.js
@@ -315,24 +315,6 @@ ethereum.request({
   result ? onApproveWatchAsset() : onDenyWatchAsset()
 )
 .catch(err => onError(err.message));
-
-
-// Alternatively, you can use ethereum.send
-ethereum
-  .send("wallet_watchAsset", {
-    type: "ERC20",
-    options: {
-      address: "0xcf664087a5bb0237a0bad6742852ec6c8d69a27a",
-      symbol: "WONE",
-      decimals: 18,
-      image: "https://s2.coinmarketcap.com/static/img/coins/64x64/11696.png"
-    }
-  })
-  .then((result: boolean) =>
-    result ? onApproveWatchAsset() : onDenyWatchAsset()
-  )
-  .catch(err => onError(err.message))
-})
 ```
 
 ### Disconnecting / De-establishing a link

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "walletlink",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "WalletLink JavaScript SDK",
   "keywords": [
     "cipher",

--- a/src/provider/JSONRPC.ts
+++ b/src/provider/JSONRPC.ts
@@ -27,6 +27,7 @@ export enum JSONRPCMethod {
   walletlink_arbitrary = "walletlink_arbitrary",
   wallet_addEthereumChain = "wallet_addEthereumChain",
   wallet_switchEthereumChain = "wallet_switchEthereumChain",
+  wallet_watchAsset = "wallet_watchAsset",
 
   // asynchronous pub/sub
   eth_subscribe = "eth_subscribe",
@@ -40,7 +41,7 @@ export enum JSONRPCMethod {
   eth_getFilterLogs = "eth_getFilterLogs"
 }
 
-export interface JSONRPCRequest<T = any[]> {
+export interface JSONRPCRequest<T = any> {
   jsonrpc: "2.0"
   id: number
   method: string

--- a/src/provider/WalletLinkProvider.ts
+++ b/src/provider/WalletLinkProvider.ts
@@ -1090,7 +1090,9 @@ export class WalletLinkProvider
   }
 
   private async _wallet_watchAsset(params: unknown): Promise<JSONRPCResponse> {
-    const request = params as WatchAssetParams
+    const request = (
+      Array.isArray(params) ? params[0] : params
+    ) as WatchAssetParams
     if (request.type?.length === 0) {
       throw ethErrors.rpc.invalidParams({
         message: "type is a required field"

--- a/src/provider/WalletLinkProvider.ts
+++ b/src/provider/WalletLinkProvider.ts
@@ -1091,31 +1091,26 @@ export class WalletLinkProvider
 
   private async _wallet_watchAsset(params: unknown): Promise<JSONRPCResponse> {
     const request = params as WatchAssetParams
-
     if (request.type?.length === 0) {
-      throw ethErrors.provider.custom({
-        code: 0,
+      throw ethErrors.rpc.invalidParams({
         message: "type is a required field"
       })
     }
 
     if (request.type !== "ERC20") {
-      throw ethErrors.provider.custom({
-        code: 0,
+      throw ethErrors.rpc.invalidParams({
         message: `Asset of type '${request.type}' not supported`
       })
     }
 
     if (!request?.options) {
-      throw ethErrors.provider.custom({
-        code: 0,
+      throw ethErrors.rpc.invalidParams({
         message: "options is a required field"
       })
     }
 
     if (!request.options.address) {
-      throw ethErrors.provider.custom({
-        code: 0,
+      throw ethErrors.rpc.invalidParams({
         message: "option address is a required option"
       })
     }

--- a/src/provider/WalletLinkProvider.ts
+++ b/src/provider/WalletLinkProvider.ts
@@ -5,7 +5,6 @@
 import SafeEventEmitter from "@metamask/safe-event-emitter"
 import BN from "bn.js"
 import { ethErrors } from "eth-rpc-errors"
-
 import { WalletLinkAnalytics } from "../connection/WalletLinkAnalytics"
 import { EVENTS, WalletLinkAnalyticsAbstract } from "../init"
 import { ScopedLocalStorage } from "../lib/ScopedLocalStorage"
@@ -232,6 +231,25 @@ export class WalletLinkProvider
       this.emit("chainChanged", this.getChainId())
       this.hasMadeFirstChainChangedEmission = true
     }
+  }
+
+  private async watchAsset(
+    type: string,
+    address: string,
+    symbol?: string,
+    decimals?: number,
+    image?: string
+  ): Promise<boolean> {
+    const relay = await this.initializeRelay()
+    const result = await relay.watchAsset(
+      type,
+      address,
+      symbol,
+      decimals,
+      image
+    ).promise
+
+    return !!result.result
   }
 
   private async addEthereumChain(
@@ -643,6 +661,9 @@ export class WalletLinkProvider
 
       case JSONRPCMethod.wallet_switchEthereumChain:
         return this._wallet_switchEthereumChain(params)
+
+      case JSONRPCMethod.wallet_watchAsset:
+        return this._wallet_watchAsset(params)
     }
 
     const relay = await this.initializeRelay()
@@ -690,7 +711,9 @@ export class WalletLinkProvider
   private _isKnownAddress(addressString: string): boolean {
     try {
       const address = ensureAddressString(addressString)
-      const lowercaseAddresses = this._addresses.map(address => ensureAddressString(address))
+      const lowercaseAddresses = this._addresses.map(address =>
+        ensureAddressString(address)
+      )
       return lowercaseAddresses.includes(address)
     } catch {}
     return false
@@ -1066,6 +1089,50 @@ export class WalletLinkProvider
     return { jsonrpc: "2.0", id: 0, result: null }
   }
 
+  private async _wallet_watchAsset(params: unknown): Promise<JSONRPCResponse> {
+    const request = params as WatchAssetParams
+
+    if (request.type?.length === 0) {
+      throw ethErrors.provider.custom({
+        code: 0,
+        message: "type is a required field"
+      })
+    }
+
+    if (request.type !== "ERC20") {
+      throw ethErrors.provider.custom({
+        code: 0,
+        message: `Asset of type '${request.type}' not supported`
+      })
+    }
+
+    if (!request?.options) {
+      throw ethErrors.provider.custom({
+        code: 0,
+        message: "options is a required field"
+      })
+    }
+
+    if (!request.options.address) {
+      throw ethErrors.provider.custom({
+        code: 0,
+        message: "option address is a required option"
+      })
+    }
+
+    const { address, symbol, image, decimals } = request.options
+
+    const res = await this.watchAsset(
+      request.type,
+      address,
+      symbol,
+      decimals,
+      image
+    )
+
+    return { jsonrpc: "2.0", id: 0, result: res }
+  }
+
   private _eth_uninstallFilter(params: unknown[]): boolean {
     const filterId = ensureHexString(params[0])
     return this._filterPolyfill.uninstallFilter(filterId)
@@ -1128,4 +1195,14 @@ interface AddEthereumChainParams {
 
 interface SwitchEthereumChainParams {
   chainId: string
+}
+
+interface WatchAssetParams {
+  type: string
+  options: {
+    address: string
+    symbol?: string
+    decimals?: number
+    image?: string
+  }
 }

--- a/src/provider/WalletLinkSdkUI.ts
+++ b/src/provider/WalletLinkSdkUI.ts
@@ -64,14 +64,27 @@ export class WalletLinkSdkUI extends WalletLinkUI {
     onApprove: () => void
     chainId: string
     rpcUrls: string[]
-    blockExplorerUrls?: string[],
-    chainName?: string,
-    iconUrls?: string[],
+    blockExplorerUrls?: string[]
+    chainName?: string
+    iconUrls?: string[]
     nativeCurrency?: {
-      name: string;
-      symbol: string;
-      decimals: number;
+      name: string
+      symbol: string
+      decimals: number
     }
+  }) {
+    // no-op
+  }
+
+  // @ts-ignore
+  watchAsset(options: {
+    onCancel: () => void
+    onApprove: () => void
+    type: string
+    address: string
+    symbol?: string
+    decimals?: number
+    image?: string
   }) {
     // no-op
   }
@@ -125,7 +138,7 @@ export class WalletLinkSdkUI extends WalletLinkUI {
   }
 
   showConnecting(options: {
-    isUnlinkedErrorState?: boolean,
+    isUnlinkedErrorState?: boolean
     onCancel: () => void
     onResetConnection: () => void
   }): () => void {
@@ -140,8 +153,7 @@ export class WalletLinkSdkUI extends WalletLinkUI {
             info: "Reset connection",
             svgWidth: "10",
             svgHeight: "11",
-            path:
-              "M5.00008 0.96875C6.73133 0.96875 8.23758 1.94375 9.00008 3.375L10.0001 2.375V5.5H9.53133H7.96883H6.87508L7.80633 4.56875C7.41258 3.3875 6.31258 2.53125 5.00008 2.53125C3.76258 2.53125 2.70633 3.2875 2.25633 4.36875L0.812576 3.76875C1.50008 2.125 3.11258 0.96875 5.00008 0.96875ZM2.19375 6.43125C2.5875 7.6125 3.6875 8.46875 5 8.46875C6.2375 8.46875 7.29375 7.7125 7.74375 6.63125L9.1875 7.23125C8.5 8.875 6.8875 10.0312 5 10.0312C3.26875 10.0312 1.7625 9.05625 1 7.625L0 8.625V5.5H0.46875H2.03125H3.125L2.19375 6.43125Z",
+            path: "M5.00008 0.96875C6.73133 0.96875 8.23758 1.94375 9.00008 3.375L10.0001 2.375V5.5H9.53133H7.96883H6.87508L7.80633 4.56875C7.41258 3.3875 6.31258 2.53125 5.00008 2.53125C3.76258 2.53125 2.70633 3.2875 2.25633 4.36875L0.812576 3.76875C1.50008 2.125 3.11258 0.96875 5.00008 0.96875ZM2.19375 6.43125C2.5875 7.6125 3.6875 8.46875 5 8.46875C6.2375 8.46875 7.29375 7.7125 7.74375 6.63125L9.1875 7.23125C8.5 8.875 6.8875 10.0312 5 10.0312C3.26875 10.0312 1.7625 9.05625 1 7.625L0 8.625V5.5H0.46875H2.03125H3.125L2.19375 6.43125Z",
             defaultFillRule: "evenodd",
             defaultClipRule: "evenodd",
             onClick: options.onResetConnection
@@ -157,8 +169,7 @@ export class WalletLinkSdkUI extends WalletLinkUI {
             info: "Cancel transaction",
             svgWidth: "11",
             svgHeight: "11",
-            path:
-              "M10.3711 1.52346L9.21775 0.370117L5.37109 4.21022L1.52444 0.370117L0.371094 1.52346L4.2112 5.37012L0.371094 9.21677L1.52444 10.3701L5.37109 6.53001L9.21775 10.3701L10.3711 9.21677L6.53099 5.37012L10.3711 1.52346Z",
+            path: "M10.3711 1.52346L9.21775 0.370117L5.37109 4.21022L1.52444 0.370117L0.371094 1.52346L4.2112 5.37012L0.371094 9.21677L1.52444 10.3701L5.37109 6.53001L9.21775 10.3701L10.3711 9.21677L6.53099 5.37012L10.3711 1.52346Z",
             defaultFillRule: "inherit",
             defaultClipRule: "inherit",
             onClick: options.onCancel
@@ -168,8 +179,7 @@ export class WalletLinkSdkUI extends WalletLinkUI {
             info: "Reset connection",
             svgWidth: "10",
             svgHeight: "11",
-            path:
-              "M5.00008 0.96875C6.73133 0.96875 8.23758 1.94375 9.00008 3.375L10.0001 2.375V5.5H9.53133H7.96883H6.87508L7.80633 4.56875C7.41258 3.3875 6.31258 2.53125 5.00008 2.53125C3.76258 2.53125 2.70633 3.2875 2.25633 4.36875L0.812576 3.76875C1.50008 2.125 3.11258 0.96875 5.00008 0.96875ZM2.19375 6.43125C2.5875 7.6125 3.6875 8.46875 5 8.46875C6.2375 8.46875 7.29375 7.7125 7.74375 6.63125L9.1875 7.23125C8.5 8.875 6.8875 10.0312 5 10.0312C3.26875 10.0312 1.7625 9.05625 1 7.625L0 8.625V5.5H0.46875H2.03125H3.125L2.19375 6.43125Z",
+            path: "M5.00008 0.96875C6.73133 0.96875 8.23758 1.94375 9.00008 3.375L10.0001 2.375V5.5H9.53133H7.96883H6.87508L7.80633 4.56875C7.41258 3.3875 6.31258 2.53125 5.00008 2.53125C3.76258 2.53125 2.70633 3.2875 2.25633 4.36875L0.812576 3.76875C1.50008 2.125 3.11258 0.96875 5.00008 0.96875ZM2.19375 6.43125C2.5875 7.6125 3.6875 8.46875 5 8.46875C6.2375 8.46875 7.29375 7.7125 7.74375 6.63125L9.1875 7.23125C8.5 8.875 6.8875 10.0312 5 10.0312C3.26875 10.0312 1.7625 9.05625 1 7.625L0 8.625V5.5H0.46875H2.03125H3.125L2.19375 6.43125Z",
             defaultFillRule: "evenodd",
             defaultClipRule: "evenodd",
             onClick: options.onResetConnection
@@ -191,6 +201,10 @@ export class WalletLinkSdkUI extends WalletLinkUI {
 
   // @ts-ignore
   inlineAddEthereumChain(chainId: string): boolean {
+    return false
+  }
+
+  inlineWatchAsset(): boolean {
     return false
   }
 

--- a/src/provider/WalletLinkUI.ts
+++ b/src/provider/WalletLinkUI.ts
@@ -14,7 +14,6 @@ import {
 } from "../relay/Web3Response"
 import { AddressString } from "../types"
 
-
 export interface WalletLinkUIOptions {
   walletLinkUrl: string
   version: string
@@ -24,7 +23,7 @@ export interface WalletLinkUIOptions {
 }
 
 export abstract class WalletLinkUI {
-  constructor(_: Readonly<WalletLinkUIOptions>) { }
+  constructor(_: Readonly<WalletLinkUIOptions>) {}
   abstract attach(): void
 
   /**
@@ -42,14 +41,24 @@ export abstract class WalletLinkUI {
     onApprove: (rpcUrl: string) => void
     chainId: string
     rpcUrls: string[]
-    blockExplorerUrls?: string[],
-    chainName?: string,
-    iconUrls?: string[],
+    blockExplorerUrls?: string[]
+    chainName?: string
+    iconUrls?: string[]
     nativeCurrency?: {
-      name: string;
-      symbol: string;
-      decimals: number;
+      name: string
+      symbol: string
+      decimals: number
     }
+  }): void
+
+  abstract watchAsset(options: {
+    onCancel: () => void
+    onApprove: () => void
+    type: string
+    address: string
+    symbol?: string
+    decimals?: number
+    image?: string
   }): void
 
   abstract switchEthereumChain(options: {
@@ -118,6 +127,12 @@ export abstract class WalletLinkUI {
   abstract inlineAddEthereumChain(chainId: string): boolean
 
   /**
+   * If the extension is available, it can handle the watch asset request without
+   * having to send a request over walletlink
+   */
+  abstract inlineWatchAsset(): boolean
+
+  /**
    * If the extension is available, it can handle the switch ethereum chain request without
    * having to send a request over walletlink
    */
@@ -131,5 +146,5 @@ export abstract class WalletLinkUI {
   /**
    * We want to disable showing the qr code for in-page walletlink if the dapp hasn't provided a json rpc url
    */
-  setConnectDisabled(_: boolean) { }
+  setConnectDisabled(_: boolean) {}
 }

--- a/src/provider/Web3Provider.ts
+++ b/src/provider/Web3Provider.ts
@@ -32,5 +32,5 @@ export interface RequestArguments {
   method: string
 
   /** The params of the RPC method, if any. */
-  params?: any[]
+  params?: any
 }

--- a/src/relay/WalletLinkRelay.ts
+++ b/src/relay/WalletLinkRelay.ts
@@ -878,17 +878,21 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
         )
       }
 
-      this.ui.watchAsset({
-        onApprove: approve,
-        onCancel: _cancel,
-        type,
-        address,
-        symbol,
-        decimals,
-        image
-      })
+      if (this.ui.inlineWatchAsset()) {
+        this.ui.watchAsset({
+          onApprove: approve,
+          onCancel: _cancel,
+          type,
+          address,
+          symbol,
+          decimals,
+          image
+        })
+      }
 
-      resolve({ method: Web3Method.watchAsset, result: true })
+      if (!this.ui.inlineWatchAsset() && !this.ui.isStandalone()) {
+        this.publishWeb3RequestEvent(id, request)
+      }
     })
 
     return { cancel, promise }

--- a/src/relay/WalletLinkRelayAbstract.ts
+++ b/src/relay/WalletLinkRelayAbstract.ts
@@ -1,5 +1,4 @@
 import { ethErrors, serializeError } from "eth-rpc-errors"
-
 import { JSONRPCRequest, JSONRPCResponse } from "../provider/JSONRPC"
 import { AddressString, IntNumber, RegExpString } from "../types"
 import { EthereumTransactionParams } from "./EthereumTransactionParams"
@@ -15,6 +14,7 @@ import {
   SignEthereumTransactionResponse,
   SubmitEthereumTransactionResponse,
   SwitchEthereumChainResponse,
+  WatchAssetResponse,
   Web3Response
 } from "./Web3Response"
 
@@ -44,6 +44,14 @@ export abstract class WalletLinkRelayAbstract {
       decimals: number
     }
   ): CancelablePromise<AddEthereumChainResponse>
+
+  abstract watchAsset(
+    type: string,
+    address: string,
+    symbol?: string,
+    decimals?: number,
+    image?: string
+  ): CancelablePromise<WatchAssetResponse>
 
   abstract switchEthereumChain(
     chainId: string

--- a/src/relay/Web3Method.ts
+++ b/src/relay/Web3Method.ts
@@ -13,5 +13,6 @@ export enum Web3Method {
   childRequestEthereumAccounts = "childRequestEthereumAccounts",
   addEthereumChain = "addEthereumChain",
   switchEthereumChain = "switchEthereumChain",
-  makeEthereumJSONRPCRequest = "makeEthereumJSONRPCRequest"
+  makeEthereumJSONRPCRequest = "makeEthereumJSONRPCRequest",
+  watchAsset = "watchAsset"
 }

--- a/src/relay/Web3Request.ts
+++ b/src/relay/Web3Request.ts
@@ -118,6 +118,19 @@ export type MakeEthereumJSONRPCRequest = BaseWeb3Request<
   }
 >
 
+export type WatchAssetRequest = BaseWeb3Request<
+  Web3Method.watchAsset,
+  {
+    type: string
+    options: {
+      address: string
+      symbol?: string
+      decimals?: number
+      image?: string
+    }
+  }
+>
+
 export type Web3Request =
   | RequestEthereumAccountsRequest
   | SignEthereumMessageRequest
@@ -129,3 +142,4 @@ export type Web3Request =
   | AddEthereumChainRequest
   | SwitchEthereumChainRequest
   | MakeEthereumJSONRPCRequest
+  | WatchAssetRequest

--- a/src/relay/Web3Response.ts
+++ b/src/relay/Web3Response.ts
@@ -30,6 +30,8 @@ export type RequestEthereumAccountsResponse = BaseWeb3Response<
 
 export type AddEthereumChainResponse = BaseWeb3Response<AddResponse> // was request approved
 
+export type WatchAssetResponse = BaseWeb3Response<boolean>
+
 export type AddResponse = {
   isApproved: boolean
   rpcUrl: string
@@ -64,6 +66,10 @@ export function RequestEthereumAccountsResponse(
   addresses: AddressString[]
 ): RequestEthereumAccountsResponse {
   return { method: Web3Method.requestEthereumAccounts, result: addresses }
+}
+
+export function WatchAssetReponse(success: boolean): WatchAssetResponse {
+  return { method: Web3Method.watchAsset, result: success }
 }
 
 export function isRequestEthereumAccountsResponse(


### PR DESCRIPTION
Today, one of the major uses of Ethereum wallets is to acquire and track assets. Currently, each wallet either needs to pre-load a list of approved assets, or users need to be stepped through a tedious process of adding an asset for their given wallet.

In the first case, wallets are burdened with both the security of managing this list, as well as the bandwidth of mass polling for known assets on their wallet.

In the second case, the user experience is terrible.

The [wallet_watchAsset](https://eips.ethereum.org/EIPS/eip-747) is a RPC method for allowing users to easily track new assets with a suggestion from sites they are visiting.