### PR TITLE
Configure publishing for Android AAR via Maven

### DIFF
--- a/examples/native-sdk-android-client/build.gradle
+++ b/examples/native-sdk-android-client/build.gradle
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '7.2.1' apply false
-    id 'com.android.library' version '7.2.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
 }
 

--- a/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/build.gradle
+++ b/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/build.gradle
@@ -66,7 +66,7 @@ afterEvaluate {
 
                 pom {
                     name = 'coinbase-wallet-sdk'
-                    description = 'Coinbase NativeWallet SDK'
+                    description = 'Coinbase Native Wallet SDK'
                     url = 'https://github.com/coinbase/coinbase-wallet-sdk'
                     licenses {
                         license {
@@ -88,7 +88,7 @@ afterEvaluate {
                         developer {
                             id = 'vishnumad'
                             name = 'Vishnu Mad'
-                            email = ''
+                            email = 'vishnu.madhusoodanan@coinbase.com'
                         }
                     }
                     scm {

--- a/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/build.gradle
+++ b/packages/wallet-native-sdk/android/CoinbaseWalletNativeSDK/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.21'
+    id 'maven-publish'
+    id 'signing'
 }
 
 android {
@@ -34,6 +36,13 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {
@@ -44,4 +53,59 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3"
     implementation 'androidx.security:security-crypto:1.0.0'
     implementation 'com.google.crypto.tink:tink-android:1.6.1'
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                groupId 'com.coinbase'
+                artifactId 'coinbase-wallet-sdk'
+                version = android.defaultConfig.versionName
+
+                pom {
+                    name = 'coinbase-wallet-sdk'
+                    description = 'Coinbase NativeWallet SDK'
+                    url = 'https://github.com/coinbase/coinbase-wallet-sdk'
+                    licenses {
+                        license {
+                            name = 'Coinbase License'
+                            url = 'https://github.com/coinbase/coinbase-wallet-sdk/blob/master/LICENSE'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'amitgoelny'
+                            name = 'Amit Goel'
+                            email = 'amit.nyc@gmail.com'
+                        }
+                        developer {
+                            id = 'bangtoven'
+                            name = 'Jungho Bang'
+                            email = 'me@bangtoven.com'
+                        }
+                        developer {
+                            id = 'vishnumad'
+                            name = 'Vishnu Mad'
+                            email = ''
+                        }
+                    }
+                    scm {
+                        developerConnection = 'scm:git@github.com:coinbase/coinbase-wallet-sdk.git'
+                        url = 'https://github.com/coinbase/coinbase-wallet-sdk/tree/main'
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    useInMemoryPgpKeys(
+        rootProject.ext["signing.keyId"],
+        rootProject.ext["signing.key"],
+        rootProject.ext["signing.password"],
+    )
+    sign publishing.publications
 }

--- a/packages/wallet-native-sdk/android/build.gradle
+++ b/packages/wallet-native-sdk/android/build.gradle
@@ -1,9 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '4.2.2' apply false
-    id 'com.android.library' version '4.2.2' apply false
+    id 'com.android.library' version '7.2.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'io.github.gradle-nexus.publish-plugin'  version '1.1.0'
 }
+
+apply from: "${rootDir}/scripts/publish-root.gradle"
 
 task clean(type: Delete) {
     delete rootProject.buildDir

--- a/packages/wallet-native-sdk/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/wallet-native-sdk/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 29 11:34:58 CDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/wallet-native-sdk/android/scripts/publish-root.gradle
+++ b/packages/wallet-native-sdk/android/scripts/publish-root.gradle
@@ -1,0 +1,45 @@
+// Create variables with empty default values
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.key"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+ext["snapshot"] = false
+
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    // Read local.properties file first if it exists
+    Properties p = new Properties()
+    new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
+    p.each { name, value -> ext[name] = value }
+} else {
+    // Use system environment variables
+    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.key"] = System.getenv('SIGNING_KEY')
+    ext["snapshot"] = System.getenv('SNAPSHOT')
+}
+def versionName = "0.1.0"
+def snapshotVersionName = "0.1.1-SNAPSHOT"
+
+if (snapshot) {
+    ext["rootVersionName"] = snapshotVersionName
+} else {
+    ext["rootVersionName"] = versionName
+}
+
+// Set up Sonatype repository
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+            version = versionName
+        }
+    }
+}


### PR DESCRIPTION
### _Summary_
Configure publishing for Android AAR via Maven.  

* Updates gradle wrapper to 7.3
* Allows Native Android SDK to be distributed via MavenCentral

### _How did you test your changes?_
manually 

<!--
  Verify changes. Include relevant screenshots/videos
-->
