### PR TITLE
ensure crypto api is referenced off of window object

### DIFF
--- a/packages/wallet-sdk/src/relay/aes256gcm.ts
+++ b/packages/wallet-sdk/src/relay/aes256gcm.ts
@@ -13,8 +13,8 @@ import { hexStringToUint8Array, uint8ArrayToHex } from '../util';
  */
 export async function encrypt(plainText: string, secret: string): Promise<string> {
   if (secret.length !== 64) throw Error(`secret must be 256 bits`);
-  const ivBytes = crypto.getRandomValues(new Uint8Array(12));
-  const secretKey: CryptoKey = await crypto.subtle.importKey(
+  const ivBytes = window.crypto.getRandomValues(new Uint8Array(12));
+  const secretKey: CryptoKey = await window.crypto.subtle.importKey(
     'raw',
     hexStringToUint8Array(secret),
     { name: 'aes-gcm' },
@@ -54,7 +54,7 @@ export function decrypt(cipherText: string, secret: string): Promise<string> {
   if (secret.length !== 64) throw Error(`secret must be 256 bits`);
   return new Promise<string>((resolve, reject) => {
     void (async function () {
-      const secretKey: CryptoKey = await crypto.subtle.importKey(
+      const secretKey: CryptoKey = await window.crypto.subtle.importKey(
         'raw',
         hexStringToUint8Array(secret),
         { name: 'aes-gcm' },

--- a/packages/wallet-sdk/src/util.ts
+++ b/packages/wallet-sdk/src/util.ts
@@ -13,7 +13,7 @@ const HEXADECIMAL_STRING_REGEX = /^[a-f0-9]*$/;
  * @param length number of bytes
  */
 export function randomBytesHex(length: number): string {
-  return uint8ArrayToHex(crypto.getRandomValues(new Uint8Array(length)));
+  return uint8ArrayToHex(window.crypto.getRandomValues(new Uint8Array(length)));
 }
 
 export function uint8ArrayToHex(value: Uint8Array) {


### PR DESCRIPTION
### _Summary_

ensure crypto object is referenced off of window object.

Removing the need for the Crypto polly fill was originally addressed here (https://github.com/coinbase/coinbase-wallet-sdk/pull/144)

### _How did you test your changes?_

manually
