### PR TITLE
WALL-12550: Validate origin for  for CoinbaseWalletProvider and Solan…

### DIFF
--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.test.ts
@@ -254,6 +254,7 @@ describe("CoinbaseWalletProvider", () => {
           type: "walletLinkMessage",
         },
         origin: "dapp.finance",
+        source: window,
       }),
     );
 
@@ -261,6 +262,32 @@ describe("CoinbaseWalletProvider", () => {
     expect(provider._addresses).toEqual([
       "0x0000000000000000000000000000000000001010",
     ]);
+  });
+
+  it("returns empty address on a postMessage's 'addressChanged' event when window is unspecified", () => {
+    const provider = setupCoinbaseWalletProvider();
+
+    // @ts-expect-error _addresses is private
+    expect(provider._addresses).not.toEqual([
+      "0x0000000000000000000000000000000000001010",
+    ]);
+
+    fireEvent(
+      window,
+      new MessageEvent("message", {
+        data: {
+          data: {
+            action: "addressChanged",
+            address: "0x0000000000000000000000000000000000001010",
+          },
+          type: "walletLinkMessage",
+        },
+        origin: "dapp.finance",
+      }),
+    );
+
+    // @ts-expect-error _addresses is private
+    expect(provider._addresses).toEqual([]);
   });
 
   it("handles error responses with generic requests", async () => {

--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
@@ -187,6 +187,11 @@ export class CoinbaseWalletProvider
     }
 
     window.addEventListener("message", event => {
+      // Used to verify the source and window are correct before proceeding
+      if (event.source !== window) {
+        return;
+      }
+
       if (event.data.type !== "walletLinkMessage") return; // compatibility with CBW extension
 
       if (

--- a/packages/wallet-sdk/src/provider/SolanaProvider.test.ts
+++ b/packages/wallet-sdk/src/provider/SolanaProvider.test.ts
@@ -100,7 +100,6 @@ describe("Solana Provider", () => {
     );
   });
 
-
   it("should resolve to error when connectionSuccess returns invalid address", async () => {
     jest.spyOn(solanaProvider, "disconnect");
 

--- a/packages/wallet-sdk/src/provider/SolanaProvider.test.ts
+++ b/packages/wallet-sdk/src/provider/SolanaProvider.test.ts
@@ -62,6 +62,7 @@ describe("Solana Provider", () => {
         type: "extensionUIResponse",
         data: { id: eventId },
       },
+      source: window,
     };
   });
 
@@ -98,6 +99,7 @@ describe("Solana Provider", () => {
       JSON.stringify([mockAddress]),
     );
   });
+
 
   it("should resolve to error when connectionSuccess returns invalid address", async () => {
     jest.spyOn(solanaProvider, "disconnect");

--- a/packages/wallet-sdk/src/provider/SolanaProvider.ts
+++ b/packages/wallet-sdk/src/provider/SolanaProvider.ts
@@ -68,6 +68,11 @@ export class SolanaProvider
   }
 
   public handleResponse = (event: any) => {
+    // Used to verify the source and window are correct before proceeding
+    if (event.source !== window) {
+      return;
+    }
+
     if (!["extensionUIResponse", "WEB3_RESPONSE"].includes(event.data.type)) {
       return;
     }


### PR DESCRIPTION
### _Summary_
Validate origin for  for CoinbaseWalletProvider and SolanaProvider

Adds conditional check for post message to ensure the request is coming from the expected window/origin 

<!--
  What changed? Link to relevant issues.
-->
https://jira.coinbase-corp.com/browse/WALL-12550

### _How did you test your changes?_

manually