### PR TITLE
perform UI reload only if not in headless mode

### DIFF
--- a/src/CoinbaseWalletSDK.test.ts
+++ b/src/CoinbaseWalletSDK.test.ts
@@ -49,11 +49,11 @@ describe("CoinbaseWalletSDK", () => {
         );
       });
 
-      test("@disconnect", () => {
+      test("@disconnect", async () => {
         const relayResetMock = jest
           .spyOn(WalletSDKRelay.prototype, "resetAndReload")
           .mockImplementation(() => "resetAndReload");
-        coinbaseWalletSDK2.disconnect();
+        await coinbaseWalletSDK2.disconnect();
 
         expect(relayResetMock).toHaveBeenCalled();
       });
@@ -96,10 +96,10 @@ describe("CoinbaseWalletSDK", () => {
         );
       });
 
-      test("@disconnect", () => {
+      test("@disconnect", async () => {
         // Calls extension close
-        coinbaseWalletSDK2.disconnect();
-        expect(mockExtensionProvider.close()).toEqual("mockClose");
+        await coinbaseWalletSDK2.disconnect();
+        expect(await mockExtensionProvider.close()).toEqual(undefined);
       });
 
       test("@setAppInfo", async () => {
@@ -151,6 +151,29 @@ describe("CoinbaseWalletSDK", () => {
           .mockImplementation(() => "setAppInfo");
         coinbaseWalletSDK2.setAppInfo("cipher", "http://cipher-image.png");
         expect(relaySetAppInfoMock).not.toBeCalled();
+      });
+    });
+  });
+
+  describe("public methods headless mode", () => {
+    let headlessWalletSDK: CoinbaseWalletSDK;
+
+    beforeEach(() => {
+      headlessWalletSDK = new CoinbaseWalletSDK({
+        appName: "Test",
+        appLogoUrl: "http://coinbase.com/wallet-logo.png",
+        headlessMode: true,
+      });
+    });
+
+    describe("sdk", () => {
+      test("@disconnect", async () => {
+        const relayMock = jest
+          .spyOn(WalletSDKRelay.prototype, "reset")
+          .mockImplementation(() => "reset");
+        await headlessWalletSDK.disconnect();
+
+        expect(relayMock).toHaveBeenCalled();
       });
     });
   });

--- a/src/__mocks__/provider.ts
+++ b/src/__mocks__/provider.ts
@@ -12,9 +12,7 @@ export class MockProviderClass extends CoinbaseWalletProvider {
     super(opts);
   }
 
-  public close() {
-    return "mockClose";
-  }
+  public async close() {}
 
   // @ts-expect-error mock relay
   private async initializeRelay() {

--- a/src/relay/WalletSDKRelayAbstract.ts
+++ b/src/relay/WalletSDKRelayAbstract.ts
@@ -29,6 +29,7 @@ export type CancelablePromise<T> = {
 };
 
 export abstract class WalletSDKRelayAbstract {
+  abstract reset(): void;
   abstract resetAndReload(): void;
 
   abstract requestEthereumAccounts(): CancelablePromise<RequestEthereumAccountsResponse>;


### PR DESCRIPTION
### *Summary*

Users in headless mode might not wish to have the page automatically reload when disconnecting the client – they are bringing their own UI and so should reload it as they see fit.

In the spirit of backwards compatibility, I copy-pasted `WalletSDKRelay#resetAndReload` into `WalletSDKRelay#reset` and omitted the call to `this.ui.reloadUI`, and updated the consumers of `WalletSDKRelay#resetAndReload` (`CoinbaseWalletProvider#close` and `CoinbaseWalletSDK#disconnect`) to call `reset` if in headless mode, or resetAndReload if not in headless mode.

Thanks for taking a look, and let me know what feedback you have or if you'd like me to expand on a specific use case for this!

### *How did you test your changes?*
Local test app
