### PR TITLE
[Fix] Add ethereum chain should work if the user hasn't authed yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "walletlink",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "WalletLink JavaScript SDK",
   "keywords": [
     "cipher",

--- a/src/provider/WalletLinkProvider.ts
+++ b/src/provider/WalletLinkProvider.ts
@@ -269,10 +269,11 @@ export class WalletLinkProvider
     }
 
     const relay = await this.initializeRelay()
+      const isWhitelistedNetwork = !relay.supportsUnauthedAddEthereumChain(chainId.toString())
 
     if (
       !this._isAuthorized() &&
-      !relay.supportsUnauthedAddEthereumChain(chainId.toString())
+      isWhitelistedNetwork
     ) {
       await relay.requestEthereumAccounts().promise
     }

--- a/src/provider/WalletLinkProvider.ts
+++ b/src/provider/WalletLinkProvider.ts
@@ -269,11 +269,11 @@ export class WalletLinkProvider
     }
 
     const relay = await this.initializeRelay()
-      const isWhitelistedNetwork = !relay.supportsUnauthedAddEthereumChain(chainId.toString())
+      const isWhitelistedNetworkOrStandalone = relay.inlineAddEthereumChain(chainId.toString())
 
     if (
       !this._isAuthorized() &&
-      isWhitelistedNetwork
+      !isWhitelistedNetworkOrStandalone 
     ) {
       await relay.requestEthereumAccounts().promise
     }

--- a/src/provider/WalletLinkProvider.ts
+++ b/src/provider/WalletLinkProvider.ts
@@ -269,6 +269,14 @@ export class WalletLinkProvider
     }
 
     const relay = await this.initializeRelay()
+
+    if (
+      !this._isAuthorized() &&
+      !relay.supportsUnauthedAddEthereumChain(chainId.toString())
+    ) {
+      await relay.requestEthereumAccounts().promise
+    }
+
     const res = await relay.addEthereumChain(
       chainId.toString(),
       rpcUrls,
@@ -769,8 +777,12 @@ export class WalletLinkProvider
     }
   }
 
+  private _isAuthorized(): boolean {
+    return this._addresses.length > 0
+  }
+
   private _requireAuthorization(): void {
-    if (this._addresses.length === 0) {
+    if (!this._isAuthorized()) {
       throw ethErrors.provider.unauthorized({})
     }
   }

--- a/src/relay/WalletLinkRelay.ts
+++ b/src/relay/WalletLinkRelay.ts
@@ -1101,6 +1101,10 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
     return { promise, cancel }
   }
 
+  supportsUnauthedAddEthereumChain(chainId: string): boolean {
+    return this.ui.inlineAddEthereumChain(chainId)
+  }
+
   private getSessionIdHash(): string {
     return Session.hash(this._session.id)
   }

--- a/src/relay/WalletLinkRelay.ts
+++ b/src/relay/WalletLinkRelay.ts
@@ -1101,7 +1101,7 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
     return { promise, cancel }
   }
 
-  supportsUnauthedAddEthereumChain(chainId: string): boolean {
+  inlineAddEthereumChain(chainId: string): boolean {
     return this.ui.inlineAddEthereumChain(chainId)
   }
 

--- a/src/relay/WalletLinkRelayAbstract.ts
+++ b/src/relay/WalletLinkRelayAbstract.ts
@@ -108,7 +108,7 @@ export abstract class WalletLinkRelayAbstract {
 
   /**
    * Whether the provider should first call request ethereum accounts
-   * if handling an add ehereum chain call
+   * if handling an add ethereum chain call
    */
   abstract supportsUnauthedAddEthereumChain(chainId: string): boolean
 

--- a/src/relay/WalletLinkRelayAbstract.ts
+++ b/src/relay/WalletLinkRelayAbstract.ts
@@ -106,6 +106,12 @@ export abstract class WalletLinkRelayAbstract {
     chainIdCallback: (chainId: string, jsonRpcUrl: string) => void
   ): void
 
+  /**
+   * Whether the provider should first call request ethereum accounts
+   * if handling an add ehereum chain call
+   */
+  abstract supportsUnauthedAddEthereumChain(chainId: string): boolean
+
   public async makeEthereumJSONRPCRequest(
     request: JSONRPCRequest,
     jsonRpcUrl: string

--- a/src/relay/WalletLinkRelayAbstract.ts
+++ b/src/relay/WalletLinkRelayAbstract.ts
@@ -107,10 +107,10 @@ export abstract class WalletLinkRelayAbstract {
   ): void
 
   /**
-   * Whether the provider should first call request ethereum accounts
-   * if handling an add ethereum chain call
+   * Whether the relay supports the add ethereum chain call without
+   * needing to be connected to the mobile client.
    */
-  abstract supportsUnauthedAddEthereumChain(chainId: string): boolean
+  abstract inlineAddEthereumChain(chainId: string): boolean
 
   public async makeEthereumJSONRPCRequest(
     request: JSONRPCRequest,


### PR DESCRIPTION
First do an eip1102 as part of add ethereum chain if the wallet isn't yet authorized.

The current implementation will call relay.addEthereumChain even if the wallet isn't authed yet.  This only works in standalone (extension) mode.  If coinbase wallet sdk isn't connected to a mobile app yet or the extension isn't signed in yet, this will cause a snack bar to popup that leaves the user in a confusing state.  

Steps to reproduce:
1. With extension signed out and dapp not yet authorized
2. Call add ethereum chain 
Result: snack bar shows telling user to go verify a request on their mobile app
Fixed result: walletlink will ask user to authorize the dapp first.