### PR TITLE
chore: add `sideEffects: false` to package.json

### DIFF
--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -19,6 +19,7 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "repository": "https://github.com/coinbase/coinbase-wallet-sdk.git",
   "author": "Coinbase, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adds `"sideEffects": false` to package.json for maximum tree-shakability.

Without `"sideEffects"` switched off build systems aren't able to properly eliminate dead code (e.g. Next.js) and could still load the Coinbase Wallet SDK JS even if it's not used.

More info: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free