### PR TITLE
Disable address switch

### DIFF
--- a/__tests__/addressStorage.test.js
+++ b/__tests__/addressStorage.test.js
@@ -43,4 +43,21 @@ describe("address storage tests", function() {
       done()
     })
   })
+
+  it("will not switch address if address switching disabled", async () => {
+    const coinbaseWalletSDK = new CoinbaseWalletSDK({
+      appName: "My Awesome DApp",
+      appLogoUrl: "https://example.com/logo.png"
+    })
+
+    const provider = coinbaseWalletSDK.makeWeb3Provider(
+        "https://mainnet.infura.io/v3/INFURA_API_KEY", 1
+    )
+    provider.supportsAddressSwitching = false
+
+    provider._addresses = ["0xfadafce89ea2221fa33005640acf2c923312f2b9"]
+    await provider.initializeRelay()
+    provider._relay.accountsCallback(["0x7f268357A8c2552623316e2562D90e642bB538E5"])
+    expect(provider._addresses[0]).toEqual("0xfadafce89ea2221fa33005640acf2c923312f2b9")
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/wallet-sdk",
-  "version": "3.0.5",
+  "version": "3.0.4",
   "description": "Coinbase Wallet JavaScript SDK",
   "keywords": [
     "cipher",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/wallet-sdk",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Coinbase Wallet JavaScript SDK",
   "keywords": [
     "cipher",

--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -56,6 +56,7 @@ export interface CoinbaseWalletProviderOptions {
   relayProvider: () => Promise<WalletSDKRelayAbstract>
   storage: ScopedLocalStorage
   eventListener?: EventListener
+  supportsAddressSwitching?: boolean
 }
 
 export class CoinbaseWalletProvider
@@ -81,6 +82,8 @@ export class CoinbaseWalletProvider
 
   private hasMadeFirstChainChangedEmission = false
 
+  private _supportsAddressSwitching?: boolean
+
   constructor(options: Readonly<CoinbaseWalletProviderOptions>) {
     super()
 
@@ -105,6 +108,8 @@ export class CoinbaseWalletProvider
     this._eventListener = options.eventListener
 
     this.isCoinbaseWallet = options.overrideIsCoinbaseWallet ?? true
+
+    this._supportsAddressSwitching = options.supportsAddressSwitching
 
     const chainId = this.getChainId()
     const chainIdStr = prepend0x(chainId.toString(16))
@@ -532,6 +537,14 @@ export class CoinbaseWalletProvider
     const newAddresses = addresses.map(address => ensureAddressString(address))
 
     if (JSON.stringify(newAddresses) === JSON.stringify(this._addresses)) {
+      return
+    }
+
+    if (this._addresses && this._supportsAddressSwitching === false) {
+      /**
+       * The extension currently doesn't support switching selected wallet index
+       * make sure walletlink doesn't update it's address in this case
+       */
       return
     }
 

--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -540,7 +540,7 @@ export class CoinbaseWalletProvider
       return
     }
 
-    if (this._addresses && this.supportsAddressSwitching === false) {
+    if (this._addresses.length > 0 && this.supportsAddressSwitching === false) {
       /**
        * The extension currently doesn't support switching selected wallet index
        * make sure walletlink doesn't update it's address in this case

--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -82,7 +82,7 @@ export class CoinbaseWalletProvider
 
   private hasMadeFirstChainChangedEmission = false
 
-  private _supportsAddressSwitching?: boolean
+  private supportsAddressSwitching?: boolean
 
   constructor(options: Readonly<CoinbaseWalletProviderOptions>) {
     super()
@@ -109,7 +109,7 @@ export class CoinbaseWalletProvider
 
     this.isCoinbaseWallet = options.overrideIsCoinbaseWallet ?? true
 
-    this._supportsAddressSwitching = options.supportsAddressSwitching
+    this.supportsAddressSwitching = options.supportsAddressSwitching
 
     const chainId = this.getChainId()
     const chainIdStr = prepend0x(chainId.toString(16))
@@ -540,7 +540,7 @@ export class CoinbaseWalletProvider
       return
     }
 
-    if (this._addresses && this._supportsAddressSwitching === false) {
+    if (this._addresses && this.supportsAddressSwitching === false) {
       /**
        * The extension currently doesn't support switching selected wallet index
        * make sure walletlink doesn't update it's address in this case


### PR DESCRIPTION
Add option to disable switching selected address.  Currently the extension doesn't support this gracefully leading to timing issues if you connect a dapp to your mobile phone via the extension, and the mobile has a different address selected than the one the extension connected to originally.