### PR TITLE
Add relaySource to walletlink event

### DIFF
--- a/packages/wallet-sdk/src/relay/WalletSDKRelay.ts
+++ b/packages/wallet-sdk/src/relay/WalletSDKRelay.ts
@@ -765,7 +765,13 @@ export class WalletSDKRelay extends WalletSDKRelayAbstract {
     return new Observable<string>(subscriber => {
       void aes256gcm
         .encrypt(
-          JSON.stringify({ ...message, origin: location.origin }),
+          JSON.stringify({
+            ...message,
+            origin: location.origin,
+            relaySource: !!window.coinbaseWalletExtension
+              ? "injected_sdk"
+              : "sdk",
+          }),
           secret,
         )
         .then((encrypted: string) => {


### PR DESCRIPTION
### _Summary_

This adds a `relaySource` property to wallet link request events. The new property is so that we can more easily distinguish in the client what the source of the request is – either a WalletLinked Extension or a direct Client -> Dapp connection.

We send 'injected_sdk' if the source is the SDK which the CBW Extension has injected or 'sdk' if it is a standard SDK installed on a dapp page.

### _How did you test your changes?_

I built the CBW SDK locally, installed it on the Extension and a test dapp, and verified it sent the correct value in the various configurations.
