### PR TITLE
Move event origin check into event listener callback

### DIFF
--- a/packages/wallet-sdk/src/provider/SolanaProvider.ts
+++ b/packages/wallet-sdk/src/provider/SolanaProvider.ts
@@ -64,15 +64,16 @@ export class SolanaProvider
     this._request = this._request.bind(this);
     this.isConnected = false;
     this.publicKey = null;
-    window.addEventListener("message", this.handleResponse);
+
+    window.addEventListener("message", event => {
+      // Used to verify the source and window are correct before proceeding
+      if (event.origin === location.origin && event.source === window) {
+        this.handleResponse(event);
+      }
+    });
   }
 
   public handleResponse = (event: any) => {
-    // Used to verify the source and window are correct before proceeding
-    if (event.origin !== location.origin || event.source !== window) {
-      return;
-    }
-
     if (!["extensionUIResponse", "WEB3_RESPONSE"].includes(event.data.type)) {
       return;
     }


### PR DESCRIPTION
### _Summary_
Moves the event origin check into the event listener callback. CB Wallet dapp browser calls the `handleResponse` function on the Solana provider directly without the `origin` and `source` fields.

### _How did you test your changes?_
Tested manually
