### PR TITLE
fix redirecting on webviews

### DIFF
--- a/packages/wallet-sdk/src/relay/mobile/MobileRelay.ts
+++ b/packages/wallet-sdk/src/relay/mobile/MobileRelay.ts
@@ -76,10 +76,6 @@ export class MobileRelay extends WalletLinkRelay {
   // override
   handleWeb3ResponseMessage(message: WalletLinkResponseEventData) {
     super.handleWeb3ResponseMessage(message);
-
-    if (this._enableMobileWalletLink && this.ui instanceof MobileRelayUI) {
-      this.ui.closeOpenedWindow();
-    }
   }
 
   connectAndSignIn(params: {

--- a/packages/wallet-sdk/src/relay/mobile/MobileRelayUI.ts
+++ b/packages/wallet-sdk/src/relay/mobile/MobileRelayUI.ts
@@ -7,7 +7,6 @@ export class MobileRelayUI implements RelayUI {
   private readonly redirectDialog: RedirectDialog;
   private attached = false;
   private darkMode = false;
-  private openedWindow: Window | null = null;
 
   constructor(options: Readonly<RelayUIOptions>) {
     this.redirectDialog = new RedirectDialog();
@@ -24,10 +23,6 @@ export class MobileRelayUI implements RelayUI {
 
   setConnected(_connected: boolean) {} // no-op
 
-  closeOpenedWindow() {
-    this.openedWindow?.close();
-    this.openedWindow = null;
-  }
 
   private redirectToCoinbaseWallet(walletLinkUrl?: string): void {
     const url = new URL('https://go.cb-w.com/walletlink');
@@ -38,8 +33,6 @@ export class MobileRelayUI implements RelayUI {
     }
 
     window.location.href = url.href;
-
-    setTimeout(() => this.closeOpenedWindow(), 5000);
 
   }
 
@@ -65,13 +58,11 @@ export class MobileRelayUI implements RelayUI {
   }): () => void {
     // it uses the return callback to clear the dialog
     return () => {
-      this.closeOpenedWindow();
       this.redirectDialog.clear();
     };
   }
 
   hideRequestEthereumAccounts() {
-    this.closeOpenedWindow();
     this.redirectDialog.clear();
   }
 

--- a/packages/wallet-sdk/src/relay/mobile/MobileRelayUI.ts
+++ b/packages/wallet-sdk/src/relay/mobile/MobileRelayUI.ts
@@ -37,10 +37,10 @@ export class MobileRelayUI implements RelayUI {
       url.searchParams.append('wl_url', walletLinkUrl);
     }
 
-    this.openedWindow = window.open(url.href, 'cbw-opener');
-    if (this.openedWindow) {
-      setTimeout(() => this.closeOpenedWindow(), 5000);
-    }
+    window.location.href = url.href;
+
+    setTimeout(() => this.closeOpenedWindow(), 5000);
+
   }
 
   openCoinbaseWalletDeeplink(walletLinkUrl?: string): void {


### PR DESCRIPTION
### _Summary_
Navigating to CB Wallet app deeplink via window.open and not replacing window.href was causing a broken behavior when the SDK is running from inside a webview. This PR replaces the redirecting strategy in order to fix this bug

### _How did you test your changes?_
Manually tested using an RN test app that renders the test dapp from inside a webview

| Before | After |
| -- | -- |
| <video src="https://github.com/coinbase/coinbase-wallet-sdk/assets/26755665/fc52ee2e-72c7-42a5-8889-a9340fe2b418" /> | <video src="https://github.com/coinbase/coinbase-wallet-sdk/assets/26755665/48e08521-0419-41f8-8f37-48ca8294575a" /> | 
