### PR TITLE
Make setStandalone on WalletUI Optional

### DIFF
--- a/src/provider/WalletUI.ts
+++ b/src/provider/WalletUI.ts
@@ -142,7 +142,7 @@ export interface WalletUI {
   /**
    * Set whether the UI is in standalone mode, to preserve context when disconnecting
    */
-  setStandalone(status: boolean): void;
+  setStandalone?(status: boolean): void;
 
   /**
    * If the extension is in standalone mode, it can handle signing locally

--- a/src/relay/WalletSDKRelay.ts
+++ b/src/relay/WalletSDKRelay.ts
@@ -409,7 +409,8 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
           this.connection = connection;
           this.ui = ui;
 
-          if (isStandalone) this.ui.setStandalone(true);
+          if (isStandalone && this.ui.setStandalone)
+            this.ui.setStandalone(true);
 
           this.attachUI();
         },


### PR DESCRIPTION
### _Summary_
- Make breaking interface change on WalletUI optional for backward compatibility

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_
locally
