### PR TITLE
Add browser-compatible buffer and util for Webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@metamask/safe-event-emitter": "2.0.0",
     "bind-decorator": "^1.0.11",
     "bn.js": "^5.1.1",
+    "buffer": "^6.0.3",
     "clsx": "^1.1.0",
     "eth-block-tracker": "4.4.3",
     "eth-json-rpc-filters": "4.2.2",
@@ -55,7 +56,8 @@
     "preact": "^10.5.9",
     "qs": "^6.10.3",
     "rxjs": "^6.6.3",
-    "stream-browserify": "^3.0.0"
+    "stream-browserify": "^3.0.0",
+    "util": "^0.12.4"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,8 @@ module.exports = {
     fallback: {
       fs: false,
       stream: require.resolve("stream-browserify"),
+      buffer: require.resolve("buffer/"),
+      util: require.resolve("util/"),
     },
     extensions: [".ts", ".tsx", ".js"],
     plugins: [],
@@ -54,6 +56,9 @@ module.exports = {
         LINK_API_URL: JSON.stringify(env.LINK_API_URL),
         SDK_VERSION: JSON.stringify(require("./package.json").version),
       },
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ["buffer", "Buffer"],
     }),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,7 +2285,7 @@ base64-arraybuffer@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz#87bd13525626db4a9838e00a508c2b73efcf348c"
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
 
@@ -2562,6 +2562,14 @@ buffer-from@^1.0.0:
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 buffer@~5.2.1:
   version "5.2.1"
@@ -4277,7 +4285,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.1.4:
+ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
 
@@ -7169,9 +7177,10 @@ util@0.10.3:
   dependencies:
     inherits "2.0.1"
 
-util@~0.12.0:
+util@^0.12.4, util@~0.12.0:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
+  integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
   dependencies:
     inherits "^2.0.3"
     is-arguments "^1.0.4"


### PR DESCRIPTION
### _Summary_
Added fallback for buffer and util node libraries for breaking dapps that are bundled with Webpack 5 build tools

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
Locally built with CRA dapp
