### PR TITLE
[bug-fix] bring back network overriding for in-app broswer

### DIFF
--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
@@ -257,11 +257,11 @@ export class CoinbaseWalletProvider
 
   /**
    * this function is called when coinbase provider is being injected to a dapp
-   * standalone + walletlinked extension, in-app browser using cipher-web-view
+   * standalone + walletlinked extension, ledger, in-app browser using cipher-web-view
    */
   public setProviderInfo(jsonRpcUrl: string, chainId: number) {
-    // extension tend to use the chianId from the dapp, while in-app browser overrides the default network
-    if (!this.isCoinbaseBrowser) {
+    // extension tend to use the chianId from the dapp, while in-app browser and ledger overrides the default network
+    if (!(this.isLedger || this.isCoinbaseBrowser)) {
       this._chainIdFromOpts = chainId;
       this._jsonRpcUrlFromOpts = jsonRpcUrl;
     }

--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
@@ -255,10 +255,18 @@ export class CoinbaseWalletProvider
     this.reloadOnDisconnect = false;
   }
 
+  /**
+   * this function is called when coinbase provider is being injected to a dapp
+   * standalone + walletlinked extension, in-app browser using cipher-web-view
+   */
   public setProviderInfo(jsonRpcUrl: string, chainId: number) {
-    this._chainIdFromOpts = chainId;
-    this._jsonRpcUrlFromOpts = jsonRpcUrl;
-    this.updateProviderInfo(jsonRpcUrl, chainId);
+    // extension tend to use the chianId from the dapp, while in-app browser overrides the default network
+    if (!this.isCoinbaseBrowser) {
+      this._chainIdFromOpts = chainId;
+      this._jsonRpcUrlFromOpts = jsonRpcUrl;
+    }
+
+    this.updateProviderInfo(this._jsonRpcUrlFromOpts, this._chainIdFromOpts);
   }
 
   private updateProviderInfo(jsonRpcUrl: string, chainId: number) {
@@ -973,7 +981,7 @@ export class CoinbaseWalletProvider
     }
 
     this._setAddresses(res.result);
-    if (!this.isLedger) {
+    if (!(this.isLedger || this.isCoinbaseBrowser)) {
       await this.switchEthereumChain(this.getChainId());
     }
 


### PR DESCRIPTION
### _Summary_

- In-app browser in Coinbase Wallet has its own logic for network switching, and it should always override the network to user chosen network when making web3 provider.
- thus, we dont need to switch network back to dapp's default after connecting.

### _How did you test your changes?_
manually tested
