### PR TITLE
Extension Detection

### DIFF
--- a/apps/testapp/src/context/CBWSDKReactContextProvider.tsx
+++ b/apps/testapp/src/context/CBWSDKReactContextProvider.tsx
@@ -30,10 +30,12 @@ declare global {
 
 if (typeof window !== 'undefined') {
   window.setPopupUrl = (url: string) => {
-    const handler = (window.ethereum as any).handlers.find(
+    const handler = (window.ethereum as any).handlers?.find(
       (h: any) => h instanceof SignRequestHandler
     );
-    handler.popupCommunicator.url = new URL(url);
+    if (handler && handler.popupCommunicator) {
+      handler.popupCommunicator.url = new URL(url);
+    }
   };
 }
 

--- a/apps/testapp/src/pages/index.tsx
+++ b/apps/testapp/src/pages/index.tsx
@@ -23,6 +23,14 @@ export default function Home() {
   const { provider } = useCBWSDK();
   const [connected, setConnected] = React.useState(Boolean(provider?.connected));
 
+  // This is for Extension compatibility, Extension with SDK3.9 does not emit connect event
+  // correctly, so we manually check if the extension is connected, and set the connected state
+  useEffect(() => {
+    if (window.coinbaseWalletExtension && !window.coinbaseWalletExtensionSigner) {
+      setConnected(true);
+    }
+  }, []);
+
   useEffect(() => {
     provider?.on('connect', async () => {
       setConnected(true);

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
@@ -3,6 +3,7 @@
 import { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
 import { CoinbaseWalletSDK } from './CoinbaseWalletSDK';
 import { ProviderInterface } from './core/type/ProviderInterface';
+import { Signer } from './sign/SignerInterface';
 
 describe('CoinbaseWalletSDK', () => {
   describe('initialize', () => {
@@ -97,11 +98,20 @@ describe('CoinbaseWalletSDK', () => {
 
       afterAll(() => {
         window.coinbaseWalletExtension = undefined;
+        window.coinbaseWalletExtensionSigner = undefined;
       });
 
-      test('@makeWeb3Provider', () => {
+      test('@makeWeb3Provider - only walletExtension injected', () => {
         // Returns extension provider
         expect(coinbaseWalletSDK2.makeWeb3Provider()).toEqual(mockProvider);
+      });
+
+      test('@makeWeb3Provider - both walletExtension and walletExtensionSigner injected', () => {
+        // Returns extension provider
+        window.coinbaseWalletExtensionSigner = {} as unknown as Signer;
+
+        const provider = coinbaseWalletSDK2.makeWeb3Provider();
+        expect(provider).not.toEqual(mockProvider);
       });
 
       test('@makeWeb3Provider, but with smartWalletOnly as true', () => {

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -5,6 +5,7 @@ import { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
 import { ScopedLocalStorage } from './core/storage/ScopedLocalStorage';
 import { ProviderInterface } from './core/type/ProviderInterface';
 import { getFavicon } from './core/util';
+import { Signer } from './sign/SignerInterface';
 import { LIB_VERSION } from './version';
 
 /** Coinbase Wallet SDK Constructor Options */
@@ -45,10 +46,11 @@ export class CoinbaseWalletSDK {
 
   public makeWeb3Provider(): ProviderInterface {
     if (!this.smartWalletOnly) {
-      const extension = this.walletExtension;
-      if (extension) {
-        extension.setAppInfo?.(this.appName, this.appLogoUrl);
-        return extension;
+      const shouldUseExtensionProvider = this.walletExtension && !this.walletExtensionSigner;
+
+      if (shouldUseExtensionProvider) {
+        this.walletExtension.setAppInfo?.(this.appName, this.appLogoUrl);
+        return this.walletExtension;
       }
     }
 
@@ -86,6 +88,10 @@ export class CoinbaseWalletSDK {
 
   private get walletExtension(): LegacyProviderInterface | undefined {
     return window.coinbaseWalletExtension;
+  }
+
+  private get walletExtensionSigner(): Signer | undefined {
+    return window.coinbaseWalletExtensionSigner;
   }
 
   private get coinbaseBrowser(): LegacyProviderInterface | undefined {

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -46,11 +46,12 @@ export class CoinbaseWalletSDK {
 
   public makeWeb3Provider(): ProviderInterface {
     if (!this.smartWalletOnly) {
-      const shouldUseExtensionProvider = this.walletExtension && !this.walletExtensionSigner;
+      const extensionProvider = this.walletExtension;
+      const shouldUseExtensionProvider = extensionProvider && !this.walletExtensionSigner;
 
       if (shouldUseExtensionProvider) {
-        this.walletExtension.setAppInfo?.(this.appName, this.appLogoUrl);
-        return this.walletExtension;
+        extensionProvider.setAppInfo?.(this.appName, this.appLogoUrl);
+        return extensionProvider;
       }
     }
 

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -3,6 +3,7 @@
 import { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
 import { CoinbaseWalletSDK } from './CoinbaseWalletSDK';
 import { ProviderInterface } from './core/type/ProviderInterface';
+import { Signer } from './sign/SignerInterface';
 
 export { CoinbaseWalletSDK } from './CoinbaseWalletSDK';
 export default CoinbaseWalletSDK;
@@ -13,6 +14,7 @@ declare global {
     CoinbaseWalletProvider: typeof CoinbaseWalletProvider;
     ethereum?: ProviderInterface;
     coinbaseWalletExtension?: ProviderInterface;
+    coinbaseWalletExtensionSigner?: Signer;
   }
 }
 

--- a/packages/wallet-sdk/src/sign/SignerConfigurator.test.ts
+++ b/packages/wallet-sdk/src/sign/SignerConfigurator.test.ts
@@ -1,0 +1,213 @@
+import { SCWSigner } from './scw/SCWSigner';
+import { PopUpCommunicator } from './scw/transport/PopUpCommunicator';
+import { SignerConfigurator } from './SignerConfigurator';
+import { Signer } from './SignerInterface';
+import { SignRequestHandlerListener } from './UpdateListenerInterface';
+import { WLSigner } from './walletlink/WLSigner';
+
+declare global {
+  interface Window {
+    coinbaseWalletExtensionSigner?: Signer;
+  }
+}
+
+jest.mock('./scw/transport/PopUpCommunicator');
+
+const mockSetItem = jest.fn();
+const mockGetItem = jest.fn();
+const mockRemoveItem = jest.fn();
+jest.mock(':core/storage/ScopedLocalStorage', () => {
+  return {
+    ScopedLocalStorage: jest.fn().mockImplementation(() => {
+      return {
+        getItem: mockGetItem,
+        removeItem: mockRemoveItem,
+        clear: jest.fn(),
+        setItem: mockSetItem,
+      };
+    }),
+  };
+});
+
+describe('SignerConfigurator', () => {
+  let popupCommunicator: PopUpCommunicator;
+
+  const updateListener: SignRequestHandlerListener = {
+    onAccountsUpdate: jest.fn(),
+    onChainUpdate: jest.fn(),
+    onConnect: jest.fn(),
+    onResetConnection: jest.fn(),
+  };
+
+  beforeEach(() => {
+    popupCommunicator = new PopUpCommunicator({ url: 'http://google.com' });
+  });
+
+  it('should not init Signer when no saved signerType', () => {
+    const signerConfigurator = new SignerConfigurator({
+      appName: 'Test App',
+      appChainIds: [1],
+      smartWalletOnly: false,
+      updateListener,
+      popupCommunicator,
+    });
+
+    expect(signerConfigurator.signerType).toBeUndefined();
+    expect(signerConfigurator.signer).toBeUndefined();
+  });
+
+  it('should initialize SCWSigner correctly', () => {
+    const signerConfigurator = new SignerConfigurator({
+      appName: 'Test App',
+      appChainIds: [1],
+      smartWalletOnly: false,
+      updateListener,
+      popupCommunicator,
+    });
+
+    signerConfigurator.signerType = 'scw';
+    signerConfigurator.initSigner();
+
+    expect(signerConfigurator.signer).toBeInstanceOf(SCWSigner);
+  });
+
+  it('should initialize WLSigner correctly', () => {
+    const signerConfigurator = new SignerConfigurator({
+      appName: 'Test App',
+      appChainIds: [1],
+      smartWalletOnly: false,
+      updateListener,
+      popupCommunicator,
+    });
+
+    signerConfigurator.signerType = 'walletlink';
+    signerConfigurator.initSigner();
+
+    expect(signerConfigurator.signer).toBeInstanceOf(WLSigner);
+  });
+
+  it('should initialize ExtensionSigner correctly', () => {
+    const signerConfigurator = new SignerConfigurator({
+      appName: 'Test App',
+      appChainIds: [1],
+      smartWalletOnly: false,
+      updateListener,
+      popupCommunicator,
+    });
+
+    window.coinbaseWalletExtensionSigner = {
+      handshake: jest.fn(),
+      request: jest.fn(),
+      disconnect: jest.fn(),
+    };
+
+    signerConfigurator.signerType = 'extension';
+    signerConfigurator.initSigner();
+
+    expect(signerConfigurator.signer).toBe(window.coinbaseWalletExtensionSigner);
+  });
+
+  it('should handle disconnect correctly', async () => {
+    const signerConfigurator = new SignerConfigurator({
+      appName: 'Test App',
+      appChainIds: [1],
+      smartWalletOnly: false,
+      updateListener,
+      popupCommunicator,
+    });
+
+    signerConfigurator.signerType = 'scw';
+    signerConfigurator.initSigner();
+
+    await signerConfigurator.onDisconnect();
+
+    expect(signerConfigurator.signer).toBeUndefined();
+    expect(signerConfigurator.signerType).toBeNull();
+    expect(mockRemoveItem).toHaveBeenCalled();
+  });
+
+  it('should complete signerType selection correctly', async () => {
+    const signerConfigurator = new SignerConfigurator({
+      appName: 'Test App',
+      appChainIds: [1],
+      smartWalletOnly: false,
+      updateListener,
+      popupCommunicator,
+    });
+
+    expect(signerConfigurator.signerType).toBeUndefined();
+    expect(signerConfigurator.signer).toBeUndefined();
+
+    (popupCommunicator.selectSignerType as jest.Mock).mockResolvedValue('scw');
+
+    await signerConfigurator.completeSignerTypeSelection();
+
+    expect(signerConfigurator.signerType).toBe('scw');
+    expect(mockSetItem).toHaveBeenCalledWith('SignerType', 'scw');
+  });
+
+  describe('init signer at constructor', () => {
+    it('should init SCWSigner correctly', () => {
+      mockGetItem.mockReturnValueOnce('scw');
+      const signerConfigurator = new SignerConfigurator({
+        appName: 'Test App',
+        appChainIds: [1],
+        smartWalletOnly: false,
+        updateListener,
+        popupCommunicator,
+      });
+
+      signerConfigurator.signerType = 'scw';
+      expect(signerConfigurator.signer).toBeInstanceOf(SCWSigner);
+    });
+
+    it('should init WLSigner correctly', () => {
+      mockGetItem.mockReturnValueOnce('walletlink');
+      const signerConfigurator = new SignerConfigurator({
+        appName: 'Test App',
+        appChainIds: [1],
+        smartWalletOnly: false,
+        updateListener,
+        popupCommunicator,
+      });
+
+      signerConfigurator.signerType = 'walletlink';
+      expect(signerConfigurator.signer).toBeInstanceOf(WLSigner);
+    });
+
+    it('should init ExtensionSigner correctly', () => {
+      mockGetItem.mockReturnValueOnce('extension');
+      window.coinbaseWalletExtensionSigner = {
+        handshake: jest.fn(),
+        request: jest.fn(),
+        disconnect: jest.fn(),
+      };
+      const signerConfigurator = new SignerConfigurator({
+        appName: 'Test App',
+        appChainIds: [1],
+        smartWalletOnly: false,
+        updateListener,
+        popupCommunicator,
+      });
+
+      signerConfigurator.signerType = 'extension';
+      expect(signerConfigurator.signer).toBe(window.coinbaseWalletExtensionSigner);
+    });
+
+    it('should disconnect at signer initialization error', () => {
+      mockGetItem.mockReturnValueOnce('extension');
+      window.coinbaseWalletExtensionSigner = undefined;
+      const signerConfigurator = new SignerConfigurator({
+        appName: 'Test App',
+        appChainIds: [1],
+        smartWalletOnly: false,
+        updateListener,
+        popupCommunicator,
+      });
+
+      expect(signerConfigurator.signer).toBeUndefined();
+      expect(mockRemoveItem).toHaveBeenCalledWith('SignerType');
+      expect(signerConfigurator.signerType).toBeNull();
+    });
+  });
+});

--- a/packages/wallet-sdk/src/sign/SignerConfigurator.ts
+++ b/packages/wallet-sdk/src/sign/SignerConfigurator.ts
@@ -149,6 +149,7 @@ export class SignerConfigurator {
       this.popupCommunicator
         .selectSignerType({
           smartWalletOnly: this.smartWalletOnly,
+          isExtensionSignerAvailable: Boolean(window.coinbaseWalletExtensionSigner),
         })
         .then((signerType) => {
           this.signerTypeSelectionResolver?.(signerType);

--- a/packages/wallet-sdk/src/sign/scw/transport/ConfigMessage.ts
+++ b/packages/wallet-sdk/src/sign/scw/transport/ConfigMessage.ts
@@ -23,7 +23,7 @@ export enum HostConfigEventType {
   PopupUnload = 'popupUnload',
 }
 
-export type SignerType = 'scw' | 'walletlink';
+export type SignerType = 'scw' | 'walletlink' | 'extension';
 
 export function isConfigMessage(msg: Message): msg is ConfigMessage {
   return msg.type === 'config' && 'event' in msg;

--- a/packages/wallet-sdk/src/sign/scw/transport/PopUpCommunicator.ts
+++ b/packages/wallet-sdk/src/sign/scw/transport/PopUpCommunicator.ts
@@ -68,11 +68,18 @@ export class PopUpCommunicator extends CrossDomainCommunicator {
     this.popUpConfigurator.getWalletLinkQRCodeUrlCallback = callback;
   }
 
-  selectSignerType({ smartWalletOnly }: { smartWalletOnly: boolean }): Promise<SignerType> {
+  selectSignerType({
+    smartWalletOnly,
+    isExtensionSignerAvailable,
+  }: {
+    smartWalletOnly: boolean;
+    isExtensionSignerAvailable: boolean;
+  }): Promise<SignerType> {
     return new Promise((resolve, reject) => {
       this.popUpConfigurator.signerTypeSelectionFulfillment = { resolve, reject };
       this.popUpConfigurator.postClientConfigMessage(ClientConfigEventType.SelectConnectionType, {
         smartWalletOnly,
+        isExtensionSignerAvailable,
       });
     });
   }


### PR DESCRIPTION
### _Summary_

- only return injected provider, when coinbaseWalletExtension is injected and coinbaseWalletExtensionSigner is not
- when FE returns selected signer as extension, grab the injected coinbaseWalletExtensionSigner
- sends coinbaseWalletExtensionSigner status to FE for selection

### _How did you test your changes?_

When extensionSigner is injected, always open SCW popup and show extension option
https://github.com/coinbase/coinbase-wallet-sdk/assets/22125939/16e27720-6e8d-4a78-b698-36305e6e04af


when extensionSigner is not injected, but old extension provider is injected
https://github.com/coinbase/coinbase-wallet-sdk/assets/22125939/c0050356-4afa-409e-a016-cb0fe81c0be6


When error grabbing injected extensionSigner, reset everything
https://github.com/coinbase/coinbase-wallet-sdk/assets/22125939/455d5fd6-afb0-4579-83f0-b4c1cb781fdd



