### PR TITLE
Reset subscriptions object, it's not reusable

### DIFF
--- a/packages/wallet-sdk/src/relay/WalletSDKRelay.ts
+++ b/packages/wallet-sdk/src/relay/WalletSDKRelay.ts
@@ -452,6 +452,7 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
             this.accountsCallback([], true);
           }
 
+          this.subscriptions = new Subscription();
           const { session, ui, connection } = this.subscribe();
           this._session = session;
           this.connection = connection;


### PR DESCRIPTION

### _Summary_

Reset the `subscriptions` object in WalletSDKRelay - rxjs subscriptions class is not reusable.  This was manifesting as a dapp not being able to connect/send messages after reconnecting (for example beta.gem.xyz)


### _How did you test your changes?_
1. Connect coinbase wallet extension to mobile app
2. Go to beta.gem.xyz click Connect Wallet
3. Click cancel on the sign message prompt on mobile
4. Click connect wallet again
Before fix: Sign message prompt wouldn't appear on mobile
After fix: Sign message prompt appears on mobile.
