### PR TITLE
Fix missing styles in dark mode

### DIFF
--- a/src/components/TryExtensionLinkDialog.scss
+++ b/src/components/TryExtensionLinkDialog.scss
@@ -68,6 +68,7 @@
         min-height: 300px;
 
         &.dark {
+          color: $white;
           background-color: $black;
           box-shadow: 0 4px 16px rgba(255, 255, 255, 0.05);
         }

--- a/src/components/TryExtensionLinkDialog.scss
+++ b/src/components/TryExtensionLinkDialog.scss
@@ -255,12 +255,25 @@
           flex-direction: column;
           align-items: center;
           justify-content: center;
-          background-color: rgba($white, 0.95);
+
+          &.light {
+            background-color: rgba($white, 0.95);
+            > p {
+              color: $black;
+            }
+          }
+
+          &.dark {
+            background-color: rgba($background-alt-dark, 0.9);
+            > p {
+              color: $white;
+            }
+          }
 
           > p {
             font-size: 12px;
             font-weight: bold;
-            color: $black;
+
             margin-top: 16px;
           }
         }

--- a/src/components/TryExtensionLinkDialog.tsx
+++ b/src/components/TryExtensionLinkDialog.tsx
@@ -215,9 +215,12 @@ const ScanQRBox: FunctionComponent<{
         {!props.isConnected && (
           <div
             data-testid="connecting-spinner"
-            class="-cbwsdk-extension-dialog-box-bottom-qr-connecting"
+            class={clsx(
+              "-cbwsdk-extension-dialog-box-bottom-qr-connecting",
+              theme,
+            )}
           >
-            <Spinner size={36} color={"#000"} />
+            <Spinner size={36} color={props.darkMode ? "#FFF" : "#000"} />
             <p>Connecting...</p>
           </div>
         )}


### PR DESCRIPTION
### _Summary_

Added styles for loading spinner state in dark mode, and fix text color after clicking the install button.  Missed these in my last PR.

![connecting](https://user-images.githubusercontent.com/311848/171193437-d4c2abbb-54ad-4682-b07c-6e38788e79c8.png)

![image](https://user-images.githubusercontent.com/311848/171197053-54c98d48-5d70-41a3-98cf-47ae019d1408.png)

![connect white](https://user-images.githubusercontent.com/311848/171193457-9ac4bcc5-52dc-46b4-a697-24a9065339ff.png)


### _How did you test your changes?_

Tested with darkMode flag true, false, and omitted
