### PR TITLE
Parse result rather than returning entire json rpc envelope

### DIFF
--- a/packages/wallet-sdk/src/rpcFetch/RPCFetchRequestHandler.ts
+++ b/packages/wallet-sdk/src/rpcFetch/RPCFetchRequestHandler.ts
@@ -23,6 +23,6 @@ export class RPCFetchRequestHandler implements RequestHandler {
       headers: { 'Content-Type': 'application/json' },
     });
     const response = await res.json();
-    return response;
+    return response.result;
   }
 }


### PR DESCRIPTION
### _Summary_

The `RPCFetchRequestHandler` class was returning the entire json rpc envelope instead of just the result (see previous implementation from [3.9.1](https://github.com/coinbase/coinbase-wallet-sdk/blob/v3.9.1/packages/wallet-sdk/src/provider/CoinbaseWalletProvider.ts#L519)).  This breaks compatibility with dapps.  Instead it should return the result.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
