### PR TITLE
Fix playground example send: don't send to wallets own address 

### DIFF
--- a/apps/testapp/src/components/RpcMethods/shortcut/sendShortcuts.ts
+++ b/apps/testapp/src/components/RpcMethods/shortcut/sendShortcuts.ts
@@ -6,7 +6,7 @@ const ethSendTransactionShortcuts: ShortcutType[] = [
     key: 'Example Tx',
     data: {
       from: ADDR_TO_FILL,
-      to: ADDR_TO_FILL,
+      to: '0xd7876e5dbd2da268a35416ba75d0ce154ed949e3',
       value: '0x0',
     },
   },

--- a/apps/testapp/src/components/RpcMethods/shortcut/sendShortcuts.ts
+++ b/apps/testapp/src/components/RpcMethods/shortcut/sendShortcuts.ts
@@ -6,7 +6,7 @@ const ethSendTransactionShortcuts: ShortcutType[] = [
     key: 'Example Tx',
     data: {
       from: ADDR_TO_FILL,
-      to: '0xd7876e5dbd2da268a35416ba75d0ce154ed949e3',
+      to: '0x0000000000000000000000000000000000000000',
       value: '0x0',
     },
   },


### PR DESCRIPTION
dapps are blocked from calling directly to the smart wallet's address

### _Summary_

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
