### PR TITLE
Added QR URL on web3 provider

### DIFF
--- a/src/CoinbaseWalletSDK.ts
+++ b/src/CoinbaseWalletSDK.ts
@@ -131,7 +131,7 @@ export class CoinbaseWalletSDK {
       storage: this._storage,
       jsonRpcUrl,
       chainId,
-      qrUrl: relay.getQRCodeUrl(),
+      qrUrl: this.getQrUrl(),
       eventListener: this._eventListener,
       overrideIsMetaMask: this._overrideIsMetaMask,
       overrideIsCoinbaseWallet: this._overrideIsCoinbaseWallet

--- a/src/CoinbaseWalletSDK.ts
+++ b/src/CoinbaseWalletSDK.ts
@@ -131,6 +131,7 @@ export class CoinbaseWalletSDK {
       storage: this._storage,
       jsonRpcUrl,
       chainId,
+      qrUrl: relay.getQRCodeUrl(),
       eventListener: this._eventListener,
       overrideIsMetaMask: this._overrideIsMetaMask,
       overrideIsCoinbaseWallet: this._overrideIsCoinbaseWallet

--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -50,6 +50,7 @@ const HAS_CHAIN_OVERRIDDEN_FROM_RELAY = "HasChainOverriddenFromRelay";
 export interface CoinbaseWalletProviderOptions {
   chainId?: number;
   jsonRpcUrl: string;
+  qrUrl: string;
   overrideIsCoinbaseWallet?: boolean;
   overrideIsMetaMask: boolean;
   relayEventManager: WalletSDKRelayEventManager;
@@ -65,6 +66,7 @@ export class CoinbaseWalletProvider
 {
   // So dapps can easily identify Coinbase Wallet for enabling features like 3085 network switcher menus
   public readonly isCoinbaseWallet: boolean;
+  public readonly qrUrl: string;
 
   private readonly _filterPolyfill = new FilterPolyfill(this);
   private readonly _subscriptionManager = new SubscriptionManager(this);
@@ -108,6 +110,8 @@ export class CoinbaseWalletProvider
     this._eventListener = options.eventListener;
 
     this.isCoinbaseWallet = options.overrideIsCoinbaseWallet ?? true;
+
+    this.qrUrl = options.qrUrl;
 
     this.supportsAddressSwitching = options.supportsAddressSwitching;
 

--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -50,7 +50,7 @@ const HAS_CHAIN_OVERRIDDEN_FROM_RELAY = "HasChainOverriddenFromRelay";
 export interface CoinbaseWalletProviderOptions {
   chainId?: number;
   jsonRpcUrl: string;
-  qrUrl: string;
+  qrUrl: string | null;
   overrideIsCoinbaseWallet?: boolean;
   overrideIsMetaMask: boolean;
   relayEventManager: WalletSDKRelayEventManager;
@@ -66,7 +66,7 @@ export class CoinbaseWalletProvider
 {
   // So dapps can easily identify Coinbase Wallet for enabling features like 3085 network switcher menus
   public readonly isCoinbaseWallet: boolean;
-  public readonly qrUrl: string;
+  public readonly qrUrl: string | null;
 
   private readonly _filterPolyfill = new FilterPolyfill(this);
   private readonly _subscriptionManager = new SubscriptionManager(this);

--- a/src/relay/WalletSDKRelay.ts
+++ b/src/relay/WalletSDKRelay.ts
@@ -515,8 +515,8 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
 
   public getQRCodeUrl() {
     return createQrUrl(
-      this.session.id,
-      this.session.secret,
+      this._session.id,
+      this._session.secret,
       this.linkAPIUrl,
       false
     );


### PR DESCRIPTION
### *Summary*
- Most third-party libraries expose the web3 provider as a connector for dev to integrate into their dapps. By adding the QR url directly onto the provider, makes it easier for devs to access on their frontend rather than accessing via our SDK method

### *How did you test your changes?*
locally
