### PR TITLE
Update SolanaProvider for simpler cipher message passing

### DIFF
--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -32,7 +32,7 @@
     "build-npm": "tsc -p ./tsconfig.build.json",
     "build:dev": "export LINK_API_URL='http://localhost:3000'; yarn build",
     "build:dev:watch": "nodemon -e 'ts,tsx,js,json,css,scss,svg' --ignore 'src/**/*-css.ts' --ignore 'src/**/*-svg.ts' --watch src/ --exec 'yarn build:dev'",
-    "build:prod": "yarn prebuild && yarn build && yarn build-npm && cp ./package.json ./README.md ./LICENSE build/npm && cp -a src/vendor-js build/npm/dist && sed -i.bak 's|  \"private\": true,||g' build/npm/package.json && rm -f build/npm/package.json.bak",
+    "build:prod": "yarn prebuild && yarn build && yarn build-npm && cp ./package.json ../../README.md ./LICENSE build/npm && cp -a src/vendor-js build/npm/dist && sed -i.bak 's|  \"private\": true,||g' build/npm/package.json && rm -f build/npm/package.json.bak",
     "lint:types": "tsc --noEmit",
     "lint:prettier": "prettier --check \"{src,__tests__}/**/*.(js|ts|tsx)\"",
     "lint:eslint": "eslint ./src --ext .ts,.tsx",

--- a/packages/wallet-sdk/src/provider/SolanaProvider.test.ts
+++ b/packages/wallet-sdk/src/provider/SolanaProvider.test.ts
@@ -142,11 +142,15 @@ describe("Solana Provider", () => {
       postMessage: mockedCipherBridge,
     };
 
-    requestMessage.type = "browserRequest";
-    requestMessage.data.action = SolanaWeb3Method.connect;
-    requestMessage.data.request = {
-      method: SolanaWeb3Method.connect,
+    const cipherRequestMessage = {
+      id: eventId,
+      type: "browserRequest",
+      request: {
+        method: SolanaWeb3Method.connect,
+      },
+      provider: SOLANA_PROVIDER_ID,
     };
+
     responseMessage.data.type = "WEB3_RESPONSE";
     responseMessage.data.data.action = SolanaWeb3Response.connectionSuccess;
     responseMessage.data.data.addresses = [mockAddress];
@@ -163,7 +167,7 @@ describe("Solana Provider", () => {
       mockedCipherBridge.mock.calls[0][0],
     );
 
-    expect(cipherBridgeCallArgs).toEqual(requestMessage);
+    expect(cipherBridgeCallArgs).toEqual(cipherRequestMessage);
     expect(mockedCipherBridge).toHaveBeenCalled();
   });
 
@@ -193,7 +197,7 @@ describe("Solana Provider", () => {
       };
 
       responseMessage.data.data.action = SolanaWeb3Response.signMessageSuccess;
-      responseMessage.data.data.response = { signature: signedMessageResponse };
+      responseMessage.data.data.signature = signedMessageResponse;
 
       const signMessagePromise = solanaProvider.signMessage(message);
 
@@ -220,9 +224,7 @@ describe("Solana Provider", () => {
       };
 
       responseMessage.data.data.action = SolanaWeb3Response.signMessageSuccess;
-      responseMessage.data.data.response = {
-        signature: invalidSignedMessageResponse,
-      };
+      responseMessage.data.data.signature = invalidSignedMessageResponse;
 
       const signMessagePromise = solanaProvider.signMessage(message);
 

--- a/packages/wallet-sdk/src/provider/SolanaProvider.ts
+++ b/packages/wallet-sdk/src/provider/SolanaProvider.ts
@@ -6,7 +6,6 @@ import { PublicKey, SendOptions, Transaction } from "@solana/web3.js";
 
 import { ScopedLocalStorage } from "../lib/ScopedLocalStorage";
 import { SolanaWeb3Method } from "../relay/solana/SolanaWeb3Method";
-import { SolanaSignMessageRequest } from "../relay/solana/SolanaWeb3Request";
 import { SolanaWeb3Response } from "../relay/solana/SolanaWeb3Response";
 import { randomBytesHex } from "../util";
 import { RequestArguments } from "./Web3Provider";

--- a/packages/wallet-sdk/src/provider/SolanaProvider.ts
+++ b/packages/wallet-sdk/src/provider/SolanaProvider.ts
@@ -251,7 +251,7 @@ export class SolanaProvider
             message,
             address: this.publicKey!.toString(),
           },
-        } as SolanaSignMessageRequest,
+        },
         (signatureArray: any, error: any) => {
           if (!error) {
             const signature = new Uint8Array(signatureArray);


### PR DESCRIPTION
### _Summary_
This simplifies the Solana request being sent over the cipher bridge while leaving the extension request shape alone.

I also updated the `build:prod` script in `wallet-sdk` to include the README.md file from the outer package, as #639 broke it. 

### _How did you test your changes?_
- Manually
- Unit tests