### PR TITLE
[trivial] Return JSON-RPC result from backend

### DIFF
--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/wallet-sdk",
-  "version": "4.0.0-beta.5",
+  "version": "4.0.0-beta.6",
   "description": "Coinbase Wallet JavaScript SDK",
   "keywords": [
     "cipher",

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -154,7 +154,7 @@ export class SCWSigner implements Signer {
           headers: { 'Content-Type': 'application/json', 'X-Cbw-Sdk-Version': LIB_VERSION },
         });
         const response = await res.json();
-        return response as T;
+        return response.result as T;
       }
       default:
         return undefined;

--- a/packages/wallet-sdk/src/version.ts
+++ b/packages/wallet-sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = '4.0.0-beta.5';
+export const LIB_VERSION = '4.0.0-beta.6';


### PR DESCRIPTION
### _Summary_

changed backend handling so we just return the json rpc result. this brings the behavior in line with how wallets (popup, extension) respond to json rpc requests. ie they respond by excluding json rpc request id and version, and just return the result.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
