### PR TITLE
Fix popup blocked on Safari

### DIFF
--- a/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
@@ -60,7 +60,6 @@ describe('Communicator', () => {
   it('should open a popup window', async () => {
     queueMessageEvent(popupLoadedMessage);
 
-    // @ts-expect-error accessing private method
     await communicator.waitForPopupLoaded();
 
     expect(openPopup).toHaveBeenCalledWith(new URL(CB_KEYS_URL));

--- a/packages/wallet-sdk/src/core/communicator/Communicator.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.ts
@@ -87,17 +87,17 @@ export class Communicator {
       });
   };
 
-    /**
+  /**
    * Closes the popup, rejects all requests and clears the listeners
    */
-    private disconnect = () => {
-      closePopup(this.popup);
-      this.popup = null;
-  
-      this.listeners.forEach(({ reject }, listener) => {
-        reject(standardErrors.provider.userRejectedRequest('Request rejected'));
-        window.removeEventListener('message', listener);
-      });
-      this.listeners.clear();
-    };
+  private disconnect = () => {
+    closePopup(this.popup);
+    this.popup = null;
+
+    this.listeners.forEach(({ reject }, listener) => {
+      reject(standardErrors.provider.userRejectedRequest('Request rejected'));
+      window.removeEventListener('message', listener);
+    });
+    this.listeners.clear();
+  };
 }

--- a/packages/wallet-sdk/src/core/communicator/Communicator.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.ts
@@ -63,6 +63,20 @@ export class Communicator {
   };
 
   /**
+   * Closes the popup, rejects all requests and clears the listeners
+   */
+  private disconnect = () => {
+    closePopup(this.popup);
+    this.popup = null;
+
+    this.listeners.forEach(({ reject }, listener) => {
+      reject(standardErrors.provider.userRejectedRequest('Request rejected'));
+      window.removeEventListener('message', listener);
+    });
+    this.listeners.clear();
+  };
+
+  /**
    * Waits for the popup window to fully load and then sends a version message.
    */
   waitForPopupLoaded = async (): Promise<Window> => {
@@ -85,19 +99,5 @@ export class Communicator {
         if (!this.popup) throw standardErrors.rpc.internal();
         return this.popup;
       });
-  };
-
-  /**
-   * Closes the popup, rejects all requests and clears the listeners
-   */
-  private disconnect = () => {
-    closePopup(this.popup);
-    this.popup = null;
-
-    this.listeners.forEach(({ reject }, listener) => {
-      reject(standardErrors.provider.userRejectedRequest('Request rejected'));
-      window.removeEventListener('message', listener);
-    });
-    this.listeners.clear();
   };
 }

--- a/packages/wallet-sdk/src/core/communicator/Communicator.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.ts
@@ -63,23 +63,9 @@ export class Communicator {
   };
 
   /**
-   * Closes the popup, rejects all requests and clears the listeners
-   */
-  private disconnect = () => {
-    closePopup(this.popup);
-    this.popup = null;
-
-    this.listeners.forEach(({ reject }, listener) => {
-      reject(standardErrors.provider.userRejectedRequest('Request rejected'));
-      window.removeEventListener('message', listener);
-    });
-    this.listeners.clear();
-  };
-
-  /**
    * Waits for the popup window to fully load and then sends a version message.
    */
-  private waitForPopupLoaded = async (): Promise<Window> => {
+  waitForPopupLoaded = async (): Promise<Window> => {
     if (this.popup) return this.popup;
 
     this.popup = openPopup(this.url);
@@ -100,4 +86,18 @@ export class Communicator {
         return this.popup;
       });
   };
+
+    /**
+   * Closes the popup, rejects all requests and clears the listeners
+   */
+    private disconnect = () => {
+      closePopup(this.popup);
+      this.popup = null;
+  
+      this.listeners.forEach(({ reject }, listener) => {
+        reject(standardErrors.provider.userRejectedRequest('Request rejected'));
+        window.removeEventListener('message', listener);
+      });
+      this.listeners.clear();
+    };
 }

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -1,6 +1,7 @@
 import { StateUpdateListener } from '../interface';
 import { SCWKeyManager } from './SCWKeyManager';
 import { SCWStateManager } from './SCWStateManager';
+import { Communicator } from ':core/communicator/Communicator';
 import { standardErrors } from ':core/error';
 import { RPCRequestMessage, RPCResponse, RPCResponseMessage } from ':core/message';
 import { AppMetadata, RequestArguments, Signer } from ':core/provider/interface';
@@ -22,20 +23,17 @@ type SwitchEthereumChainParam = [
 
 export class SCWSigner implements Signer {
   private readonly metadata: AppMetadata;
-  private readonly waitForPopupLoaded: () => Promise<Window>;
-  private readonly postMessageToPopup: (_: RPCRequestMessage) => Promise<RPCResponseMessage>;
+  private readonly communicator: Communicator;
   private readonly keyManager: SCWKeyManager;
   private readonly stateManager: SCWStateManager;
 
   constructor(params: {
     metadata: AppMetadata;
-    waitForPopupLoaded: () => Promise<Window>;
-    postMessageToPopup: (_: RPCRequestMessage) => Promise<RPCResponseMessage>;
+    communicator: Communicator;
     updateListener: StateUpdateListener;
   }) {
     this.metadata = params.metadata;
-    this.waitForPopupLoaded = params.waitForPopupLoaded;
-    this.postMessageToPopup = params.postMessageToPopup;
+    this.communicator = params.communicator;
     this.keyManager = new SCWKeyManager();
     this.stateManager = new SCWStateManager({
       appChainIds: this.metadata.appChainIds,
@@ -55,7 +53,9 @@ export class SCWSigner implements Signer {
         params: this.metadata,
       },
     });
-    const response: RPCResponseMessage = await this.postMessageToPopup(handshakeMessage);
+    const response: RPCResponseMessage = await this.communicator.postRequestAndWaitForResponse(
+      handshakeMessage
+    );
 
     // store peer's public key
     if ('failure' in response.content) throw response.content.failure;
@@ -80,7 +80,7 @@ export class SCWSigner implements Signer {
 
     // Open the popup before constructing the request message.
     // This is to ensure that the popup is not blocked by some browsers (i.e. Safari)
-    await this.waitForPopupLoaded();
+    await this.communicator.waitForPopupLoaded();
 
     const response = await this.sendEncryptedRequest(request);
     const decrypted = await this.decryptResponseMessage<T>(response);
@@ -142,7 +142,7 @@ export class SCWSigner implements Signer {
     );
     const message = await this.createRequestMessage({ encrypted });
 
-    return this.postMessageToPopup(message);
+    return this.communicator.postRequestAndWaitForResponse(message);
   }
 
   private async createRequestMessage(

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -48,6 +48,7 @@ export function createSigner(params: {
       return new SCWSigner({
         metadata,
         updateListener,
+        waitForPopupLoaded: communicator.waitForPopupLoaded,
         postMessageToPopup: communicator.postRequestAndWaitForResponse,
       });
     case 'walletlink':

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -48,8 +48,7 @@ export function createSigner(params: {
       return new SCWSigner({
         metadata,
         updateListener,
-        waitForPopupLoaded: communicator.waitForPopupLoaded,
-        postMessageToPopup: communicator.postRequestAndWaitForResponse,
+        communicator,
       });
     case 'walletlink':
       return new WalletLinkSigner({


### PR DESCRIPTION
### _Summary_

- Safari was blocking the popup from opening whenever a request was sent. This is because the request message is being constructed before the popup is opened in `SCWSigner`. Safari blocks it because it is not opened immediately after a button is clicked.
  - This PR updates the `request` method so that it first opens the popup and then constructs the request. This is how it was done before [this PR](https://github.com/coinbase/coinbase-wallet-sdk/pull/1260)
<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

- Manually:

| Before | After |
| ------------- | ------------- |
| <video src="https://github.com/coinbase/coinbase-wallet-sdk/assets/16995513/619d30b6-ca27-4401-b979-a462a2935a0a">  | <video src="https://github.com/coinbase/coinbase-wallet-sdk/assets/16995513/bf69b157-c3d6-41d9-81fa-cee43cc02b35">|







<!--
  Verify changes. Include relevant screenshots/videos
-->
