### PR TITLE
Fix: Send dapps current network chainId through walletlink on wallet_watchAsset event

### DIFF
--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -235,7 +235,8 @@ export class CoinbaseWalletProvider
     address: string,
     symbol?: string,
     decimals?: number,
-    image?: string
+    image?: string,
+    chainId?: number
   ): Promise<boolean> {
     const relay = await this.initializeRelay()
     const result = await relay.watchAsset(
@@ -243,7 +244,8 @@ export class CoinbaseWalletProvider
       address,
       symbol,
       decimals,
-      image
+      image,
+      chainId?.toString()
     ).promise
 
     return !!result.result
@@ -1124,6 +1126,7 @@ export class CoinbaseWalletProvider
       })
     }
 
+    const chainId = parseInt(this.chainId, 16)
     const { address, symbol, image, decimals } = request.options
 
     const res = await this.watchAsset(
@@ -1131,7 +1134,8 @@ export class CoinbaseWalletProvider
       address,
       symbol,
       decimals,
-      image
+      image,
+      chainId
     )
 
     return { jsonrpc: "2.0", id: 0, result: res }

--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -1126,7 +1126,7 @@ export class CoinbaseWalletProvider
       })
     }
 
-    const chainId = parseInt(this.chainId, 16)
+    const chainId = this.getChainId();
     const { address, symbol, image, decimals } = request.options
 
     const res = await this.watchAsset(

--- a/src/provider/WalletUI.ts
+++ b/src/provider/WalletUI.ts
@@ -58,6 +58,7 @@ export interface WalletUI {
     symbol?: string
     decimals?: number
     image?: string
+    chainId?: string
   }): void
 
   switchEthereumChain(options: {

--- a/src/relay/WalletSDKRelay.ts
+++ b/src/relay/WalletSDKRelay.ts
@@ -78,9 +78,7 @@ export interface WalletSDKRelayOptions {
   darkMode: boolean
   storage: ScopedLocalStorage
   relayEventManager: WalletSDKRelayEventManager
-  uiConstructor: (
-    options: Readonly<WalletUIOptions>
-  ) => WalletUI
+  uiConstructor: (options: Readonly<WalletUIOptions>) => WalletUI
   eventListener?: EventListener
 }
 
@@ -158,10 +156,10 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
               ) {
                 this.isUnlinkedErrorState = true
                 const sessionIdHash = this.getSessionIdHash()
-                this.eventListener?.onEvent(
-                  EVENTS.UNLINKED_ERROR_STATE,
-                  { sessionIdHash, origin: location.origin }
-                )
+                this.eventListener?.onEvent(EVENTS.UNLINKED_ERROR_STATE, {
+                  sessionIdHash,
+                  origin: location.origin
+                })
               }
             }
           })
@@ -357,14 +355,11 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
           if (storedSession?.id === this._session.id) {
             this.storage.clear()
           } else if (storedSession) {
-            this.eventListener?.onEvent(
-              EVENTS.SKIPPED_CLEARING_SESSION,
-              {
-                sessionIdHash: this.getSessionIdHash(),
-                storedSessionIdHash: Session.hash(storedSession.id),
-                origin: location.origin
-              }
-            )
+            this.eventListener?.onEvent(EVENTS.SKIPPED_CLEARING_SESSION, {
+              sessionIdHash: this.getSessionIdHash(),
+              storedSessionIdHash: Session.hash(storedSession.id),
+              origin: location.origin
+            })
           }
           this.ui.reloadUI()
         },
@@ -884,7 +879,8 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
           address,
           symbol,
           decimals,
-          image
+          image,
+          chainId
         })
       }
 

--- a/src/relay/WalletSDKRelay.ts
+++ b/src/relay/WalletSDKRelay.ts
@@ -809,7 +809,8 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
     address: string,
     symbol?: string,
     decimals?: number,
-    image?: string
+    image?: string,
+    chainId?: string
   ): CancelablePromise<WatchAssetResponse> {
     const request: Web3Request = {
       method: Web3Method.watchAsset,
@@ -820,7 +821,8 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
           symbol,
           decimals,
           image
-        }
+        },
+        chainId
       }
     }
 

--- a/src/relay/WalletSDKRelayAbstract.ts
+++ b/src/relay/WalletSDKRelayAbstract.ts
@@ -50,7 +50,8 @@ export abstract class WalletSDKRelayAbstract {
     address: string,
     symbol?: string,
     decimals?: number,
-    image?: string
+    image?: string,
+    chainId?: string
   ): CancelablePromise<WatchAssetResponse>
 
   abstract switchEthereumChain(

--- a/src/relay/Web3Request.ts
+++ b/src/relay/Web3Request.ts
@@ -117,16 +117,20 @@ export type MakeEthereumJSONRPCRequest = BaseWeb3Request<
   }
 >
 
+type WatchAssetRequestBaseParams = {
+  type: string
+  options: {
+    address: string
+    symbol?: string
+    decimals?: number
+    image?: string
+  }
+}
+
 export type WatchAssetRequest = BaseWeb3Request<
   Web3Method.watchAsset,
-  {
-    type: string
-    options: {
-      address: string
-      symbol?: string
-      decimals?: number
-      image?: string
-    }
+  WatchAssetRequestBaseParams & {
+    chainId?: string
   }
 >
 


### PR DESCRIPTION
For this first version of `watchAsset` feature, we're assuming that once users authorize wallet_watchAsset request, the token should be added in the current network. That said, we've decided to follow the approach of sending its current network chainId on the event params (cc @brendanww). 

It may be used by both extension and mobile apps to add token in the correct network