### PR TITLE
make testapp listen for chainChanged event to avoid using a getter

### DIFF
--- a/apps/testapp/src/pages/index.tsx
+++ b/apps/testapp/src/pages/index.tsx
@@ -32,10 +32,11 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    provider?.on('connect', async () => {
-      const chainId = await provider.request({ method: 'eth_chainId' });
-      setChainId(chainId);
+    provider?.on('connect', () => {
       setConnected(true);
+    });
+    provider?.on('chainChanged', (newChainId) => {
+      setChainId(newChainId);
     });
   }, [provider]);
 

--- a/apps/testapp/src/pages/index.tsx
+++ b/apps/testapp/src/pages/index.tsx
@@ -22,7 +22,7 @@ import { useCBWSDK } from '../context/CBWSDKReactContextProvider';
 export default function Home() {
   const { provider } = useCBWSDK();
   const [connected, setConnected] = React.useState(Boolean(provider?.connected));
-
+  const [chainId, setChainId] = React.useState<number | undefined>(undefined);
   // This is for Extension compatibility, Extension with SDK3.9 does not emit connect event
   // correctly, so we manually check if the extension is connected, and set the connected state
   useEffect(() => {
@@ -33,6 +33,8 @@ export default function Home() {
 
   useEffect(() => {
     provider?.on('connect', async () => {
+      const chainId = await provider.request({ method: 'eth_chainId' });
+      setChainId(chainId);
       setConnected(true);
     });
   }, [provider]);
@@ -56,7 +58,7 @@ export default function Home() {
           <MethodsSection
             title="Sign Message"
             methods={signMessageMethods}
-            shortcutsMap={signMessageShortcutsMap(provider?.chainId)}
+            shortcutsMap={signMessageShortcutsMap(chainId)}
           />
           <MethodsSection title="Send" methods={sendMethods} shortcutsMap={sendShortcutsMap} />
           <MethodsSection

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -32,6 +32,10 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
     return this.accounts.length > 0;
   }
 
+  public get chainId() {
+    return this.chain.id;
+  }
+
   public async request<T>(args: RequestArguments): Promise<T> {
     const invalidArgsError = checkErrorForInvalidRequestArgs(args);
     if (invalidArgsError) throw invalidArgsError;

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -32,10 +32,6 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
     return this.accounts.length > 0;
   }
 
-  public get chainId() {
-    return this.chain.id;
-  }
-
   public async request<T>(args: RequestArguments): Promise<T> {
     const invalidArgsError = checkErrorForInvalidRequestArgs(args);
     if (invalidArgsError) throw invalidArgsError;


### PR DESCRIPTION
### _Summary_
fixes the testapp which was using a nonstandard getter which sdk v4 no longer supports

### _How did you test your changes?_

locally
