### PR TITLE
Re-focus the popup between requests

### DIFF
--- a/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
@@ -44,7 +44,10 @@ const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
 describe('Communicator', () => {
   let urlOrigin: string;
   let communicator: Communicator;
-  let mockPopup: Pick<Exclude<Communicator['popup'], null>, 'postMessage' | 'close' | 'closed'>;
+  let mockPopup: Pick<
+    Exclude<Communicator['popup'], null>,
+    'postMessage' | 'close' | 'closed' | 'focus'
+  >;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -57,6 +60,7 @@ describe('Communicator', () => {
       postMessage: jest.fn(),
       close: jest.fn(),
       closed: false,
+      focus: jest.fn(),
     } as unknown as Window;
     (openPopup as jest.Mock).mockImplementation(() => mockPopup);
   });
@@ -148,10 +152,19 @@ describe('Communicator', () => {
       expect(popup).toBeTruthy();
     });
 
-    it('should not open a popup window if one is already open', async () => {
+    it('should re-focus and return the existing popup window if one is already open.', async () => {
+      mockPopup = {
+        postMessage: jest.fn(),
+        close: jest.fn(),
+        closed: false,
+        focus: jest.fn(),
+      } as unknown as Window;
+      (openPopup as jest.Mock).mockImplementationOnce(() => mockPopup);
+
       queueMessageEvent(popupLoadedMessage);
       await communicator.waitForPopupLoaded();
 
+      expect(mockPopup.focus).toHaveBeenCalledTimes(1);
       expect(openPopup).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/wallet-sdk/src/core/communicator/Communicator.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.ts
@@ -80,7 +80,11 @@ export class Communicator {
    * Waits for the popup window to fully load and then sends a version message.
    */
   waitForPopupLoaded = async (): Promise<Window> => {
-    if (this.popup && !this.popup.closed) return this.popup;
+    if (this.popup && !this.popup.closed) {
+      // In case the user un-focused the popup between requests, focus it again
+      this.popup.focus();
+      return this.popup;
+    }
 
     this.popup = openPopup(this.url);
 


### PR DESCRIPTION
### _Summary_

- It's possible for a user to leave the popup open between requests, especially after onboarding when the popup is not closed programmatically. Because of this, when a new request comes through, the popup doesn't re-focus itself and updates in the background. This leads to a bad UX since the user can't see the popup and has to manually re open it.
  - This PR simply calls `popup.focus()` every time a new request comes to an already open popup. This ensures that the popup doesn't stay hidden in the background when a user performs an action on a dapp

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

- Manually and unit tests

### **BEFORE:**
https://github.com/coinbase/coinbase-wallet-sdk/assets/16995513/47df2600-d3e0-4864-bd5c-c3918473838a

### **AFTER:**

https://github.com/coinbase/coinbase-wallet-sdk/assets/16995513/7e738c17-869f-43aa-8088-083ffe2cf1c7




<!--
  Verify changes. Include relevant screenshots/videos
-->
