### PR TITLE
Add option on SDK to disable reloading dapp after disconnect

### DIFF
--- a/src/CoinbaseWalletSDK.ts
+++ b/src/CoinbaseWalletSDK.ts
@@ -37,6 +37,8 @@ export interface CoinbaseWalletSDKOptions {
   overrideIsCoinbaseBrowser?: boolean;
   /** @optional whether or not onboarding overlay popup should be displayed */
   headlessMode?: boolean;
+  /** @optional whether or not to disable reloading dapp automatically after disconnect */
+  disableReloadDisconnect?: boolean;
 }
 
 export class CoinbaseWalletSDK {
@@ -51,6 +53,7 @@ export class CoinbaseWalletSDK {
   private _overrideIsCoinbaseWallet: boolean;
   private _overrideIsCoinbaseBrowser: boolean;
   private _diagnosticLogger?: DiagnosticLogger;
+  private _disableReloadDisconnect?: boolean;
 
   /**
    * Constructor
@@ -76,6 +79,8 @@ export class CoinbaseWalletSDK {
       options.overrideIsCoinbaseBrowser ?? false;
 
     this._diagnosticLogger = options.diagnosticLogger;
+
+    this._disableReloadDisconnect = options.disableReloadDisconnect;
 
     const u = new URL(linkAPIUrl);
     const origin = `${u.protocol}//${u.host}`;
@@ -120,6 +125,8 @@ export class CoinbaseWalletSDK {
       if (!this.isCipherProvider(extension)) {
         extension.setProviderInfo(jsonRpcUrl, chainId);
       }
+
+      if (this._disableReloadDisconnect) extension.setDisableDisconnectReload();
 
       return extension;
     }

--- a/src/CoinbaseWalletSDK.ts
+++ b/src/CoinbaseWalletSDK.ts
@@ -126,7 +126,8 @@ export class CoinbaseWalletSDK {
         extension.setProviderInfo(jsonRpcUrl, chainId);
       }
 
-      if (this._reloadOnDisconnect === false) extension.disableReloadOnDisconnect();
+      if (this._reloadOnDisconnect === false)
+        extension.disableReloadOnDisconnect();
 
       return extension;
     }

--- a/src/CoinbaseWalletSDK.ts
+++ b/src/CoinbaseWalletSDK.ts
@@ -37,8 +37,8 @@ export interface CoinbaseWalletSDKOptions {
   overrideIsCoinbaseBrowser?: boolean;
   /** @optional whether or not onboarding overlay popup should be displayed */
   headlessMode?: boolean;
-  /** @optional whether or not to disable reloading dapp automatically after disconnect */
-  disableReloadDisconnect?: boolean;
+  /** @optional whether or not to reload dapp automatically after disconnect, defaults to true */
+  reloadOnDisconnect?: boolean;
 }
 
 export class CoinbaseWalletSDK {
@@ -53,7 +53,7 @@ export class CoinbaseWalletSDK {
   private _overrideIsCoinbaseWallet: boolean;
   private _overrideIsCoinbaseBrowser: boolean;
   private _diagnosticLogger?: DiagnosticLogger;
-  private _disableReloadDisconnect?: boolean;
+  private _reloadOnDisconnect?: boolean;
 
   /**
    * Constructor
@@ -80,7 +80,7 @@ export class CoinbaseWalletSDK {
 
     this._diagnosticLogger = options.diagnosticLogger;
 
-    this._disableReloadDisconnect = options.disableReloadDisconnect;
+    this._reloadOnDisconnect = options.reloadOnDisconnect ?? true;
 
     const u = new URL(linkAPIUrl);
     const origin = `${u.protocol}//${u.host}`;
@@ -126,7 +126,7 @@ export class CoinbaseWalletSDK {
         extension.setProviderInfo(jsonRpcUrl, chainId);
       }
 
-      if (this._disableReloadDisconnect) extension.setDisableDisconnectReload();
+      if (this._reloadOnDisconnect === false) extension.disableReloadOnDisconnect();
 
       return extension;
     }

--- a/src/provider/CoinbaseWalletProvider.test.ts
+++ b/src/provider/CoinbaseWalletProvider.test.ts
@@ -86,6 +86,12 @@ describe("CoinbaseWalletProvider", () => {
     expect(provider.host).toBe("http://test.ethnode.com");
   });
 
+  it("handles setting disable reload on disconnect flag", () => {
+    const provider = setupCoinbaseWalletProvider();
+    provider.setDisableDisconnectReload();
+    expect(provider.disableDisconnectReload).toBe(true);
+  });
+
   it("handles subscriptions", () => {
     const provider = setupCoinbaseWalletProvider();
     expect(provider.supportsSubscriptions()).toBe(false);

--- a/src/provider/CoinbaseWalletProvider.test.ts
+++ b/src/provider/CoinbaseWalletProvider.test.ts
@@ -88,8 +88,8 @@ describe("CoinbaseWalletProvider", () => {
 
   it("handles setting disable reload on disconnect flag", () => {
     const provider = setupCoinbaseWalletProvider();
-    provider.setDisableDisconnectReload();
-    expect(provider.disableDisconnectReload).toBe(true);
+    provider.disableReloadOnDisconnect();
+    expect(provider.reloadOnDisconnect).toBe(false);
   });
 
   it("handles subscriptions", () => {

--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -98,6 +98,7 @@ export class CoinbaseWalletProvider
   public readonly isCoinbaseBrowser: boolean;
 
   public readonly qrUrl?: string | null;
+  public disableDisconnectReload: boolean;
 
   private readonly _filterPolyfill = new FilterPolyfill(this);
   private readonly _subscriptionManager = new SubscriptionManager(this);
@@ -139,6 +140,7 @@ export class CoinbaseWalletProvider
     this._storage = options.storage;
     this._relayEventManager = options.relayEventManager;
     this.diagnostic = options.diagnosticLogger;
+    this.disableDisconnectReload = false;
 
     this.isCoinbaseWallet = options.overrideIsCoinbaseWallet ?? true;
     this.isCoinbaseBrowser = options.overrideIsCoinbaseBrowser ?? false;
@@ -241,6 +243,10 @@ export class CoinbaseWalletProvider
 
   private set isChainOverridden(value: boolean) {
     this._storage.setItem(HAS_CHAIN_OVERRIDDEN_FROM_RELAY, value.toString());
+  }
+
+  public setDisableDisconnectReload() {
+    this.disableDisconnectReload = true;
   }
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -1242,7 +1248,7 @@ export class CoinbaseWalletProvider
 
     return this._relayProvider().then(relay => {
       relay.setAccountsCallback((accounts, isDisconnect) =>
-        this._setAddresses(accounts, isDisconnect)
+        this._setAddresses(accounts, isDisconnect),
       );
       relay.setChainCallback((chainId, jsonRpcUrl) => {
         this.updateProviderInfo(jsonRpcUrl, parseInt(chainId, 10), true);

--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -98,7 +98,7 @@ export class CoinbaseWalletProvider
   public readonly isCoinbaseBrowser: boolean;
 
   public readonly qrUrl?: string | null;
-  public disableDisconnectReload: boolean;
+  public reloadOnDisconnect: boolean;
 
   private readonly _filterPolyfill = new FilterPolyfill(this);
   private readonly _subscriptionManager = new SubscriptionManager(this);
@@ -140,7 +140,7 @@ export class CoinbaseWalletProvider
     this._storage = options.storage;
     this._relayEventManager = options.relayEventManager;
     this.diagnostic = options.diagnosticLogger;
-    this.disableDisconnectReload = false;
+    this.reloadOnDisconnect = true;
 
     this.isCoinbaseWallet = options.overrideIsCoinbaseWallet ?? true;
     this.isCoinbaseBrowser = options.overrideIsCoinbaseBrowser ?? false;
@@ -245,8 +245,8 @@ export class CoinbaseWalletProvider
     this._storage.setItem(HAS_CHAIN_OVERRIDDEN_FROM_RELAY, value.toString());
   }
 
-  public setDisableDisconnectReload() {
-    this.disableDisconnectReload = true;
+  public disableReloadOnDisconnect() {
+    this.reloadOnDisconnect = false;
   }
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/provider/CoinbaseWalletProvider.ts
+++ b/src/provider/CoinbaseWalletProvider.ts
@@ -570,7 +570,7 @@ export class CoinbaseWalletProvider
     return response;
   }
 
-  private _setAddresses(addresses: string[]): void {
+  private _setAddresses(addresses: string[], isDisconnect?: boolean): void {
     if (!Array.isArray(addresses)) {
       throw new Error("addresses is not an array");
     }
@@ -581,7 +581,11 @@ export class CoinbaseWalletProvider
       return;
     }
 
-    if (this._addresses.length > 0 && this.supportsAddressSwitching === false) {
+    if (
+      this._addresses.length > 0 &&
+      this.supportsAddressSwitching === false &&
+      !isDisconnect
+    ) {
       /**
        * The extension currently doesn't support switching selected wallet index
        * make sure walletlink doesn't update it's address in this case
@@ -1237,7 +1241,9 @@ export class CoinbaseWalletProvider
     }
 
     return this._relayProvider().then(relay => {
-      relay.setAccountsCallback(accounts => this._setAddresses(accounts));
+      relay.setAccountsCallback((accounts, isDisconnect) =>
+        this._setAddresses(accounts, isDisconnect)
+      );
       relay.setChainCallback((chainId, jsonRpcUrl) => {
         this.updateProviderInfo(jsonRpcUrl, parseInt(chainId, 10), true);
       });

--- a/src/provider/WalletSDKUI.ts
+++ b/src/provider/WalletSDKUI.ts
@@ -18,9 +18,12 @@ import { WalletUI, WalletUIOptions } from "./WalletUI";
 export class WalletSDKUI implements WalletUI {
   private readonly linkFlow: LinkFlow;
   private readonly snackbar: Snackbar;
+  private standalone: boolean | null;
   private attached = false;
 
   constructor(options: Readonly<WalletUIOptions>) {
+    this.standalone = null;
+
     this.snackbar = new Snackbar({
       darkMode: options.darkMode,
     });
@@ -221,7 +224,12 @@ export class WalletSDKUI implements WalletUI {
   }
 
   /* istanbul ignore next */
+  setStandalone(status: boolean): void {
+    this.standalone = status;
+  }
+
+  /* istanbul ignore next */
   isStandalone(): boolean {
-    return false;
+    return this.standalone ?? false;
   }
 }

--- a/src/provider/WalletSDKUI.ts
+++ b/src/provider/WalletSDKUI.ts
@@ -18,12 +18,10 @@ import { WalletUI, WalletUIOptions } from "./WalletUI";
 export class WalletSDKUI implements WalletUI {
   private readonly linkFlow: LinkFlow;
   private readonly snackbar: Snackbar;
-  private standalone: boolean | null;
+  private standalone: boolean | null = null;
   private attached = false;
 
   constructor(options: Readonly<WalletUIOptions>) {
-    this.standalone = null;
-
     this.snackbar = new Snackbar({
       darkMode: options.darkMode,
     });

--- a/src/provider/WalletUI.ts
+++ b/src/provider/WalletUI.ts
@@ -140,6 +140,11 @@ export interface WalletUI {
   inlineSwitchEthereumChain(): boolean;
 
   /**
+   * Set whether the UI is in standalone mode, to preserve context when disconnecting
+   */
+  setStandalone(status: boolean): void;
+
+  /**
    * If the extension is in standalone mode, it can handle signing locally
    */
   isStandalone(): boolean;

--- a/src/relay/WalletSDKRelay.ts
+++ b/src/relay/WalletSDKRelay.ts
@@ -82,7 +82,7 @@ export interface WalletSDKRelayOptions {
   relayEventManager: WalletSDKRelayEventManager;
   uiConstructor: (options: Readonly<WalletUIOptions>) => WalletUI;
   diagnosticLogger?: DiagnosticLogger;
-  disableDisconnectReload?: boolean;
+  reloadOnDisconnect?: boolean;
 }
 
 export class WalletSDKRelay extends WalletSDKRelayAbstract {
@@ -107,7 +107,7 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
   private appName = "";
   private appLogoUrl: string | null = null;
   private subscriptions = new Subscription();
-  private reloadOnDisconnect: boolean;
+  private _reloadOnDisconnect: boolean;
   isLinked: boolean | undefined;
   isUnlinkedErrorState: boolean | undefined;
 
@@ -125,9 +125,7 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
     this.relayEventManager = options.relayEventManager;
     this.diagnostic = options.diagnosticLogger;
 
-    this.reloadOnDisconnect = options.disableDisconnectReload
-      ? !options.disableDisconnectReload
-      : true;
+    this._reloadOnDisconnect = options.reloadOnDisconnect ?? true;
 
     this.ui = ui;
   }
@@ -397,7 +395,7 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
             });
           }
 
-          if (this.reloadOnDisconnect) {
+          if (this._reloadOnDisconnect) {
             this.ui.reloadUI();
             return;
           }

--- a/src/relay/WalletSDKRelay.ts
+++ b/src/relay/WalletSDKRelay.ts
@@ -300,7 +300,7 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
         .subscribe({
           next: selectedAddress => {
             if (this.accountsCallback) {
-              this.accountsCallback([selectedAddress], true);
+              this.accountsCallback([selectedAddress]);
             }
 
             if (WalletSDKRelay.accountRequestCallbackIds.size > 0) {

--- a/src/relay/WalletSDKRelay.ts
+++ b/src/relay/WalletSDKRelay.ts
@@ -399,6 +399,7 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
 
           if (this.reloadOnDisconnect) {
             this.ui.reloadUI();
+            return;
           }
 
           if (this.accountsCallback) {

--- a/src/relay/WalletSDKRelayAbstract.ts
+++ b/src/relay/WalletSDKRelayAbstract.ts
@@ -101,7 +101,7 @@ export abstract class WalletSDKRelayAbstract {
   abstract setAppInfo(appName: string, appLogoUrl: string | null): void;
 
   abstract setAccountsCallback(
-    accountsCallback: (accounts: string[]) => void,
+    accountsCallback: (accounts: string[], isDisconnect?: boolean) => void,
   ): void;
 
   abstract setChainCallback(


### PR DESCRIPTION
### _Summary_
- Added option on SDK to disable reloading dapp on disconnect
- Added feature to disable reload of page and emit "accountsChanged" event on disconnect (if option set true)
- Feature is optional due to lack of compatibility with existing dapps and aggregator libraries

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_
locally with the following dapps: 
- Uniswap
- Compound
- Zapper
- Opensea
- Curve
- Sushiswap
- AAVE
- Balancer
- Prettier-Test-Dapp

<!--
  Verify changes. Include relevant screenshots/videos
-->
![2022-05-31 12 25 56](https://user-images.githubusercontent.com/15843286/171225512-dce90e1e-f326-403e-947a-1a7fc1283828.gif)

