### PR TITLE
Fix/deeplink from webview for android

### DIFF
--- a/packages/wallet-sdk/src/relay/mobile/MobileRelayUI.ts
+++ b/packages/wallet-sdk/src/relay/mobile/MobileRelayUI.ts
@@ -33,7 +33,7 @@ export class MobileRelayUI implements RelayUI {
     }
 
     const anchorTag = document.createElement('a');
-    anchorTag.target = '_blank';
+    anchorTag.target = 'cbw-opener';
     anchorTag.href = url.href;
     anchorTag.rel = 'noreferrer noopener';
     anchorTag.click();

--- a/packages/wallet-sdk/src/relay/mobile/MobileRelayUI.ts
+++ b/packages/wallet-sdk/src/relay/mobile/MobileRelayUI.ts
@@ -32,8 +32,11 @@ export class MobileRelayUI implements RelayUI {
       url.searchParams.append('wl_url', walletLinkUrl);
     }
 
-    window.location.href = url.href;
-
+    const anchorTag = document.createElement('a');
+    anchorTag.target = '_blank';
+    anchorTag.href = url.href;
+    anchorTag.rel = 'noreferrer noopener';
+    anchorTag.click();
   }
 
   openCoinbaseWalletDeeplink(walletLinkUrl?: string): void {


### PR DESCRIPTION
### _Summary_
The href replacing approach has fixed the deeplink issue for WebView on IOS, but caused a regression on Android. The anchor tag approach fixes it for both platforms

### _How did you test your changes?_
Manually tested
