### PR TITLE
Add keys-beta.coinbase.com/connect to playground

### DIFF
--- a/apps/testapp/src/context/CBWSDKReactContextProvider.tsx
+++ b/apps/testapp/src/context/CBWSDKReactContextProvider.tsx
@@ -17,6 +17,7 @@ export type SDKVersionType = (typeof sdkVersions)[number];
 const SELECTED_SCW_URL_KEY = 'scw_url';
 export const scwUrls = [
   'https://keys.coinbase.com/connect',
+  'https://keys-beta.coinbase.com/connect',
   'http://localhost:3005/connect',
 ] as const;
 export type ScwUrlType = (typeof scwUrls)[number];


### PR DESCRIPTION
### _Summary_

This PR adds keys-beta.coinbase.com/connect as an option for developers to test against.

### _How did you test your changes?_

Verified locally by setting it and opening up a eth_requestAccounts

<img width="1080" alt="Screenshot 2024-05-01 at 5 52 20 PM" src="https://github.com/coinbase/coinbase-wallet-sdk/assets/935795/882a3889-c17f-4fa2-b8b1-f7720b03324a">
