### PR TITLE
Restricts handshake request to not include Sign/Send Tx methods

### DIFF
--- a/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/src/main/java/com/coinbase/android/nativesdk/CoinbaseWalletSDK.kt
+++ b/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/src/main/java/com/coinbase/android/nativesdk/CoinbaseWalletSDK.kt
@@ -8,6 +8,7 @@ import com.coinbase.android.nativesdk.message.MessageConverter
 import com.coinbase.android.nativesdk.message.request.Action
 import com.coinbase.android.nativesdk.message.request.RequestContent
 import com.coinbase.android.nativesdk.message.request.RequestMessage
+import com.coinbase.android.nativesdk.message.request.nonHandshakeActions
 import com.coinbase.android.nativesdk.message.response.FailureResponseCallback
 import com.coinbase.android.nativesdk.message.response.ResponseHandler
 import com.coinbase.android.nativesdk.message.response.SuccessResponseCallback
@@ -64,6 +65,13 @@ class CoinbaseWalletSDK(
         onResponse: ResponseHandler
     ) {
         resetSession()
+
+        val hasIllegalAction = initialActions?.any { nonHandshakeActions.contains(it.method) } == true
+        if (hasIllegalAction) {
+            onResponse(Result.failure(CoinbaseWalletSDKError.InvalidHandshakeRequest))
+            return
+        }
+
         val message = RequestMessage(
             uuid = UUID.randomUUID().toString(),
             version = sdkVersion,
@@ -185,5 +193,4 @@ class CoinbaseWalletSDK(
     private fun isWalletSegueResponseURL(uri: Uri): Boolean {
         return uri.host == domain.host && uri.path == domain.path && uri.getQueryParameter("p") != null
     }
-
 }

--- a/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/src/main/java/com/coinbase/android/nativesdk/CoinbaseWalletSDKError.kt
+++ b/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/src/main/java/com/coinbase/android/nativesdk/CoinbaseWalletSDKError.kt
@@ -5,5 +5,6 @@ sealed class CoinbaseWalletSDKError(errorMessage: String? = null) : Exception(er
     object DecodingFailed : CoinbaseWalletSDKError("Decoding failed")
     object MissingSharedSecret : CoinbaseWalletSDKError("Missing shared secret")
     object OpenWalletFailed : CoinbaseWalletSDKError("Could not open wallet")
+    object InvalidHandshakeRequest : CoinbaseWalletSDKError("Could not process this request in handshake")
     class WalletReturnedError(error: String) : CoinbaseWalletSDKError(error)
 }

--- a/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/src/main/java/com/coinbase/android/nativesdk/message/request/Web3JsonRPC.kt
+++ b/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/src/main/java/com/coinbase/android/nativesdk/message/request/Web3JsonRPC.kt
@@ -17,6 +17,8 @@ const val WEB3_JSON_RPC_WALLET_SWITCH_ETHEREUM_CHAIN = "wallet_switchEthereumCha
 const val WEB3_JSON_RPC_WALLET_ADD_ETHEREUM_CHAIN = "wallet_addEthereumChain"
 const val WEB3_JSON_RPC_WALLET_WATCH_ASSET = "wallet_watchAsset"
 
+val nonHandshakeActions = listOf(WEB3_JSON_RPC_ETH_SEND_TRANSACTION, WEB3_JSON_RPC_ETH_SIGN_TRANSACTION)
+
 @Suppress("unused")
 @Serializable
 sealed class Web3JsonRPC {

--- a/packages/wallet-native-sdk/ios/CoinbaseWalletSDK/Error.swift
+++ b/packages/wallet-native-sdk/ios/CoinbaseWalletSDK/Error.swift
@@ -13,6 +13,7 @@ extension CoinbaseWalletSDK {
         case encodingFailed
         case decodingFailed
         case missingSymmetricKey
+        case invalidHandshakeRequest
         case openUrlFailed
         case walletReturnedError(String)
     }

--- a/packages/wallet-native-sdk/ios/CoinbaseWalletSDK/Message/Message.swift
+++ b/packages/wallet-native-sdk/ios/CoinbaseWalletSDK/Message/Message.swift
@@ -30,7 +30,7 @@ public struct BaseMessage<C: BaseContent>: Codable {
     public let content: C
     public let version: String
     public let timestamp: Date
-    public let callbackUrl: String
+    public let callbackUrl: String?
 
     static func copy<T>(_ orig: BaseMessage<T>, replaceContentWith content: C) -> BaseMessage<C> {
         return BaseMessage<C>.init(

--- a/packages/wallet-native-sdk/ios/CoinbaseWalletSDK/Message/Request/Web3JSONRPC.swift
+++ b/packages/wallet-native-sdk/ios/CoinbaseWalletSDK/Message/Request/Web3JSONRPC.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public typealias BigInt = String
 
+public let unsupportedHandShakeMethod: [String] = ["eth_signTransaction", "eth_sendTransaction"]
+
 public enum Web3JSONRPC: Codable {
     case eth_requestAccounts
     


### PR DESCRIPTION
### _Summary_
Restricts handshake request to not include Sign/Send Tx methods

Handshake request should not be able to sign or send tx.  These actions only available post handshake.

  What changed? Link to relevant issues.

### _How did you test your changes?_
manually 

<!--
  Verify changes. Include relevant screenshots/videos
-->
