### PR TITLE
Fix popup not opening on iPad

### DIFF
--- a/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
@@ -53,6 +53,7 @@ describe('Communicator', () => {
     mockPopup = {
       postMessage: jest.fn(),
       close: jest.fn(),
+      closed: false,
     } as unknown as Window;
     (openPopup as jest.Mock).mockImplementation(() => mockPopup);
   });
@@ -98,9 +99,7 @@ describe('Communicator', () => {
   });
 
   it('should not open a popup window if one is already open', async () => {
-    // First call to waitForPopupLoaded
     queueMessageEvent(popupLoadedMessage);
-    // Second call to waitForPopupLoaded
     await communicator.waitForPopupLoaded();
 
     expect(openPopup).toHaveBeenCalledTimes(1);
@@ -110,13 +109,12 @@ describe('Communicator', () => {
     mockPopup = {
       postMessage: jest.fn(),
       close: jest.fn(),
+      // Simulate the popup being closed
       closed: true,
     } as unknown as Window;
     (openPopup as jest.Mock).mockImplementation(() => mockPopup);
 
-    // First call to waitForPopupLoaded
     queueMessageEvent(popupLoadedMessage);
-    // Second call to waitForPopupLoaded
     await communicator.waitForPopupLoaded();
 
     expect(openPopup).toHaveBeenCalledTimes(2);

--- a/packages/wallet-sdk/src/core/communicator/Communicator.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.ts
@@ -80,7 +80,7 @@ export class Communicator {
    * Waits for the popup window to fully load and then sends a version message.
    */
   waitForPopupLoaded = async (): Promise<Window> => {
-    if (this.popup) return this.popup;
+    if (this.popup && !this.popup.closed) return this.popup;
 
     this.popup = openPopup(this.url);
 


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

- There's an issue on iPads where the object returned from `window.open` stays defined even after the window/tab is closed. This causes the popup to not be opened when one was opened in the past due to this line of code:
https://github.com/coinbase/coinbase-wallet-sdk/blob/53f37742c40ff5c20f6c652611b322c318332328/packages/wallet-sdk/src/core/communicator/Communicator.ts#L82-L83

- To solve this, I added a check for `popup.closed` on the same line, so that the popup is opened again when it's closed

### _How did you test your changes?_

- Manually and unit tests
- Also verified that it's still working as expected on other devices

<!--
  Verify changes. Include relevant screenshots/videos
-->

| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/coinbase/coinbase-wallet-sdk/assets/16995513/f1043bb0-79c9-4c22-b45c-1d846c6f5db7">  | <video src="https://github.com/coinbase/coinbase-wallet-sdk/assets/16995513/380bcbb4-96ad-43bb-8486-0befef5eb463">|





