### PR TITLE
Update postmessage targetOrigin to window.origin

### DIFF
--- a/packages/wallet-sdk/src/provider/SolanaProvider.test.ts
+++ b/packages/wallet-sdk/src/provider/SolanaProvider.test.ts
@@ -84,7 +84,7 @@ describe('Solana Provider', () => {
     const connectionPromise = solanaProvider.connect();
 
     expect(window.postMessage).toHaveBeenCalledWith(firstConnectMessage, '*');
-    expect(window.postMessage).toHaveBeenCalledWith(requestMessage, '*');
+    expect(window.postMessage).toHaveBeenCalledWith(requestMessage, 'http://localhost');
     expect(scopedStorageCopy.getItem('Addresses')).toBe(null);
 
     solanaProvider.handleResponse(responseMessage);
@@ -197,7 +197,7 @@ describe('Solana Provider', () => {
 
       const signMessagePromise = solanaProvider.signMessage(message);
 
-      expect(window.postMessage).toHaveBeenCalledWith(requestMessage, '*');
+      expect(window.postMessage).toHaveBeenCalledWith(requestMessage, 'http://localhost');
 
       solanaProvider.handleResponse(responseMessage);
 
@@ -245,7 +245,7 @@ describe('Solana Provider', () => {
 
       solanaProvider.handleResponse(responseMessage);
 
-      expect(window.postMessage).toHaveBeenCalledWith(requestMessage, '*');
+      expect(window.postMessage).toHaveBeenCalledWith(requestMessage, 'http://localhost');
       expect(solanaProvider.getCallback(eventId)).toBeFalsy();
       return expect(signTransactionPromise).resolves.toBe(mockSolanaSignedTransaction);
     });
@@ -322,7 +322,7 @@ describe('Solana Provider', () => {
 
       solanaProvider.handleResponse(responseMessage);
 
-      expect(window.postMessage).toHaveBeenCalledWith(requestMessage, '*');
+      expect(window.postMessage).toHaveBeenCalledWith(requestMessage, 'http://localhost');
       expect(solanaProvider.getCallback(eventId)).toBeFalsy();
       return expect(signAllTransactionsPromise).resolves.toEqual(solSignedTransactions);
     });
@@ -435,7 +435,7 @@ describe('Solana Provider', () => {
 
       solanaProvider.handleResponse(responseMessage);
 
-      expect(window.postMessage).toHaveBeenCalledWith(requestMessage, '*');
+      expect(window.postMessage).toHaveBeenCalledWith(requestMessage, 'http://localhost');
       expect(solanaProvider.getCallback(eventId)).toBeFalsy();
       return expect(sendTransactionPromise).resolves.toEqual({
         signature: mockTxHash,

--- a/packages/wallet-sdk/src/provider/SolanaProvider.ts
+++ b/packages/wallet-sdk/src/provider/SolanaProvider.ts
@@ -366,7 +366,7 @@ export class SolanaProvider extends EventEmitter implements SolanaWeb3Provider {
           },
         },
       };
-      window.postMessage(message, '*');
+      window.postMessage(message, window.origin);
     }
   }
 }


### PR DESCRIPTION
### _Summary_

Security request to remove postMessage wildcard in favor of window.origin

### _How did you test your changes?_

Manually in cipher and react native
