### PR TITLE
Fix broken link to the public developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 > Migrating from v3 to v4? Please see our [v4 migration guide](docs/migration_guide.md) for a full list of breaking changes.
 
 - This readme contains brief instructions to get up and running.
-- Visit our [public developer docs](https://docs.cloud.coinbase.com/wallet-sdk/docs) for more detail, including samples for integrating Coinbase Wallet using libraries like [web3-react](https://github.com/Uniswap/web3-react), [web3modal](https://github.com/Web3Modal/web3modal), [Web3-Onboard](https://docs.blocknative.com/onboard), and [wagmi](https://wagmi.sh/).
+- Visit our [public developer docs](https://docs.cloud.coinbase.com/wallet-sdk/docs/welcome) for more detail, including samples for integrating Coinbase Wallet using libraries like [web3-react](https://github.com/Uniswap/web3-react), [web3modal](https://github.com/Web3Modal/web3modal), [Web3-Onboard](https://docs.blocknative.com/onboard), and [wagmi](https://wagmi.sh/).
 
 ### Installing Wallet SDK
 


### PR DESCRIPTION
### _Summary_

  The link to the public documentation website was incorrect. The previous link resulted in a 404. This change updates the link to point to the most recent developer documentation start page for the wallet SDK.

