### PR TITLE
SDK Pass Version on Handshake + Error Handling for Signer Selection

### DIFF
--- a/packages/wallet-sdk/src/sign/SignerConfigurator.ts
+++ b/packages/wallet-sdk/src/sign/SignerConfigurator.ts
@@ -121,7 +121,7 @@ export class SignerConfigurator {
   async completeSignerTypeSelection() {
     await this.popupCommunicator.connect();
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.signerTypeSelectionResolver = (signerType: string) => {
         this.setSignerType(signerType);
         resolve(signerType);
@@ -133,6 +133,9 @@ export class SignerConfigurator {
         })
         .then((signerType) => {
           this.signerTypeSelectionResolver?.(signerType);
+        })
+        .catch((err) => {
+          reject(err);
         });
     });
   }

--- a/packages/wallet-sdk/src/sign/scw/transport/PopUpCommunicator.ts
+++ b/packages/wallet-sdk/src/sign/scw/transport/PopUpCommunicator.ts
@@ -69,8 +69,8 @@ export class PopUpCommunicator extends CrossDomainCommunicator {
   }
 
   selectSignerType({ smartWalletOnly }: { smartWalletOnly: boolean }): Promise<SignerType> {
-    return new Promise((resolve) => {
-      this.popUpConfigurator.resolveSignerTypeSelection = resolve;
+    return new Promise((resolve, reject) => {
+      this.popUpConfigurator.signerTypeSelectionFulfillment = { resolve, reject };
       this.popUpConfigurator.postClientConfigMessage(ClientConfigEventType.SelectConnectionType, {
         smartWalletOnly,
       });

--- a/packages/wallet-sdk/src/sign/scw/transport/PopUpConfigurator.ts
+++ b/packages/wallet-sdk/src/sign/scw/transport/PopUpConfigurator.ts
@@ -1,3 +1,4 @@
+import { LIB_VERSION } from '../../../version';
 import {
   ClientConfigEventType,
   ConfigMessage,
@@ -23,7 +24,9 @@ export class PopUpConfigurator {
       case HostConfigEventType.PopupListenerAdded:
         // Handshake Step 2: After receiving POPUP_LISTENER_ADDED_MESSAGE from Dapp,
         // Dapp sends DAPP_ORIGIN_MESSAGE to FE to help FE confirm the origin of the Dapp
-        this.postClientConfigMessage(ClientConfigEventType.DappOriginMessage);
+        this.postClientConfigMessage(ClientConfigEventType.DappOriginMessage, {
+          sdkVersion: LIB_VERSION,
+        });
         break;
       case HostConfigEventType.PopupReadyForRequest:
         // Handshake Step 4: After receiving POPUP_READY_MESSAGE from Dapp, FE knows that
@@ -50,7 +53,11 @@ export class PopUpConfigurator {
   }
 
   postClientConfigMessage(type: ClientConfigEventType, options?: any) {
-    if (options && type !== ClientConfigEventType.SelectConnectionType) {
+    if (
+      options &&
+      type !== ClientConfigEventType.SelectConnectionType &&
+      type !== ClientConfigEventType.DappOriginMessage
+    ) {
       throw standardErrors.rpc.internal('ClientConfigEvent does not accept options');
     }
 

--- a/packages/wallet-sdk/src/sign/scw/transport/PopUpConfigurator.ts
+++ b/packages/wallet-sdk/src/sign/scw/transport/PopUpConfigurator.ts
@@ -13,7 +13,10 @@ export class PopUpConfigurator {
 
   getWalletLinkQRCodeUrlCallback?: () => string;
   resolvePopupConnection?: () => void;
-  resolveSignerTypeSelection?: (_: SignerType) => void;
+  signerTypeSelectionFulfillment?: {
+    resolve: (_: SignerType) => void;
+    reject: (_: Error) => void;
+  };
 
   constructor({ communicator }: { communicator: PopUpCommunicator }) {
     this.communicator = communicator;
@@ -36,8 +39,8 @@ export class PopUpConfigurator {
         break;
       case HostConfigEventType.ConnectionTypeSelected:
         if (!this.communicator.connected) return;
-        this.resolveSignerTypeSelection?.(message.event.value as SignerType);
-        this.resolveSignerTypeSelection = undefined;
+        this.signerTypeSelectionFulfillment?.resolve(message.event.value as SignerType);
+        this.signerTypeSelectionFulfillment = undefined;
         break;
       case HostConfigEventType.RequestWalletLinkUrl:
         if (!this.communicator.connected) return;
@@ -74,7 +77,10 @@ export class PopUpConfigurator {
 
   onDisconnect() {
     this.resolvePopupConnection = undefined;
-    this.resolveSignerTypeSelection = undefined;
+    this.signerTypeSelectionFulfillment?.reject(
+      standardErrors.provider.userRejectedRequest('Request rejected')
+    );
+    this.signerTypeSelectionFulfillment = undefined;
   }
 
   private respondToWlQRCodeUrlRequest() {


### PR DESCRIPTION
### _Summary_

1. SDK Pass Version on Handshake
2. When user close popup before selecting the signer, SDK can now correctly handling it and throw back to dapp


### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
