### PR TITLE
Fix: clean up listeners on disconnection / diagnostic log only when it fails

### DIFF
--- a/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
+++ b/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
@@ -232,6 +232,11 @@ export class WalletLinkConnection {
       sessionIdHash: Session.hash(this.sessionId),
     });
     this.destroyed = true;
+
+    this.sessionConfigListener = undefined;
+    this.connectedListener = undefined;
+    this.linkedListener = undefined;
+    this.incomingEventListener = undefined;
   }
 
   public get isDestroyed(): boolean {

--- a/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
+++ b/packages/wallet-sdk/src/connection/WalletLinkConnection.ts
@@ -227,11 +227,12 @@ export class WalletLinkConnection {
    * instance of WalletSDKConnection
    */
   public destroy(): void {
+    this.destroyed = true;
+
     this.ws.disconnect();
     this.diagnostic?.log(EVENTS.DISCONNECTED, {
       sessionIdHash: Session.hash(this.sessionId),
     });
-    this.destroyed = true;
 
     this.sessionConfigListener = undefined;
     this.connectedListener = undefined;

--- a/packages/wallet-sdk/src/connection/WalletLinkWebSocket.ts
+++ b/packages/wallet-sdk/src/connection/WalletLinkWebSocket.ts
@@ -94,6 +94,7 @@ export class WalletLinkWebSocket {
       return;
     }
     this.clearWebSocket();
+
     this.connectionStateListener?.(ConnectionState.DISCONNECTED);
     this.connectionStateListener = undefined;
     this.incomingDataListener = undefined;

--- a/packages/wallet-sdk/src/connection/WalletLinkWebSocket.ts
+++ b/packages/wallet-sdk/src/connection/WalletLinkWebSocket.ts
@@ -95,6 +95,9 @@ export class WalletLinkWebSocket {
     }
     this.clearWebSocket();
     this.connectionStateListener?.(ConnectionState.DISCONNECTED);
+    this.connectionStateListener = undefined;
+    this.incomingDataListener = undefined;
+
     try {
       webSocket.close();
     } catch {


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
