### PR TITLE
fix: make qr code url available in headless mode

### DIFF
--- a/src/CoinbaseWalletSDK.ts
+++ b/src/CoinbaseWalletSDK.ts
@@ -8,7 +8,7 @@ import { WalletSDKUI } from "./provider/WalletSDKUI";
 import { WalletUI, WalletUIOptions } from "./provider/WalletUI";
 import { WalletSDKRelay } from "./relay/WalletSDKRelay";
 import { WalletSDKRelayEventManager } from "./relay/WalletSDKRelayEventManager";
-import { createQrUrl, getFavicon } from "./util";
+import { getFavicon } from "./util";
 
 const LINK_API_URL = process.env.LINK_API_URL || "https://www.walletlink.org";
 const SDK_VERSION =
@@ -43,7 +43,6 @@ export class CoinbaseWalletSDK {
   private _appLogoUrl: string | null = null;
   private _relay: WalletSDKRelay | null = null;
   private _relayEventManager: WalletSDKRelayEventManager | null = null;
-  private _qrUrl: string | null = null;
   private _storage: ScopedLocalStorage;
   private _overrideIsMetaMask: boolean;
   private _overrideIsCoinbaseWallet: boolean;
@@ -98,13 +97,6 @@ export class CoinbaseWalletSDK {
     if (!!options.headlessMode) return;
 
     this._relay.attachUI();
-
-    this._qrUrl = createQrUrl(
-      this._relay.session.id,
-      this._relay.session.secret,
-      linkAPIUrl,
-      false
-    );
   }
 
   /**
@@ -184,7 +176,7 @@ export class CoinbaseWalletSDK {
    * Return QR URL for mobile wallet connection, will return null if extension is installed
    */
   public getQrUrl(): string | null {
-    return this._qrUrl;
+    return this._relay?.getQRCodeUrl() ?? null;
   }
 
   private get walletExtension(): CoinbaseWalletProvider | undefined {

--- a/src/relay/WalletSDKRelay.ts
+++ b/src/relay/WalletSDKRelay.ts
@@ -23,6 +23,7 @@ import { WalletUI, WalletUIOptions } from "../provider/WalletUI";
 import { AddressString, IntNumber, RegExpString } from "../types";
 import {
   bigIntStringFromBN,
+  createQrUrl,
   hexStringFromBuffer,
   randomBytesHex
 } from "../util";
@@ -510,6 +511,15 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
       method: Web3Method.scanQRCode,
       params: { regExp }
     });
+  }
+
+  public getQRCodeUrl() {
+    return createQrUrl(
+      this.session.id,
+      this.session.secret,
+      this.linkAPIUrl,
+      false
+    );
   }
 
   public genericRequest(


### PR DESCRIPTION
### *Summary*
Hey y'all, thanks for working on this project 👋 

We'd like to make the QR code URL available when running the SDK in headless mode. Currently there is an [early return in the `CoinbaseWalletSDK` constructor](https://github.com/coinbase/coinbase-wallet-sdk/blob/master/src/CoinbaseWalletSDK.ts#L98) that results in the QR code URL not being set when running in headless mode.

Since the inputs to `createQrUrl` are specific to the relay, it makes sense for the relay to expose it as a method. Users of `CoinbaseWalletSDK` will now be able to call `getQrUrl` and get back a URL whether or not they are running in headless mode!

### *How did you test your changes?*
Local test app
