### PR TITLE
disconnect cleanup

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
@@ -35,15 +35,6 @@ describe('CoinbaseWalletSDK', () => {
       });
 
       // TODO: nate re-enable these tests
-      // test('@disconnect', () => {
-      //   const relayResetMock = jest
-      //     .spyOn((coinbaseWalletSDK2 as any)._relay, 'resetAndReload')
-      //     .mockImplementation(() => 'resetAndReload');
-      //   coinbaseWalletSDK2.disconnect();
-
-      //   expect(relayResetMock).toHaveBeenCalled();
-      // });
-
       // test('@setAppInfo', () => {
       //   const relaySetAppInfoMock = jest
       //     .spyOn(WalletLinkRelay.prototype, 'setAppInfo')
@@ -124,14 +115,6 @@ describe('CoinbaseWalletSDK', () => {
         const provider = sdk.makeWeb3Provider();
         expect(provider).toBeTruthy();
         expect(provider).not.toEqual(mockProvider);
-      });
-
-      test('@disconnect', async () => {
-        const mockExtensionProvider = mockProvider as unknown as { close: jest.Mock };
-        jest.spyOn(mockExtensionProvider, 'close').mockImplementation(() => 'mockClose');
-        // Calls extension close
-        coinbaseWalletSDK2.disconnect();
-        expect(await mockExtensionProvider.close()).toBe('mockClose');
       });
     });
 

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
@@ -34,24 +34,6 @@ describe('CoinbaseWalletSDK', () => {
         expect(coinbaseWalletSDK2.makeWeb3Provider()).toBeInstanceOf(CoinbaseWalletProvider);
       });
 
-      // TODO: nate re-enable these tests
-      // test('@setAppInfo', () => {
-      //   const relaySetAppInfoMock = jest
-      //     .spyOn(WalletLinkRelay.prototype, 'setAppInfo')
-      //     .mockImplementation(() => 'setAppInfo');
-      //   coinbaseWalletSDK2.setAppInfo('sdk', 'http://sdk-image.png');
-
-      //   expect(relaySetAppInfoMock).toHaveBeenCalledWith('sdk', 'http://sdk-image.png');
-      // });
-
-      // test('@getQrUrl', () => {
-      //   const qrUrl = coinbaseWalletSDK2.getQrUrl() || '';
-      //   const url = new URL(qrUrl);
-
-      //   expect(url.hostname).toEqual('www.walletlink.org');
-      //   expect(url.hash.split('=')).toHaveLength(6);
-      // });
-
       test('@getCoinbaseWalletLogo', () => {
         let svgUri;
 

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -48,8 +48,14 @@ export class CoinbaseWalletSDK {
     if (!this.smartWalletOnly) {
       const extensionProvider = this.walletExtension;
       const shouldUseExtensionProvider = extensionProvider && !this.walletExtensionSigner;
+
       if (shouldUseExtensionProvider) {
-        (extensionProvider as ExtensionProvider).setAppInfo?.(this.appName, this.appLogoUrl);
+        if (
+          'setAppInfo' in extensionProvider &&
+          typeof extensionProvider.setAppInfo === 'function'
+        ) {
+          extensionProvider.setAppInfo?.(this.appName, this.appLogoUrl);
+        }
         return extensionProvider;
       }
     }
@@ -101,8 +107,4 @@ export class CoinbaseWalletSDK {
       return undefined;
     }
   }
-}
-
-interface ExtensionProvider extends ProviderInterface {
-  setAppInfo?(appName: string, appLogoUrl: string | null): void;
 }

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -3,7 +3,7 @@
 import { LogoType, walletLogo } from './assets/wallet-logo';
 import { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
 import { ScopedLocalStorage } from './core/storage/ScopedLocalStorage';
-import { LegacyProviderInterface, ProviderInterface } from './core/type/ProviderInterface';
+import { ProviderInterface } from './core/type/ProviderInterface';
 import { getFavicon } from './core/util';
 import { Signer } from './sign/SignerInterface';
 import { LIB_VERSION } from './version';
@@ -78,7 +78,7 @@ export class CoinbaseWalletSDK {
     return walletLogo(type, width);
   }
 
-  private get walletExtension(): LegacyProviderInterface | undefined {
+  private get walletExtension(): ProviderInterface | undefined {
     return window.coinbaseWalletExtension;
   }
 
@@ -86,7 +86,7 @@ export class CoinbaseWalletSDK {
     return window.coinbaseWalletExtensionSigner;
   }
 
-  private get coinbaseBrowser(): LegacyProviderInterface | undefined {
+  private get coinbaseBrowser(): ProviderInterface | undefined {
     try {
       // Coinbase DApp browser does not inject into iframes so grab provider from top frame if it exists
       const ethereum = window.ethereum ?? window.top?.ethereum;

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -3,7 +3,7 @@
 import { LogoType, walletLogo } from './assets/wallet-logo';
 import { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
 import { ScopedLocalStorage } from './core/storage/ScopedLocalStorage';
-import { ProviderInterface } from './core/type/ProviderInterface';
+import { LegacyProviderInterface, ProviderInterface } from './core/type/ProviderInterface';
 import { getFavicon } from './core/util';
 import { Signer } from './sign/SignerInterface';
 import { LIB_VERSION } from './version';
@@ -68,15 +68,6 @@ export class CoinbaseWalletSDK {
     });
   }
 
-  public disconnect(): void {
-    const extension = this?.walletExtension;
-    if (extension) {
-      extension.close?.();
-    } else {
-      ScopedLocalStorage.clearAll();
-    }
-  }
-
   /**
    * Official Coinbase Wallet logo for developers to use on their frontend
    * @param type Type of wallet logo: "standard" | "circle" | "text" | "textWithLogo" | "textLight" | "textWithLogoLight"
@@ -111,9 +102,4 @@ export class CoinbaseWalletSDK {
       return undefined;
     }
   }
-}
-
-interface LegacyProviderInterface extends ProviderInterface {
-  setAppInfo?(appName: string, appLogoUrl: string | null): void;
-  close?(): void;
 }

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -48,9 +48,8 @@ export class CoinbaseWalletSDK {
     if (!this.smartWalletOnly) {
       const extensionProvider = this.walletExtension;
       const shouldUseExtensionProvider = extensionProvider && !this.walletExtensionSigner;
-
       if (shouldUseExtensionProvider) {
-        extensionProvider.setAppInfo?.(this.appName, this.appLogoUrl);
+        (extensionProvider as ExtensionProvider).setAppInfo?.(this.appName, this.appLogoUrl);
         return extensionProvider;
       }
     }
@@ -102,4 +101,8 @@ export class CoinbaseWalletSDK {
       return undefined;
     }
   }
+}
+
+interface ExtensionProvider extends ProviderInterface {
+  setAppInfo?(appName: string, appLogoUrl: string | null): void;
 }

--- a/packages/wallet-sdk/src/core/type/ProviderInterface.ts
+++ b/packages/wallet-sdk/src/core/type/ProviderInterface.ts
@@ -22,11 +22,22 @@ interface ProviderConnectInfo {
 
 // properties explicitly required by EIP-1193 spec
 // + extends EventEmitter per spec recomendation
-export interface ProviderInterface extends EventEmitter {
+interface MinimalProviderInterface extends EventEmitter {
   request<T>(args: RequestArguments): Promise<T>;
   on(event: 'connect', listener: (info: ProviderConnectInfo) => void): this;
   on(event: 'disconnect', listener: (error: ProviderRpcError) => void): this;
   on(event: 'chainChanged', listener: (chainId: string) => void): this;
   on(event: 'accountsChanged', listener: (accounts: string[]) => void): this;
   on(event: 'message', listener: (message: ProviderMessage) => void): this;
+}
+
+//
+export interface ProviderInterface extends MinimalProviderInterface {
+  disconnect(): Promise<void>;
+}
+
+// Extension provider interface
+export interface LegacyProviderInterface extends MinimalProviderInterface {
+  setAppInfo?(appName: string, appLogoUrl: string | null): void;
+  close?(): void;
 }

--- a/packages/wallet-sdk/src/core/type/ProviderInterface.ts
+++ b/packages/wallet-sdk/src/core/type/ProviderInterface.ts
@@ -23,7 +23,6 @@ interface ProviderConnectInfo {
 export interface ProviderInterface extends EventEmitter {
   request<T>(args: RequestArguments): Promise<T>;
   disconnect(): Promise<void>;
-  setAppInfo?(appName: string, appLogoUrl: string | null): void; // legacy extension only
   on(event: 'connect', listener: (info: ProviderConnectInfo) => void): this;
   on(event: 'disconnect', listener: (error: ProviderRpcError) => void): this;
   on(event: 'chainChanged', listener: (chainId: string) => void): this;

--- a/packages/wallet-sdk/src/core/type/ProviderInterface.ts
+++ b/packages/wallet-sdk/src/core/type/ProviderInterface.ts
@@ -33,7 +33,7 @@ interface MinimalProviderInterface extends EventEmitter {
 
 //
 export interface ProviderInterface extends MinimalProviderInterface {
-  disconnect(): Promise<void>;
+  disconnect?(): Promise<void>;
 }
 
 // Extension provider interface

--- a/packages/wallet-sdk/src/core/type/ProviderInterface.ts
+++ b/packages/wallet-sdk/src/core/type/ProviderInterface.ts
@@ -20,24 +20,13 @@ interface ProviderConnectInfo {
   readonly chainId: string;
 }
 
-// properties explicitly required by EIP-1193 spec
-// + extends EventEmitter per spec recomendation
-interface MinimalProviderInterface extends EventEmitter {
+export interface ProviderInterface extends EventEmitter {
   request<T>(args: RequestArguments): Promise<T>;
+  disconnect(): Promise<void>;
+  setAppInfo?(appName: string, appLogoUrl: string | null): void; // legacy extension only
   on(event: 'connect', listener: (info: ProviderConnectInfo) => void): this;
   on(event: 'disconnect', listener: (error: ProviderRpcError) => void): this;
   on(event: 'chainChanged', listener: (chainId: string) => void): this;
   on(event: 'accountsChanged', listener: (accounts: string[]) => void): this;
   on(event: 'message', listener: (message: ProviderMessage) => void): this;
-}
-
-//
-export interface ProviderInterface extends MinimalProviderInterface {
-  disconnect?(): Promise<void>;
-}
-
-// Extension provider interface
-export interface LegacyProviderInterface extends MinimalProviderInterface {
-  setAppInfo?(appName: string, appLogoUrl: string | null): void;
-  close?(): void;
 }


### PR DESCRIPTION
### _Summary_
- remove `sdk.disconnect()` method
- add disconnect to `ProviderInterface` otherwise TS complains if anyone tries to call provider.disconnect [like this example in wagmi](https://github.com/wevm/wagmi/pull/3784/files/8c213576b671b1c7b033f2f9e1188bcbd5068f82#diff-b05598fc1a520e04372175e02a71b5110937ac12bb448dd939b163f5ad8ee463R65)
- on the extension side, `ExtensionCoinbaseWalletProvider extends CoinbaseWalletProvider` so disconnect can be called now with v3 and also when the extension upgrades to SDK v4

### _How did you test your changes?_
locally
