### PR TITLE
Replace connectionPreference: enum with smartWalletOnly: boolean

### DIFF
--- a/apps/testapp/src/components/Layout.tsx
+++ b/apps/testapp/src/components/Layout.tsx
@@ -20,7 +20,7 @@ type LayoutProps = {
 export const WIDTH_2XL = '1536px';
 
 export function Layout({ children }: LayoutProps) {
-  const { provider, connectionPreference, setPreference } = useCBWSDK();
+  const { provider, smartWalletOnly, setPreference } = useCBWSDK();
 
   const handleDisconnect = () => {
     if (provider) {
@@ -37,17 +37,17 @@ export function Layout({ children }: LayoutProps) {
             <Flex justifyContent="space-between" alignItems="center" gap={4}>
               <Menu>
                 <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
-                  {`Mode: ${connectionPreference}`}
+                  {`smartWalletOnly: ${smartWalletOnly}`}
                 </MenuButton>
                 <MenuList>
-                  {['default', 'embedded'].map((preference) => (
+                  {[true, false].map((b) => (
                     <MenuItem
                       color={'MenuText'}
-                      key={preference}
-                      icon={preference === connectionPreference ? <CheckIcon /> : null}
-                      onClick={() => setPreference(preference)}
+                      key={b.toString()}
+                      icon={b === smartWalletOnly ? <CheckIcon /> : null}
+                      onClick={() => setPreference(b)}
                     >
-                      {preference}
+                      {b.toString()}
                     </MenuItem>
                   ))}
                 </MenuList>

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -9,7 +9,7 @@ describe('EIP1193Provider', () => {
       scwUrl: 'http://fooUrl.com',
       appName: 'TestApp',
       appChainIds: [],
-      connectionPreference: 'default',
+      smartWalletOnly: false,
     });
   });
 
@@ -30,7 +30,7 @@ describe('EIP1193Provider', () => {
         scwUrl: 'http://fooUrl.com',
         appName: 'TestApp',
         appChainIds: [8453, 84532],
-        connectionPreference: 'default',
+        smartWalletOnly: false,
       });
       expect(provider.chainId).toBe(8453);
     });
@@ -40,7 +40,7 @@ describe('EIP1193Provider', () => {
         scwUrl: 'http://fooUrl.com',
         appName: 'TestApp',
         appChainIds: [],
-        connectionPreference: 'default',
+        smartWalletOnly: false,
       });
       expect(provider.chainId).toBe(1);
     });

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -17,14 +17,13 @@ import { RPCFetchRequestHandler } from './rpcFetch/RPCFetchRequestHandler';
 import { SignRequestHandler } from './sign/SignRequestHandler';
 import { AccountsUpdate, ChainUpdate } from './sign/UpdateListenerInterface';
 import { SubscriptionRequestHandler } from './subscription/SubscriptionRequestHandler';
-import { ConnectionPreference } from ':core/communicator/ConnectionPreference';
 
 interface ConstructorOptions {
   scwUrl?: string;
   appName: string;
   appLogoUrl?: string | null;
   appChainIds: number[];
-  connectionPreference: ConnectionPreference;
+  smartWalletOnly: boolean;
 }
 
 export class CoinbaseWalletProvider extends EventEmitter implements ProviderInterface {

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
@@ -104,11 +104,11 @@ describe('CoinbaseWalletSDK', () => {
         expect(coinbaseWalletSDK2.makeWeb3Provider()).toEqual(mockProvider);
       });
 
-      test('@makeWeb3Provider, but with connectionPreference as embedded', () => {
+      test('@makeWeb3Provider, but with smartWalletOnly as true', () => {
         const sdk = new CoinbaseWalletSDK({
           appName: 'Test',
           appLogoUrl: 'http://coinbase.com/wallet-logo.png',
-          connectionPreference: 'embedded',
+          smartWalletOnly: true,
         });
         // Returns extension provider
         const provider = sdk.makeWeb3Provider();
@@ -144,11 +144,11 @@ describe('CoinbaseWalletSDK', () => {
         expect(coinbaseWalletSDK2.makeWeb3Provider()).toEqual(mockCipherProvider);
       });
 
-      test('@makeWeb3Provider, it should ignore embedded connectionPreference', () => {
+      test('@makeWeb3Provider, it should ignore smartWalletOnly true', () => {
         const sdk = new CoinbaseWalletSDK({
           appName: 'Test',
           appLogoUrl: 'http://coinbase.com/wallet-logo.png',
-          connectionPreference: 'embedded',
+          smartWalletOnly: true,
         });
         expect(sdk.makeWeb3Provider()).toEqual(mockCipherProvider);
       });

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -6,7 +6,6 @@ import { ScopedLocalStorage } from './core/storage/ScopedLocalStorage';
 import { ProviderInterface } from './core/type/ProviderInterface';
 import { getFavicon } from './core/util';
 import { LIB_VERSION } from './version';
-import { ConnectionPreference } from ':core/communicator/ConnectionPreference';
 
 /** Coinbase Wallet SDK Constructor Options */
 export interface CoinbaseWalletSDKOptions {
@@ -17,13 +16,13 @@ export interface CoinbaseWalletSDKOptions {
   /** @optional Array of chainIds your dapp supports */
   chainIds?: string[];
   /** @optional Pre-select the wallet connection method */
-  connectionPreference?: ConnectionPreference;
+  smartWalletOnly?: boolean;
 }
 
 export class CoinbaseWalletSDK {
   private appName: string;
   private appLogoUrl: string | null;
-  private connectionPreference: ConnectionPreference;
+  private smartWalletOnly: boolean;
   private chainIds: number[];
 
   /**
@@ -31,7 +30,7 @@ export class CoinbaseWalletSDK {
    * @param options Coinbase Wallet SDK constructor options
    */
   constructor(options: Readonly<CoinbaseWalletSDKOptions>) {
-    this.connectionPreference = options.connectionPreference || 'default';
+    this.smartWalletOnly = options.smartWalletOnly || false;
     this.chainIds = options.chainIds ? options.chainIds.map(Number) : [];
     this.appName = options.appName || 'DApp';
     this.appLogoUrl = options.appLogoUrl || getFavicon();
@@ -45,7 +44,7 @@ export class CoinbaseWalletSDK {
   }
 
   public makeWeb3Provider(): ProviderInterface {
-    if (this.connectionPreference !== 'embedded') {
+    if (!this.smartWalletOnly) {
       const extension = this.walletExtension;
       if (extension) {
         extension.setAppInfo?.(this.appName, this.appLogoUrl);
@@ -62,7 +61,7 @@ export class CoinbaseWalletSDK {
       appName: this.appName,
       appLogoUrl: this.appLogoUrl,
       appChainIds: this.chainIds,
-      connectionPreference: this.connectionPreference,
+      smartWalletOnly: this.smartWalletOnly,
     });
   }
 

--- a/packages/wallet-sdk/src/core/communicator/ConnectionPreference.ts
+++ b/packages/wallet-sdk/src/core/communicator/ConnectionPreference.ts
@@ -1,1 +1,0 @@
-export type ConnectionPreference = 'default' | 'embedded';

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -5,7 +5,6 @@ import { CoinbaseWalletSDK } from './CoinbaseWalletSDK';
 import { ProviderInterface } from './core/type/ProviderInterface';
 
 export { CoinbaseWalletSDK } from './CoinbaseWalletSDK';
-export type { ConnectionPreference } from './core/communicator/ConnectionPreference';
 export default CoinbaseWalletSDK;
 
 declare global {

--- a/packages/wallet-sdk/src/sign/SignRequestHandler.ts
+++ b/packages/wallet-sdk/src/sign/SignRequestHandler.ts
@@ -4,7 +4,6 @@ import { PopUpCommunicator } from './scw/transport/PopUpCommunicator';
 import { Signer, SignerUpdateListener } from './SignerInterface';
 import { SignRequestHandlerListener } from './UpdateListenerInterface';
 import { WLSigner } from './walletlink/WLSigner';
-import { ConnectionPreference } from ':core/communicator/ConnectionPreference';
 import { CB_KEYS_URL } from ':core/constants';
 import { standardErrorCodes, standardErrors } from ':core/error';
 import { ScopedLocalStorage } from ':core/storage/ScopedLocalStorage';
@@ -17,7 +16,7 @@ interface SignRequestHandlerOptions {
   appName: string;
   appLogoUrl?: string | null;
   appChainIds: number[];
-  connectionPreference: ConnectionPreference;
+  smartWalletOnly: boolean;
   updateListener: SignRequestHandlerListener;
 }
 
@@ -27,7 +26,7 @@ export class SignRequestHandler implements RequestHandler {
   private appName: string;
   private appLogoUrl: string | null;
   private appChainIds: number[];
-  private connectionPreference: ConnectionPreference;
+  private smartWalletOnly: boolean;
 
   private connectionType: string | null;
   private connectionTypeSelectionResolver: ((value: unknown) => void) | undefined;
@@ -56,7 +55,7 @@ export class SignRequestHandler implements RequestHandler {
 
     const persistedConnectionType = this.signerTypeStorage.getItem(SIGNER_TYPE_KEY);
     this.connectionType = persistedConnectionType;
-    this.connectionPreference = options.connectionPreference;
+    this.smartWalletOnly = options.smartWalletOnly;
 
     if (persistedConnectionType) {
       this.initSigner();
@@ -191,7 +190,7 @@ export class SignRequestHandler implements RequestHandler {
 
       this.popupCommunicator
         .selectConnectionType({
-          connectionPreference: this.connectionPreference,
+          smartWalletOnly: this.smartWalletOnly,
         })
         .then((connectionType) => {
           resolve(connectionType);

--- a/packages/wallet-sdk/src/sign/scw/transport/PopUpCommunicator.ts
+++ b/packages/wallet-sdk/src/sign/scw/transport/PopUpCommunicator.ts
@@ -7,7 +7,6 @@ import {
   HostConfigEventType,
   isConfigMessage,
 } from './ConfigMessage';
-import { ConnectionPreference } from ':core/communicator/ConnectionPreference';
 import { CrossDomainCommunicator } from ':core/communicator/CrossDomainCommunicator';
 import { Message } from ':core/communicator/Message';
 import { standardErrors } from ':core/error';
@@ -122,11 +121,7 @@ export class PopUpCommunicator extends CrossDomainCommunicator {
     }
   }
 
-  selectConnectionType({
-    connectionPreference,
-  }: {
-    connectionPreference: ConnectionPreference;
-  }): Promise<ConnectionType> {
+  selectConnectionType({ smartWalletOnly }: { smartWalletOnly: boolean }): Promise<ConnectionType> {
     return new Promise((resolve, reject) => {
       if (!this.peerWindow) {
         reject(
@@ -138,7 +133,7 @@ export class PopUpCommunicator extends CrossDomainCommunicator {
 
       this.resolveConnectionType = resolve;
       this.postClientConfigMessage(ClientConfigEventType.SelectConnectionType, {
-        connectionPreference,
+        smartWalletOnly,
       });
     });
   }


### PR DESCRIPTION
### _Summary_

- This PR replaces the `connectionPreference?: ConnectionPreference` SDK Option with a simpler `smartWalletOnly?: boolean`
- reduces mental overhead for dapp developers compared to connectionPreference enum
- gives dapp developers and easy way to hide wallet link if desired


### _How did you test your changes?_
locally 
unit tests 
