### PR TITLE
Handle addressChanged Event

### DIFF
--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.test.ts
@@ -1,3 +1,5 @@
+import { fireEvent } from "@testing-library/preact";
+
 import { MockRelayClass } from "../__mocks__/relay";
 import {
   MOCK_ADDERESS,
@@ -231,6 +233,34 @@ describe("CoinbaseWalletProvider", () => {
 
     const result = await provider.genericRequest(data, action);
     expect(result).toBe("Success");
+  });
+
+  it("updates the providers address on a postMessage's 'addressChanged' event", () => {
+    const provider = setupCoinbaseWalletProvider();
+
+    // @ts-expect-error _addresses is private
+    expect(provider._addresses).not.toEqual([
+      "0x0000000000000000000000000000000000001010",
+    ]);
+
+    fireEvent(
+      window,
+      new MessageEvent("message", {
+        data: {
+          data: {
+            action: "addressChanged",
+            address: "0x0000000000000000000000000000000000001010",
+          },
+          type: "walletLinkMessage",
+        },
+        origin: "dapp.finance",
+      }),
+    );
+
+    // @ts-expect-error _addresses is private
+    expect(provider._addresses).toEqual([
+      "0x0000000000000000000000000000000000001010",
+    ]);
   });
 
   it("handles error responses with generic requests", async () => {

--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
@@ -187,6 +187,10 @@ export class CoinbaseWalletProvider
         const jsonRpcUrl = event.data.data.jsonRpcUrl ?? this.jsonRpcUrl;
         this.updateProviderInfo(jsonRpcUrl, Number(_chainId), true);
       }
+      
+      if (event.data.data.action === "addressChanged") {
+        this._setAddresses([event.data.data.address]);
+      }
     });
   }
 

--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
@@ -187,7 +187,7 @@ export class CoinbaseWalletProvider
         const jsonRpcUrl = event.data.data.jsonRpcUrl ?? this.jsonRpcUrl;
         this.updateProviderInfo(jsonRpcUrl, Number(_chainId), true);
       }
-      
+
       if (event.data.data.action === "addressChanged") {
         this._setAddresses([event.data.data.address]);
       }


### PR DESCRIPTION
### _Summary_

Added handling for a WalletLinkMessage of type "addressChanged" which calls _setAddresses() with the provided address. This allows a consumer of the provider to change addresses on a dapp without the dapp needing to first request the address.

### _How did you test your changes?_

Manually tested and confirmed:

- Behavior related to initial connection to a dapp remains unchanged.
- Upon receiving the new "addressChanged" event, _setAddresses is called and the address is updated in the provider
- If the dapp supports the "accountsChanged" event, the address will immediately update on the dapp. If not, the page will need to be refreshed before the new address is visible.
