### PR TITLE
Add support for Wallet SDK running in iframe in CB Dapp browser

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line max-classes-per-file
 import { waitFor } from "@testing-library/preact";
 
 import {
@@ -181,6 +182,36 @@ describe("CoinbaseWalletSDK", () => {
           .mockImplementation(() => "setAppInfo");
         coinbaseWalletSDK2.setAppInfo("cipher", "http://cipher-image.png");
         expect(relaySetAppInfoMock).not.toBeCalled();
+      });
+    });
+
+    describe("coinbase browser iframe", () => {
+      class MockCoinbaseBrowserProvider extends MockProviderClass {
+        public isCoinbaseBrowser = true;
+
+        constructor(opts: Readonly<CoinbaseWalletProviderOptions>) {
+          super(opts);
+        }
+      }
+
+      const mockCoinbaseBrowserProvider = new MockCoinbaseBrowserProvider({
+        jsonRpcUrl: "url",
+        overrideIsMetaMask: false,
+        relayEventManager: new WalletSDKRelayEventManager(),
+        relayProvider: jest.fn(),
+        storage: new ScopedLocalStorage("-walletlink"),
+      });
+
+      beforeAll(() => {
+        window.ethereum = undefined;
+        window.top = window;
+        window.ethereum = mockCoinbaseBrowserProvider;
+      });
+
+      test("@makeWeb3Provider", () => {
+        expect(coinbaseWalletSDK2.makeWeb3Provider()).toEqual(
+          mockCoinbaseBrowserProvider,
+        );
       });
     });
   });

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
@@ -204,8 +204,7 @@ describe("CoinbaseWalletSDK", () => {
 
       beforeAll(() => {
         window.ethereum = undefined;
-        window.top = window;
-        window.ethereum = mockCoinbaseBrowserProvider;
+        window.top!.ethereum = mockCoinbaseBrowserProvider;
       });
 
       test("@makeWeb3Provider", () => {

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -235,15 +235,19 @@ export class CoinbaseWalletSDK {
   }
 
   private get coinbaseBrowser(): CoinbaseWalletProvider | undefined {
-    // Coinbase DApp browser does not inject into iframes so grab provider from top frame if it exists
-    const ethereum = (window.ethereum ?? window.top?.ethereum) as any;
-    if (!ethereum) {
-      return undefined;
-    }
+    try {
+      // Coinbase DApp browser does not inject into iframes so grab provider from top frame if it exists
+      const ethereum = (window.ethereum ?? window.top?.ethereum) as any;
+      if (!ethereum) {
+        return undefined;
+      }
 
-    if ("isCoinbaseBrowser" in ethereum && ethereum.isCoinbaseBrowser) {
-      return ethereum;
-    } else {
+      if ("isCoinbaseBrowser" in ethereum && ethereum.isCoinbaseBrowser) {
+        return ethereum;
+      } else {
+        return undefined;
+      }
+    } catch (e) {
       return undefined;
     }
   }

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -105,7 +105,7 @@ export class CoinbaseWalletSDK {
 
     this._storage.setItem("version", CoinbaseWalletSDK.VERSION);
 
-    if (this.walletExtension) {
+    if (this.walletExtension || this.coinbaseBrowser) {
       return;
     }
 
@@ -150,6 +150,11 @@ export class CoinbaseWalletSDK {
         extension.disableReloadOnDisconnect();
 
       return extension;
+    }
+
+    const dappBrowser = this.coinbaseBrowser;
+    if (dappBrowser) {
+      return dappBrowser;
     }
 
     const relay = this._relay;
@@ -227,6 +232,20 @@ export class CoinbaseWalletSDK {
 
   private get walletExtension(): CoinbaseWalletProvider | undefined {
     return window.coinbaseWalletExtension ?? window.walletLinkExtension;
+  }
+
+  private get coinbaseBrowser(): CoinbaseWalletProvider | undefined {
+    // Coinbase DApp browser does not inject into iframes so grab provider from top frame if it exists
+    const ethereum = (window.ethereum ?? window.top?.ethereum) as any;
+    if (!ethereum) {
+      return undefined;
+    }
+
+    if ("isCoinbaseBrowser" in ethereum && ethereum.isCoinbaseBrowser) {
+      return ethereum;
+    } else {
+      return undefined;
+    }
   }
 
   private isCipherProvider(provider: CoinbaseWalletProvider): boolean {

--- a/packages/wallet-sdk/src/relay/WalletSDKRelay.ts
+++ b/packages/wallet-sdk/src/relay/WalletSDKRelay.ts
@@ -28,6 +28,7 @@ import {
   bigIntStringFromBN,
   createQrUrl,
   hexStringFromBuffer,
+  isInIFrame,
   randomBytesHex,
 } from "../util";
 import * as aes256gcm from "./aes256gcm";
@@ -850,8 +851,19 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
             userAgent,
           )
         ) {
-          window.location.href = `https://go.cb-w.com/xoXnYwQimhb?cb_url=${encodeURIComponent(
-            window.location.href,
+          let location: Location;
+          try {
+            if (isInIFrame() && window.top) {
+              location = window.top.location;
+            } else {
+              location = window.location;
+            }
+          } catch (e) {
+            location = window.location;
+          }
+
+          location.href = `https://go.cb-w.com/xoXnYwQimhb?cb_url=${encodeURIComponent(
+            location.href,
           )}`;
           return;
         }

--- a/packages/wallet-sdk/src/util.ts
+++ b/packages/wallet-sdk/src/util.ts
@@ -242,3 +242,11 @@ export function createQrUrl(
 
   return qrUrl;
 }
+
+export function isInIFrame(): boolean {
+  try {
+    return window.frameElement !== null;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
### _Summary_
* Coinbase DApp browser does not inject into iframes so grab CB browser's provider from top frame if it exists
* Support redirecting to CB Wallet's dapp browser when SDK is running in iframe 

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
