### PR TITLE
Setup blur and focus events prior to navigating

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
@@ -442,35 +442,27 @@ export class WalletLinkRelay extends RelayAbstract implements WalletLinkConnecti
   private openCoinbaseWalletDeeplink(method: SupportedWeb3Method) {
     if (!(this.ui instanceof WLMobileRelayUI)) return;
 
-    let navigatedToCBW = false;
-
     // For mobile relay requests, open the Coinbase Wallet app
     switch (method) {
       case 'requestEthereumAccounts': // requestEthereumAccounts is handled via popup
       case 'switchEthereumChain': // switchEthereumChain doesn't need to open the app
         return;
       default:
-        navigatedToCBW = true;
+        window.addEventListener(
+          'blur',
+          () => {
+            window.addEventListener(
+              'focus',
+              () => {
+                this.connection.checkUnseenEvents();
+              },
+              { once: true }
+            );
+          },
+          { once: true }
+        );
         this.ui.openCoinbaseWalletDeeplink();
         break;
-    }
-
-    // If the user navigated to the Coinbase Wallet app, then we need to check
-    // for unseen events once the user returns to the browser
-    if (navigatedToCBW) {
-      window.addEventListener(
-        'blur',
-        () => {
-          window.addEventListener(
-            'focus',
-            () => {
-              this.connection.checkUnseenEvents();
-            },
-            { once: true }
-          );
-        },
-        { once: true }
-      );
     }
   }
 


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
Certain consumers are seeing inconsistent results when navigating to the wallet from a mobile browser to establish a walletlink connection. This applies specifically to the configuration where the dapp does not want to route the user to the in-app "dapp browser".

The change is to ensure the blur listener event is set before the app hits the blur event.

In the future we could look at checking for unseen events any time we re-establish the websocket, or even every time we refocus on the app. That would be even better - and this is just a small step in the right direction that should improve how reliably this code executes.

### _How did you test your changes?_
Change is straightforward and trivial enough - totally untested - just moved a bit of code up in the sequence of a file. Any help sanity checking this is appreciated.

<!--
  Verify changes. Include relevant screenshots/videos
-->
