### PR TITLE
initialize SCWStateManager with dapp chainIds

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -39,6 +39,7 @@ export class SCWSigner implements Signer {
     this.puc = options.puc;
     this.keyManager = new SCWKeyManager();
     this.stateManager = new SCWStateManager({
+      appChainIds: this.appChainIds,
       updateListener: {
         onAccountsUpdate: (...args) => options.updateListener.onAccountsUpdate(this, ...args),
         onChainUpdate: (...args) => options.updateListener.onChainUpdate(this, ...args),

--- a/packages/wallet-sdk/src/sign/scw/SCWStateManager.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWStateManager.test.ts
@@ -11,6 +11,7 @@ describe('SCWStateManager', () => {
 
   beforeEach(() => {
     stateManager = new SCWStateManager({
+      appChainIds: [DEFAULT_CHAIN.id],
       updateListener: {
         onAccountsUpdate: jest.fn(),
         onChainUpdate: jest.fn(),
@@ -20,6 +21,35 @@ describe('SCWStateManager', () => {
 
   afterEach(() => {
     stateManager.clear();
+  });
+
+  describe('fallback to appChainIds[0]', () => {
+    const appChainIds = [10];
+
+    let stateManager: SCWStateManager;
+    beforeEach(() => {
+      stateManager = new SCWStateManager({
+        appChainIds,
+        updateListener: {
+          onAccountsUpdate: jest.fn(),
+          onChainUpdate: jest.fn(),
+        },
+      });
+    });
+    it('should use the first chain id from appChainIds as the active chain', () => {
+      expect(stateManager.activeChain.id).toBe(appChainIds[0]);
+    });
+
+    it('should use the first chain id from appChainIds as the active chain when appChainIds is empty', () => {
+      stateManager = new SCWStateManager({
+        appChainIds: [],
+        updateListener: {
+          onAccountsUpdate: jest.fn(),
+          onChainUpdate: jest.fn(),
+        },
+      });
+      expect(stateManager.activeChain.id).toBe(1);
+    });
   });
 
   describe('switchChain', () => {
@@ -64,6 +94,7 @@ describe('SCWStateManager', () => {
 
     beforeEach(() => {
       stateManager = new SCWStateManager({
+        appChainIds: [1],
         updateListener: {
           onAccountsUpdate: jest.fn(),
           onChainUpdate: chainUpdatedListener,

--- a/packages/wallet-sdk/src/sign/scw/SCWStateManager.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWStateManager.ts
@@ -41,7 +41,7 @@ export class SCWStateManager {
     }
 
     this._accounts = accounts || [];
-    this._activeChain = chain || { id: options.appChainIds[0] };
+    this._activeChain = chain || { id: options.appChainIds?.[0] ?? 1 };
   }
 
   updateAccounts(accounts: AddressString[]) {

--- a/packages/wallet-sdk/src/sign/scw/SCWStateManager.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWStateManager.ts
@@ -20,7 +20,7 @@ export class SCWStateManager {
     return this._activeChain;
   }
 
-  constructor(options: { updateListener: StateUpdateListener }) {
+  constructor(options: { appChainIds: number[]; updateListener: StateUpdateListener }) {
     this.updateListener = options.updateListener;
 
     this.availableChains = this.loadItemFromStorage(AVAILABLE_CHAINS_STORAGE_KEY);
@@ -41,7 +41,7 @@ export class SCWStateManager {
     }
 
     this._accounts = accounts || [];
-    this._activeChain = chain || { id: 1 };
+    this._activeChain = chain || { id: options.appChainIds[0] };
   }
 
   updateAccounts(accounts: AddressString[]) {


### PR DESCRIPTION
### _Summary_

We follow the app's `chainIds` param to set the default network for SDK, but we missed out SCWStateManager, so it's always sending requests on mainnet. This PR updated SCWStateManager to take `chainIds` for fallback

### _How did you test your changes?_

Manually
