### PR TITLE
[fix] Use `message` argument

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -45,5 +45,5 @@ jobs:
       - name: Commit and tag updated version
         uses: EndBug/add-and-commit@v9
         with:
-          commit: "v${{ env.PACKAGE_VERSION }}"
+          message: "v${{ env.PACKAGE_VERSION }}"
           tag: "v${{ env.PACKAGE_VERSION }}"


### PR DESCRIPTION
### *Summary*
<!--
  What changed? Link to relevant issues.
-->

- Fixes wrong argument used for version tag github action. Updated.
- 
![image](https://user-images.githubusercontent.com/50590950/161793927-f8b2d1b1-02b2-458d-af81-58c96c752477.png)


### *How did you test your changes?*
<!--
  Verify changes. Include relevant screenshots/videos
-->
