### PR TITLE
Fix v4 example with wagmi

### DIFF
--- a/packages/wallet-sdk/docs/v4_with_wagmi.md
+++ b/packages/wallet-sdk/docs/v4_with_wagmi.md
@@ -36,7 +36,7 @@ This quickstart guide walks through building a dapp for Coinbase smart wallet us
 
    export const config = createConfig({
      chains: [baseSepolia],
-     connectors: [coinbaseWallet({ appName: 'Create Wagmi', chainIds: [baseSepolia.id] })],
+     connectors: [coinbaseWallet({ appName: 'Create Wagmi', chainId: baseSepolia.id })],
      transports: {
        [baseSepolia.id]: http(),
      },


### PR DESCRIPTION
### _Summary_

Its looks like now chainIds not exist, but chainId exist

`Object literal may only specify known properties, but 'chainIds' does not exist in type '{ appName: string; appLogoUrl?: string | null; darkMode?: boolean; linkAPIUrl?: string; uiConstructor?: (options: RelayUIOptions) => RelayUI; diagnosticLogger?: any; overrideIsMetaMask?: boolean; overrideIsCoinbaseWallet?: boolean; ... 5 more ...; reloadOnDisconnect?: boolean | undefined; }'. Did you mean to write 'chainId'?`