### PR TITLE
[Bugfix] Read IsStandaloneSigning from Storage

### DIFF
--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
@@ -42,9 +42,10 @@ import {
 } from "./SubscriptionManager";
 import { RequestArguments, Web3Provider } from "./Web3Provider";
 
-const DEFAULT_CHAIN_ID_KEY = 'DefaultChainId';
-const DEFAULT_JSON_RPC_URL = 'DefaultJsonRpcUrl';
-const SUPPORT_ADDRESS_SWITCHING = 'IsStandaloneSigning';
+const DEFAULT_CHAIN_ID_KEY = "DefaultChainId";
+const DEFAULT_JSON_RPC_URL = "DefaultJsonRpcUrl";
+
+const SUPPORT_ADDRESS_SWITCHING = "IsStandaloneSigning";
 
 export interface CoinbaseWalletProviderOptions {
   chainId: number;
@@ -245,7 +246,7 @@ export class CoinbaseWalletProvider
   }
 
   private get supportsAddressSwitching(): boolean {
-    return this._storage.getItem(SUPPORT_ADDRESS_SWITCHING) === 'true';
+    return this._storage.getItem(SUPPORT_ADDRESS_SWITCHING) === "true";
   }
 
   private get jsonRpcUrl(): string {

--- a/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts
@@ -42,8 +42,9 @@ import {
 } from "./SubscriptionManager";
 import { RequestArguments, Web3Provider } from "./Web3Provider";
 
-const DEFAULT_CHAIN_ID_KEY = "DefaultChainId";
-const DEFAULT_JSON_RPC_URL = "DefaultJsonRpcUrl";
+const DEFAULT_CHAIN_ID_KEY = 'DefaultChainId';
+const DEFAULT_JSON_RPC_URL = 'DefaultJsonRpcUrl';
+const SUPPORT_ADDRESS_SWITCHING = 'IsStandaloneSigning';
 
 export interface CoinbaseWalletProviderOptions {
   chainId: number;
@@ -116,8 +117,6 @@ export class CoinbaseWalletProvider
 
   private hasMadeFirstChainChangedEmission = false;
 
-  private supportsAddressSwitching?: boolean;
-
   private isLedger?: boolean;
 
   constructor(options: Readonly<CoinbaseWalletProviderOptions>) {
@@ -150,7 +149,6 @@ export class CoinbaseWalletProvider
 
     this.qrUrl = options.qrUrl;
 
-    this.supportsAddressSwitching = options.supportsAddressSwitching;
     this.isLedger = options.isLedger;
 
     const chainId = this.getChainId();
@@ -244,6 +242,10 @@ export class CoinbaseWalletProvider
 
   public isConnected(): boolean {
     return true;
+  }
+
+  private get supportsAddressSwitching(): boolean {
+    return this._storage.getItem(SUPPORT_ADDRESS_SWITCHING) === 'true';
   }
 
   private get jsonRpcUrl(): string {


### PR DESCRIPTION
### _Summary_

CBW Extension used to read `IsStandaloneSigning` from storage and pass in this value to CoinbaseWalletProvider during its initialization. However, when user first open a dapp and before they connect wallet, there would be no `IsStandaloneSigning` saved in storage, and it caused issue for when user switches address. Changing it to read this value from storage directly when user switches address.

### _How did you test your changes?_
Manually tested on 
1. Standalone Extension: Dapp address switches as user switch address from extension
2. Walletlinked Extension: Dapp address does not switch as user switch address from RN
3. RN browser: Does not utilize this variable
4. RN Walletlink: Does not utilize this variable
