### PR TITLE
Check unseen events after navigating back to browser

### DIFF
--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/wallet-sdk",
-  "version": "3.8.0-beta.1",
+  "version": "3.8.0-beta.2",
   "description": "Coinbase Wallet JavaScript SDK",
   "keywords": [
     "cipher",

--- a/packages/wallet-sdk/src/connection/RxWebSocket.test.ts
+++ b/packages/wallet-sdk/src/connection/RxWebSocket.test.ts
@@ -108,12 +108,6 @@ describe("RxWebSocket", () => {
   });
 
   describe("is not connected", () => {
-    test("sendData error", () => {
-      expect(() => rxWS.sendData("data")).toThrowError(
-        "websocket is not connected",
-      );
-    });
-
     test("disconnect returns", () => {
       const webSocketCloseMock = jest
         .spyOn(WebSocket.prototype, "close")

--- a/packages/wallet-sdk/src/connection/RxWebSocket.ts
+++ b/packages/wallet-sdk/src/connection/RxWebSocket.ts
@@ -27,6 +27,7 @@ export class RxWebSocket<T = object> {
     ConnectionState.DISCONNECTED,
   );
   private incomingDataSubject = new Subject<string>();
+  private pendingData: string[] = [];
 
   /**
    * Constructor
@@ -66,6 +67,12 @@ export class RxWebSocket<T = object> {
         obs.next();
         obs.complete();
         this.connectionStateSubject.next(ConnectionState.CONNECTED);
+
+        if (this.pendingData.length > 0) {
+          const pending = [...this.pendingData];
+          pending.forEach(data => this.sendData(data));
+          this.pendingData = [];
+        }
       };
       webSocket.onmessage = evt => {
         this.incomingDataSubject.next(evt.data as string);
@@ -129,7 +136,9 @@ export class RxWebSocket<T = object> {
   public sendData(data: string): void {
     const { webSocket } = this;
     if (!webSocket) {
-      throw new Error("websocket is not connected");
+      this.pendingData.push(data);
+      this.connect().subscribe();
+      return;
     }
     webSocket.send(data);
   }

--- a/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
+++ b/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
@@ -211,16 +211,20 @@ export class WalletLinkConnection {
 
     // mark unseen events as seen
     this.subscriptions.add(
-      this.unseenEventsSubject.subscribe(async e => {
+      this.unseenEventsSubject.subscribe(e => {
         const credentials = `${this.sessionId}:${this.sessionKey}`;
         const auth = `Basic ${btoa(credentials)}`;
 
-        await fetch(`${this.linkAPIUrl}/events/${e.eventId}/seen`, {
-          method: "POST",
-          headers: {
-            Authorization: auth,
-          },
-        });
+        try {
+          fetch(`${this.linkAPIUrl}/events/${e.eventId}/seen`, {
+            method: "POST",
+            headers: {
+              Authorization: auth,
+            },
+          });
+        } catch (e) {
+          console.error("Unabled to mark event as failed:", e);
+        }
       }),
     );
   }
@@ -328,7 +332,7 @@ export class WalletLinkConnection {
   public async checkUnseenEvents() {
     const credentials = `${this.sessionId}:${this.sessionKey}`;
     const auth = `Basic ${btoa(credentials)}`;
-    
+
     const response = await fetch(`${this.linkAPIUrl}/events?unseen=true`, {
       headers: {
         Authorization: auth,

--- a/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
+++ b/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
@@ -215,16 +215,12 @@ export class WalletLinkConnection {
         const credentials = `${this.sessionId}:${this.sessionKey}`;
         const auth = `Basic ${btoa(credentials)}`;
 
-        try {
-          fetch(`${this.linkAPIUrl}/events/${e.eventId}/seen`, {
-            method: "POST",
-            headers: {
-              Authorization: auth,
-            },
-          });
-        } catch (e) {
-          console.error("Unabled to mark event as failed:", e);
-        }
+        fetch(`${this.linkAPIUrl}/events/${e.eventId}/seen`, {
+          method: "POST",
+          headers: {
+            Authorization: auth,
+          },
+        }).catch(e => console.error("Unabled to mark event as failed:", e));
       }),
     );
   }

--- a/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
+++ b/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
@@ -220,7 +220,9 @@ export class WalletLinkConnection {
           headers: {
             Authorization: auth,
           },
-        }).catch(e => console.error("Unabled to mark event as failed:", e));
+        }).catch(error =>
+          console.error("Unabled to mark event as failed:", error),
+        );
       }),
     );
   }

--- a/packages/wallet-sdk/src/relay/MobileRelay.ts
+++ b/packages/wallet-sdk/src/relay/MobileRelay.ts
@@ -43,18 +43,48 @@ export class MobileRelay extends WalletLinkRelay {
     if (!(this._enableMobileWalletLink && this.ui instanceof MobileRelayUI))
       return;
 
+    let navigatedToCBW = false;
+
     // For mobile relay requests, open the Coinbase Wallet app
     switch (request.method) {
       case Web3Method.requestEthereumAccounts:
       case Web3Method.connectAndSignIn:
+        navigatedToCBW = true;
         this.ui.openCoinbaseWalletDeeplink(this.getQRCodeUrl());
         break;
       case Web3Method.switchEthereumChain:
         // switchEthereumChain doesn't need to open the app
         return;
       default:
+        navigatedToCBW = true;
         this.ui.openCoinbaseWalletDeeplink();
         break;
+    }
+
+    // If the user navigated to the Coinbase Wallet app, then we need to check
+    // for unseen events once the user returns to the browser
+    if (navigatedToCBW) {
+      window.addEventListener(
+        "blur",
+        () => {
+          window.addEventListener(
+            "focus",
+            async () => {
+              this.connection.onceConnected$.subscribe(async () => {
+                setTimeout(() => {
+                  try {
+                    this.connection.checkUnseenEvents();
+                  } catch (e) {
+                    console.error("Unable to check for unseen events", e);
+                  }
+                }, 250);
+              });
+            },
+            { once: true },
+          );
+        },
+        { once: true },
+      );
     }
   }
 

--- a/packages/wallet-sdk/src/relay/MobileRelay.ts
+++ b/packages/wallet-sdk/src/relay/MobileRelay.ts
@@ -70,13 +70,13 @@ export class MobileRelay extends WalletLinkRelay {
           window.addEventListener(
             "focus",
             () => {
-              this.connection.onceConnected$.subscribe(async () => {
+              this.connection.onceConnected$.subscribe(() => {
                 setTimeout(() => {
-                  try {
-                    this.connection.checkUnseenEvents();
-                  } catch (e) {
-                    console.error("Unable to check for unseen events", e);
-                  }
+                  this.connection
+                    .checkUnseenEvents()
+                    .catch(e =>
+                      console.error("Unable to check for unseen events", e),
+                    );
                 }, 250);
               });
             },

--- a/packages/wallet-sdk/src/relay/MobileRelay.ts
+++ b/packages/wallet-sdk/src/relay/MobileRelay.ts
@@ -69,7 +69,7 @@ export class MobileRelay extends WalletLinkRelay {
         () => {
           window.addEventListener(
             "focus",
-            async () => {
+            () => {
               this.connection.onceConnected$.subscribe(async () => {
                 setTimeout(() => {
                   try {

--- a/packages/wallet-sdk/src/relay/WalletLinkRelay.ts
+++ b/packages/wallet-sdk/src/relay/WalletLinkRelay.ts
@@ -102,7 +102,7 @@ export class WalletLinkRelay extends WalletSDKRelayAbstract {
   private _session: Session;
   private readonly relayEventManager: WalletSDKRelayEventManager;
   protected readonly diagnostic?: DiagnosticLogger;
-  private connection: WalletLinkConnection;
+  protected connection: WalletLinkConnection;
   private accountsCallback:
     | ((account: string[], isDisconnect?: boolean) => void)
     | null = null;

--- a/packages/wallet-sdk/src/version.ts
+++ b/packages/wallet-sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "3.8.0-beta.0";
+export const LIB_VERSION = "3.8.0-beta.2";


### PR DESCRIPTION
### _Summary_
For mobile connections on iOS, sometimes Safari will kill the websocket connection in the background causing us to miss events. 

This hacky fix checks the `/events` endpoint for unseen events and merges it into the incoming events observable. Also needed to add some logic to re-connect the RxWebsocket connection instead of throwing an error when `sendData` is called while the websocket is connected. From testing, this seems to work fairly reliably, but a more robust solution would be better in the long term.

### _How did you test your changes?_

