### PR TITLE
Add alert when popup is blocked

### DIFF
--- a/packages/wallet-sdk/src/core/communicator/util.test.ts
+++ b/packages/wallet-sdk/src/core/communicator/util.test.ts
@@ -59,7 +59,9 @@ describe('Communicator util', () => {
 
       expect(() => openPopup(url)).toThrowError('Pop up window failed to open');
       expect(window.alert).toHaveBeenCalledTimes(1);
-      expect(window.alert).toHaveBeenCalledWith('Please disable your pop-up blocker and try again');
+      expect(window.alert).toHaveBeenCalledWith(
+        'Smart wallet pop up failed, please disable your pop up blocker and try again.'
+      );
     });
   });
 

--- a/packages/wallet-sdk/src/core/communicator/util.test.ts
+++ b/packages/wallet-sdk/src/core/communicator/util.test.ts
@@ -1,0 +1,91 @@
+import { closePopup, openPopup } from './util';
+
+describe('Communicator util', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('openPopup', () => {
+    it('opens a popup window', () => {
+      const url = new URL('https://keys.coinbase.com');
+      const mockFocus = jest.fn();
+
+      const windowSpy = jest.spyOn(window, 'open').mockImplementation(() => {
+        return {
+          focus: mockFocus,
+        } as any;
+      });
+
+      openPopup(url);
+
+      expect(windowSpy).toHaveBeenCalledTimes(1);
+      expect(windowSpy).toHaveBeenCalledWith(url, 'Smart Wallet', expect.any(String));
+      expect(mockFocus).toHaveBeenCalled();
+    });
+
+    it('uses the correct dimensions and location for the popup window', () => {
+      const url = new URL('https://keys.coinbase.com');
+
+      const mockScreenXY = 100;
+      const mockScreenInnerWidthHeight = 50;
+      Object.defineProperty(window, 'screenX', { value: mockScreenXY });
+      Object.defineProperty(window, 'screenY', { value: mockScreenXY });
+      Object.defineProperty(window, 'innerWidth', { value: mockScreenInnerWidthHeight });
+      Object.defineProperty(window, 'innerHeight', { value: mockScreenInnerWidthHeight });
+
+      const windowSpy = jest.spyOn(window, 'open').mockImplementation(() => {
+        return {
+          focus: jest.fn(),
+        } as any;
+      });
+
+      openPopup(url);
+
+      const expectedWidth = 420;
+      const expectedHeight = 540;
+      const expectedLeft = (mockScreenInnerWidthHeight - expectedWidth) / 2 + mockScreenXY;
+      const expectedTop = (mockScreenInnerWidthHeight - expectedHeight) / 2 + mockScreenXY;
+      expect(windowSpy).toHaveBeenCalledWith(
+        url,
+        'Smart Wallet',
+        `width=${expectedWidth}, height=${expectedHeight}, left=${expectedLeft}, top=${expectedTop}`
+      );
+    });
+
+    it('displays an alert and throws an error if the popup fails to open', () => {
+      const url = new URL('https://keys.coinbase.com');
+      jest.spyOn(window, 'open').mockReturnValue(null);
+      jest.spyOn(window, 'alert').mockImplementation();
+
+      expect(() => openPopup(url)).toThrowError('Pop up window failed to open');
+      expect(window.alert).toHaveBeenCalledTimes(1);
+      expect(window.alert).toHaveBeenCalledWith('Please disable your pop-up blocker and try again');
+    });
+  });
+
+  describe('closePopup', () => {
+    it('closes the popup window', () => {
+      const mockClose = jest.fn();
+      const popup = {
+        close: mockClose,
+        closed: false,
+      } as any;
+
+      closePopup(popup);
+
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing if the popup is already closed', () => {
+      const mockClose = jest.fn();
+      const popup = {
+        close: mockClose,
+        closed: true,
+      } as any;
+
+      closePopup(popup);
+
+      expect(mockClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/wallet-sdk/src/core/communicator/util.ts
+++ b/packages/wallet-sdk/src/core/communicator/util.ts
@@ -19,7 +19,7 @@ export function openPopup(url: URL): Window {
     popup.focus();
   } else {
     // The popup may fail to open if the user has a pop-up blocker enabled
-    alert('Please disable your pop-up blocker and try again');
+    alert('Smart wallet pop up failed, please disable your pop up blocker and try again.');
     throw standardErrors.rpc.internal('Pop up window failed to open');
   }
 

--- a/packages/wallet-sdk/src/core/communicator/util.ts
+++ b/packages/wallet-sdk/src/core/communicator/util.ts
@@ -14,10 +14,15 @@ export function openPopup(url: URL): Window {
     'Smart Wallet',
     `width=${POPUP_WIDTH}, height=${POPUP_HEIGHT}, left=${left}, top=${top}`
   );
-  popup?.focus();
-  if (!popup) {
+
+  if (popup) {
+    popup.focus();
+  } else {
+    // The popup may fail to open if the user has a pop-up blocker enabled
+    alert('Please disable your pop-up blocker and try again');
     throw standardErrors.rpc.internal('Pop up window failed to open');
   }
+
   return popup;
 }
 


### PR DESCRIPTION
### _Summary_

- While it's unlikely, the popup may get blocked on some browsers due to strict popup blockers. This PR adds an alert to inform the user to disable their popup blocker when the popup gets blocked.

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

- Manually and unit tests

How to test:
1. Comment out [this line](https://github.com/coinbase/coinbase-wallet-sdk/blob/master/packages/wallet-sdk/src/sign/scw/SCWSigner.ts#L83)
2. Attempt to sign a transaction using the test app


https://github.com/coinbase/coinbase-wallet-sdk/assets/16995513/7b6584a3-8bef-4226-a43f-367124e960ea



<!--
  Verify changes. Include relevant screenshots/videos
-->
