### PR TITLE
Passes reloadOnDisconnect to WalletSDKRelay.

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -118,6 +118,7 @@ export class CoinbaseWalletSDK {
       storage: this._storage,
       relayEventManager: this._relayEventManager,
       diagnosticLogger: this._diagnosticLogger,
+      reloadOnDisconnect: this._reloadOnDisconnect,
     });
     this.setAppInfo(options.appName, options.appLogoUrl);
 


### PR DESCRIPTION
### _Summary_

Was able to replicate #764 . To replicate we need to ensure that we go through the else branch below:  https://github.com/coinbase/coinbase-wallet-sdk/blob/51841bbda08a5951d55dd4ed96c83298af53705a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts#L206-L213

Since `this._reloadOnDisconnect` was not passed to `this._relay`, it will default to `true` and the code below will run on disconnect:
https://github.com/coinbase/coinbase-wallet-sdk/blob/51841bbda08a5951d55dd4ed96c83298af53705a/packages/wallet-sdk/src/relay/WalletSDKRelay.ts#L446-L449

[Code sandbox](https://codesandbox.io/s/stoic-hellman-kjxfe2?file=/src/App.js) shows the issue.

### _How did you test your changes?_
Not tested yet.
