### PR TITLE
Add getAllItems to ScopedLocalStorage

### DIFF
--- a/src/lib/ScopedLocalStorage.test.ts
+++ b/src/lib/ScopedLocalStorage.test.ts
@@ -25,14 +25,29 @@ describe("ScopedLocalStorage", () => {
       expect(localStorage.length).toEqual(0);
     });
 
-    test("@clear", () => {
+    test("@getAllItems", () => {
+      localStorage.setItem("other", "1");
       scopedLocalStorage.setItem("foo1", "bar1");
       scopedLocalStorage.setItem("foo2", "bar2");
       scopedLocalStorage.setItem("foo3", "bar3");
-      expect(localStorage.length).toEqual(3);
+      expect(localStorage.length).toEqual(4);
+
+      expect(scopedLocalStorage.getAllItems()).toEqual([
+        "bar1",
+        "bar2",
+        "bar3",
+      ]);
+    });
+
+    test("@clear", () => {
+      localStorage.setItem("other", "1");
+      scopedLocalStorage.setItem("foo1", "bar1");
+      scopedLocalStorage.setItem("foo2", "bar2");
+      scopedLocalStorage.setItem("foo3", "bar3");
+      expect(localStorage.length).toEqual(4);
 
       scopedLocalStorage.clear();
-      expect(localStorage.length).toEqual(0);
+      expect(localStorage.length).toEqual(1);
     });
   });
 });

--- a/src/lib/ScopedLocalStorage.ts
+++ b/src/lib/ScopedLocalStorage.ts
@@ -16,16 +16,24 @@ export class ScopedLocalStorage {
     localStorage.removeItem(this.scopedKey(key));
   }
 
+  public getAllItems(): string[] {
+    return this.getAllScopedKeys().map(key => localStorage.getItem(key)!);
+  }
+
   public clear(): void {
+    this.getAllScopedKeys().forEach(key => localStorage.removeItem(key));
+  }
+
+  private getAllScopedKeys(): string[] {
     const prefix = this.scopedKey("");
-    const keysToRemove: string[] = [];
+    const keys: string[] = [];
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
       if (typeof key === "string" && key.startsWith(prefix)) {
-        keysToRemove.push(key);
+        keys.push(key);
       }
     }
-    keysToRemove.forEach(key => localStorage.removeItem(key));
+    return keys;
   }
 
   private scopedKey(key: string): string {


### PR DESCRIPTION
### _Summary_

We're using ScopedLocalStorage in wallet extension and needed a way to get all items from the scoped storage. I wanted to avoid having to fork this to add this one method, but let me know if this is out of scope (pun intended).

### _How did you test your changes?_

Unit tests, tested change in wallet extension.
