### PR TITLE
make eth_chainId comply with spec

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -27,7 +27,7 @@ describe('CoinbaseWalletProvider', () => {
     test('handles request correctly', async () => {
       const provider = createProvider();
       const response1 = await provider.request({ method: 'eth_chainId' });
-      expect(response1).toBe(1);
+      expect(response1).toBe('0x1');
     });
 
     test('throws error when handling invalid request', async () => {

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -107,6 +107,7 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
       };
       switch (request.method) {
         case 'eth_chainId':
+          return hexStringFromIntNumber(IntNumber(this.chain.id));
         case 'net_version':
           return this.chain.id;
         case 'eth_accounts':


### PR DESCRIPTION
### _Summary_
Make `eth_chainId` match the spec. It should return a hex string.

https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainid
