### PR TITLE
UPDATED: qrUrl on provider to be optional

### DIFF
--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -50,7 +50,7 @@ const HAS_CHAIN_OVERRIDDEN_FROM_RELAY = "HasChainOverriddenFromRelay";
 export interface CoinbaseWalletProviderOptions {
   chainId?: number;
   jsonRpcUrl: string;
-  qrUrl: string | null;
+  qrUrl?: string | null;
   overrideIsCoinbaseWallet?: boolean;
   overrideIsMetaMask: boolean;
   relayEventManager: WalletSDKRelayEventManager;
@@ -66,7 +66,7 @@ export class CoinbaseWalletProvider
 {
   // So dapps can easily identify Coinbase Wallet for enabling features like 3085 network switcher menus
   public readonly isCoinbaseWallet: boolean;
-  public readonly qrUrl: string | null;
+  public readonly qrUrl?: string | null;
 
   private readonly _filterPolyfill = new FilterPolyfill(this);
   private readonly _subscriptionManager = new SubscriptionManager(this);


### PR DESCRIPTION
non-optional qrUrl made breaking change on extension, making the parameter optional.