### PR TITLE
Fixed the issue of wrong chainID and jsonRpcUrl for provider

### DIFF
--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
@@ -266,10 +266,12 @@ export class CoinbaseWalletProvider
    */
   public setProviderInfo(jsonRpcUrl: string, chainId: number) {
     // extension tend to use the chianId from the dapp, while in-app browser and ledger overrides the default network
-    if (!(this.isLedger || this.isCoinbaseBrowser)) {
-      this._chainIdFromOpts = chainId;
-      this._jsonRpcUrlFromOpts = jsonRpcUrl;
-    }
+    const isLedgerOrBrowser = this.isLedger || this.isCoinbaseBrowser;
+
+    this._jsonRpcUrlFromOpts = !isLedgerOrBrowser
+      ? jsonRpcUrl
+      : this.jsonRpcUrl;
+    this._chainIdFromOpts = !isLedgerOrBrowser ? chainId : this.getChainId();
 
     this.updateProviderInfo(this._jsonRpcUrlFromOpts, this._chainIdFromOpts);
   }


### PR DESCRIPTION
### _Summary_

Update from this [PR](https://github.com/coinbase/coinbase-wallet-sdk/pull/722)

This PR will few bugs that were noticed after the release of network switching project release.

Auto switch chain to previously used chain not working on Uniswap
Not able to connect wallet to Etherscan when it uses Goerli

### _How did you test your changes?_

Tested manually on multiple dapps including prettier test dapp
