### PR TITLE
FIx Version in URL for qrcode

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -13,7 +13,8 @@ import { WalletSDKRelayEventManager } from "./relay/WalletSDKRelayEventManager";
 import { getFavicon } from "./util";
 
 const LINK_API_URL = process.env.LINK_API_URL || "https://www.walletlink.org";
-const SDK_VERSION = require("../package.json").version || "unknown";
+const SDK_VERSION =
+  process.env.SDK_VERSION! || require("../package.json").version || "unknown";
 
 /** Coinbase Wallet SDK Constructor Options */
 export interface CoinbaseWalletSDKOptions {

--- a/packages/wallet-sdk/src/components/TryExtensionLinkDialog.tsx
+++ b/packages/wallet-sdk/src/components/TryExtensionLinkDialog.tsx
@@ -173,6 +173,7 @@ const ScanQRBox: FunctionComponent<{
     props.sessionSecret,
     props.linkAPIUrl,
     props.isParentConnection,
+    props.version,
     props.chainId,
   );
 

--- a/packages/wallet-sdk/src/relay/WalletSDKRelay.ts
+++ b/packages/wallet-sdk/src/relay/WalletSDKRelay.ts
@@ -599,6 +599,7 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
       this._session.secret,
       this.linkAPIUrl,
       false,
+      this.options.version,
       this.dappDefaultChain,
     );
   }

--- a/packages/wallet-sdk/src/util.test.ts
+++ b/packages/wallet-sdk/src/util.test.ts
@@ -223,6 +223,7 @@ describe("util", () => {
         "b9a1d5933eae7064fc6e1a673235f648",
         "https://www.walletlink.org",
         false,
+        "1",
         1,
       ),
     ).toEqual(
@@ -234,6 +235,7 @@ describe("util", () => {
         "b9a1d5933eae7064fc6e1a673235f648",
         "https://www.walletlink.org",
         true,
+        "1",
         1,
       ),
     ).toEqual(

--- a/packages/wallet-sdk/src/util.ts
+++ b/packages/wallet-sdk/src/util.ts
@@ -228,6 +228,7 @@ export function createQrUrl(
   sessionSecret: string,
   serverUrl: string,
   isParentConnection: boolean,
+  version: string,
   chainId: number,
 ): string {
   const sessionIdKey = isParentConnection ? "parent-id" : "id";
@@ -236,7 +237,7 @@ export function createQrUrl(
     [sessionIdKey]: sessionId,
     secret: sessionSecret,
     server: serverUrl,
-    v: "1",
+    v: version,
     chainId,
   });
 


### PR DESCRIPTION
### _Summary_

Qrcode when extension is not installed had "1" as version number always. This PR will fix the url with the correct version number.

### _How did you test your changes?_

Manually

OLD URL: `https://www.walletlink.org/#/link?id=380e3ad1a9026379298001e8a00a86a2&secret=563db92b5[…]71bcd&server=https%3A%2F%2Fwww.walletlink.org&v=1&chainId=1`

NEW URL: `https://www.walletlink.org/#/link?id=380e3ad1a9026379298001e8a00a86a2&secret=563db92b5[…]71bcd&server=https%3A%2F%2Fwww.walletlink.org&v=3.5.1&chainId=1`
