### PR TITLE
replace sha.js and keccak with smaller and more secure @noble/hashes

### DIFF
--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -28,11 +28,10 @@
     "lint": "eslint . --ext .ts,.tsx --fix"
   },
   "dependencies": {
+    "@noble/hashes": "^1.4.0",
     "buffer": "^6.0.3",
     "clsx": "^1.2.1",
     "eventemitter3": "^5.0.1",
-    "js-sha256": "^0.11.0",
-    "keccak": "^3.0.3",
     "preact": "^10.16.0"
   },
   "devDependencies": {

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -64,6 +64,5 @@
     "tsc-alias": "^1.8.8",
     "tslib": "^2.6.0",
     "typescript": "^5.1.6"
-  },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  }
 }

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -31,9 +31,9 @@
     "buffer": "^6.0.3",
     "clsx": "^1.2.1",
     "eventemitter3": "^5.0.1",
+    "js-sha256": "^0.11.0",
     "keccak": "^3.0.3",
-    "preact": "^10.16.0",
-    "sha.js": "^2.4.11"
+    "preact": "^10.16.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.9",
@@ -46,7 +46,6 @@
     "@testing-library/preact": "^2.0.1",
     "@types/jest": "^27.5.2",
     "@types/node": "^14.18.54",
-    "@types/sha.js": "^2.4.1",
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
     "babel-jest": "^27.5.1",

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -65,5 +65,6 @@
     "tsc-alias": "^1.8.8",
     "tslib": "^2.6.0",
     "typescript": "^5.1.6"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.4.0",
-    "buffer": "^6.0.3",
     "clsx": "^1.2.1",
     "eventemitter3": "^5.0.1",
     "preact": "^10.16.0"

--- a/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2023 Coinbase, Inc. <https://www.coinbase.com/>
 
-import { sha256 } from 'js-sha256';
+import { sha256 } from '@noble/hashes/sha256';
 
 import { randomBytesHex } from ':core/type/util';
 import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
@@ -21,10 +21,9 @@ export class WalletLinkSession {
     this._id = id || randomBytesHex(16);
     this._secret = secret || randomBytesHex(32);
 
-    this._key = sha256
-      .create()
-      .update(`${this._id}, ${this._secret} WalletLink`) // ensure old sessions stay connected
-      .hex();
+    const hash = sha256.create().update(`${this._id}, ${this._secret} WalletLink`).digest();
+
+    this._key = Array.from(hash, (byte) => byte.toString(16).padStart(2, '0')).join('');
 
     this._linked = !!linked;
   }

--- a/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2023 Coinbase, Inc. <https://www.coinbase.com/>
 
-import { sha256 } from 'sha.js';
+import { sha256 } from 'js-sha256';
 
 import { randomBytesHex } from ':core/type/util';
 import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
@@ -21,9 +21,10 @@ export class WalletLinkSession {
     this._id = id || randomBytesHex(16);
     this._secret = secret || randomBytesHex(32);
 
-    this._key = new sha256()
+    this._key = sha256
+      .create()
       .update(`${this._id}, ${this._secret} WalletLink`) // ensure old sessions stay connected
-      .digest('hex');
+      .hex();
 
     this._linked = !!linked;
   }

--- a/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2018-2023 Coinbase, Inc. <https://www.coinbase.com/>
 
 import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
 
 import { randomBytesHex } from ':core/type/util';
 import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
@@ -21,9 +22,7 @@ export class WalletLinkSession {
     this._id = id || randomBytesHex(16);
     this._secret = secret || randomBytesHex(32);
 
-    const hash = sha256.create().update(`${this._id}, ${this._secret} WalletLink`).digest();
-
-    this._key = Array.from(hash, (byte) => byte.toString(16).padStart(2, '0')).join('');
+    this._key = bytesToHex(sha256(`${this._id}, ${this._secret} WalletLink`));
 
     this._linked = !!linked;
   }

--- a/packages/wallet-sdk/src/vendor-js/eth-eip712-util/index.js
+++ b/packages/wallet-sdk/src/vendor-js/eth-eip712-util/index.js
@@ -1,5 +1,6 @@
-const util = require('./util')
-const abi = require('./abi')
+/* eslint-disable @typescript-eslint/no-var-requires */
+const util = require('./util');
+const abi = require('./abi');
 
 const TYPED_MESSAGE_SCHEMA = {
   type: 'object',
@@ -11,19 +12,19 @@ const TYPED_MESSAGE_SCHEMA = {
         items: {
           type: 'object',
           properties: {
-            name: {type: 'string'},
-            type: {type: 'string'},
+            name: { type: 'string' },
+            type: { type: 'string' },
           },
           required: ['name', 'type'],
         },
       },
     },
-    primaryType: {type: 'string'},
-    domain: {type: 'object'},
-    message: {type: 'object'},
+    primaryType: { type: 'string' },
+    domain: { type: 'object' },
+    message: { type: 'object' },
   },
   required: ['types', 'primaryType', 'domain', 'message'],
-}
+};
 
 /**
  * A collection of utility functions used for signing typed data
@@ -37,82 +38,88 @@ const TypedDataUtils = {
    * @param {Object} types - Type definitions
    * @returns {string} - Encoded representation of an object
    */
-  encodeData (primaryType, data, types, useV4 = true) {
-    const encodedTypes = ['bytes32']
-    const encodedValues = [this.hashType(primaryType, types)]
+  encodeData(primaryType, data, types, useV4 = true) {
+    const encodedTypes = ['bytes32'];
+    const encodedValues = [this.hashType(primaryType, types)];
 
-    if(useV4) {
+    if (useV4) {
       const encodeField = (name, type, value) => {
         if (types[type] !== undefined) {
-          return ['bytes32', value == null ?
-            '0x0000000000000000000000000000000000000000000000000000000000000000' :
-            util.keccak(this.encodeData(type, value, types, useV4))]
+          return [
+            'bytes32',
+            value == null
+              ? '0x0000000000000000000000000000000000000000000000000000000000000000'
+              : util.keccak(this.encodeData(type, value, types, useV4)),
+          ];
         }
 
-        if(value === undefined)
-          throw new Error(`missing value for field ${name} of type ${type}`)
+        if (value === undefined) throw new Error(`missing value for field ${name} of type ${type}`);
 
         if (type === 'bytes') {
-          return ['bytes32', util.keccak(value)]
+          return ['bytes32', util.keccak(value)];
         }
 
         if (type === 'string') {
           // convert string to buffer - prevents ethUtil from interpreting strings like '0xabcd' as hex
           if (typeof value === 'string') {
-            value = Buffer.from(value, 'utf8')
+            value = Buffer.from(value, 'utf8');
           }
-          return ['bytes32', util.keccak(value)]
+          return ['bytes32', util.keccak(value)];
         }
 
         if (type.lastIndexOf(']') === type.length - 1) {
-          const parsedType = type.slice(0, type.lastIndexOf('['))
-          const typeValuePairs = value.map(item =>
-            encodeField(name, parsedType, item))
-          return ['bytes32', util.keccak(abi.rawEncode(
-            typeValuePairs.map(([type]) => type),
-            typeValuePairs.map(([, value]) => value),
-          ))]
+          const parsedType = type.slice(0, type.lastIndexOf('['));
+          const typeValuePairs = value.map((item) => encodeField(name, parsedType, item));
+          return [
+            'bytes32',
+            util.keccak(
+              abi.rawEncode(
+                typeValuePairs.map(([type]) => type),
+                typeValuePairs.map(([, value]) => value)
+              )
+            ),
+          ];
         }
 
-        return [type, value]
-      }
+        return [type, value];
+      };
 
       for (const field of types[primaryType]) {
-        const [type, value] = encodeField(field.name, field.type, data[field.name])
-        encodedTypes.push(type)
-        encodedValues.push(value)
+        const [type, value] = encodeField(field.name, field.type, data[field.name]);
+        encodedTypes.push(type);
+        encodedValues.push(value);
       }
     } else {
       for (const field of types[primaryType]) {
-        let value = data[field.name]
+        let value = data[field.name];
         if (value !== undefined) {
           if (field.type === 'bytes') {
-            encodedTypes.push('bytes32')
-            value = util.keccak(value)
-            encodedValues.push(value)
+            encodedTypes.push('bytes32');
+            value = util.keccak(value);
+            encodedValues.push(value);
           } else if (field.type === 'string') {
-            encodedTypes.push('bytes32')
+            encodedTypes.push('bytes32');
             // convert string to buffer - prevents ethUtil from interpreting strings like '0xabcd' as hex
             if (typeof value === 'string') {
-              value = Buffer.from(value, 'utf8')
+              value = Buffer.from(value, 'utf8');
             }
-            value = util.keccak(value)
-            encodedValues.push(value)
+            value = util.keccak(value);
+            encodedValues.push(value);
           } else if (types[field.type] !== undefined) {
-            encodedTypes.push('bytes32')
-            value = util.keccak(this.encodeData(field.type, value, types, useV4))
-            encodedValues.push(value)
+            encodedTypes.push('bytes32');
+            value = util.keccak(this.encodeData(field.type, value, types, useV4));
+            encodedValues.push(value);
           } else if (field.type.lastIndexOf(']') === field.type.length - 1) {
-            throw new Error('Arrays currently unimplemented in encodeData')
+            throw new Error('Arrays currently unimplemented in encodeData');
           } else {
-            encodedTypes.push(field.type)
-            encodedValues.push(value)
+            encodedTypes.push(field.type);
+            encodedValues.push(value);
           }
         }
       }
     }
 
-    return abi.rawEncode(encodedTypes, encodedValues)
+    return abi.rawEncode(encodedTypes, encodedValues);
   },
 
   /**
@@ -122,18 +129,18 @@ const TypedDataUtils = {
    * @param {Object} types - Type definitions
    * @returns {string} - Encoded representation of the type of an object
    */
-  encodeType (primaryType, types) {
-    let result = ''
-    let deps = this.findTypeDependencies(primaryType, types).filter(dep => dep !== primaryType)
-    deps = [primaryType].concat(deps.sort())
+  encodeType(primaryType, types) {
+    let result = '';
+    let deps = this.findTypeDependencies(primaryType, types).filter((dep) => dep !== primaryType);
+    deps = [primaryType].concat(deps.sort());
     for (const type of deps) {
-      const children = types[type]
+      const children = types[type];
       if (!children) {
-        throw new Error('No type definition specified: ' + type)
+        throw new Error('No type definition specified: ' + type);
       }
-      result += type + '(' + types[type].map(({ name, type }) => type + ' ' + name).join(',') + ')'
+      result += type + '(' + types[type].map(({ name, type }) => type + ' ' + name).join(',') + ')';
     }
-    return result
+    return result;
   },
 
   /**
@@ -144,16 +151,18 @@ const TypedDataUtils = {
    * @param {Array} results - current set of accumulated types
    * @returns {Array} - Set of all types found in the type definition
    */
-  findTypeDependencies (primaryType, types, results = []) {
-    primaryType = primaryType.match(/^\w*/)[0]
-    if (results.includes(primaryType) || types[primaryType] === undefined) { return results }
-    results.push(primaryType)
+  findTypeDependencies(primaryType, types, results = []) {
+    primaryType = primaryType.match(/^\w*/)[0];
+    if (results.includes(primaryType) || types[primaryType] === undefined) {
+      return results;
+    }
+    results.push(primaryType);
     for (const field of types[primaryType]) {
       for (const dep of this.findTypeDependencies(field.type, types, results)) {
-        !results.includes(dep) && results.push(dep)
+        !results.includes(dep) && results.push(dep);
       }
     }
-    return results
+    return results;
   },
 
   /**
@@ -164,8 +173,8 @@ const TypedDataUtils = {
    * @param {Object} types - Type definitions
    * @returns {Buffer} - Hash of an object
    */
-  hashStruct (primaryType, data, types, useV4 = true) {
-    return util.keccak(this.encodeData(primaryType, data, types, useV4))
+  hashStruct(primaryType, data, types, useV4 = true) {
+    return util.keccak(this.encodeData(primaryType, data, types, useV4));
   },
 
   /**
@@ -175,8 +184,8 @@ const TypedDataUtils = {
    * @param {Object} types - Type definitions
    * @returns {string} - Hash of an object
    */
-  hashType (primaryType, types) {
-    return util.keccak(this.encodeType(primaryType, types))
+  hashType(primaryType, types) {
+    return util.keccak(this.encodeType(primaryType, types));
   },
 
   /**
@@ -185,15 +194,15 @@ const TypedDataUtils = {
    * @param {Object} data - typed message object
    * @returns {Object} - typed message object with only allowed fields
    */
-  sanitizeData (data) {
-    const sanitizedData = {}
+  sanitizeData(data) {
+    const sanitizedData = {};
     for (const key in TYPED_MESSAGE_SCHEMA.properties) {
-      data[key] && (sanitizedData[key] = data[key])
+      data[key] && (sanitizedData[key] = data[key]);
     }
     if (sanitizedData.types) {
-      sanitizedData.types = Object.assign({ EIP712Domain: [] }, sanitizedData.types)
+      sanitizedData.types = Object.assign({ EIP712Domain: [] }, sanitizedData.types);
     }
-    return sanitizedData
+    return sanitizedData;
   },
 
   /**
@@ -202,56 +211,65 @@ const TypedDataUtils = {
    * @param {Object} typedData - Types message data to sign
    * @returns {string} - sha3 hash for signing
    */
-  hash (typedData, useV4 = true) {
-    const sanitizedData = this.sanitizeData(typedData)
-    const parts = [Buffer.from('1901', 'hex')]
-    parts.push(this.hashStruct('EIP712Domain', sanitizedData.domain, sanitizedData.types, useV4))
+  hash(typedData, useV4 = true) {
+    const sanitizedData = this.sanitizeData(typedData);
+    const parts = [Buffer.from('1901', 'hex')];
+    parts.push(this.hashStruct('EIP712Domain', sanitizedData.domain, sanitizedData.types, useV4));
     if (sanitizedData.primaryType !== 'EIP712Domain') {
-      parts.push(this.hashStruct(sanitizedData.primaryType, sanitizedData.message, sanitizedData.types, useV4))
+      parts.push(
+        this.hashStruct(
+          sanitizedData.primaryType,
+          sanitizedData.message,
+          sanitizedData.types,
+          useV4
+        )
+      );
     }
-    return util.keccak(Buffer.concat(parts))
+    return util.keccak(Buffer.concat(parts));
   },
-}
+};
 
 module.exports = {
   TYPED_MESSAGE_SCHEMA,
   TypedDataUtils,
 
   hashForSignTypedDataLegacy: function (msgParams) {
-    return typedSignatureHashLegacy(msgParams.data)
+    return typedSignatureHashLegacy(msgParams.data);
   },
 
   hashForSignTypedData_v3: function (msgParams) {
-    return TypedDataUtils.hash(msgParams.data, false)
+    return TypedDataUtils.hash(msgParams.data, false);
   },
 
   hashForSignTypedData_v4: function (msgParams) {
-    return TypedDataUtils.hash(msgParams.data)
+    return TypedDataUtils.hash(msgParams.data);
   },
-}
+};
 
 /**
  * @param typedData - Array of data along with types, as per EIP712.
  * @returns Buffer
  */
 function typedSignatureHashLegacy(typedData) {
-  const error = new Error('Expect argument to be non-empty array')
-  if (typeof typedData !== 'object' || !typedData.length) throw error
+  const error = new Error('Expect argument to be non-empty array');
+  if (typeof typedData !== 'object' || !typedData.length) throw error;
 
   const data = typedData.map(function (e) {
-    return e.type === 'bytes' ? util.toBuffer(e.value) : e.value
-  })
-  const types = typedData.map(function (e) { return e.type })
+    return e.type === 'bytes' ? util.toBuffer(e.value) : e.value;
+  });
+  const types = typedData.map(function (e) {
+    return e.type;
+  });
   const schema = typedData.map(function (e) {
-    if (!e.name) throw error
-    return e.type + ' ' + e.name
-  })
+    if (!e.name) throw error;
+    return e.type + ' ' + e.name;
+  });
 
   return abi.soliditySHA3(
     ['bytes32', 'bytes32'],
     [
       abi.soliditySHA3(new Array(typedData.length).fill('string'), schema),
-      abi.soliditySHA3(types, data)
+      abi.soliditySHA3(types, data),
     ]
-  )
+  );
 }

--- a/packages/wallet-sdk/src/vendor-js/eth-eip712-util/index.js
+++ b/packages/wallet-sdk/src/vendor-js/eth-eip712-util/index.js
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const util = require('./util');
-const abi = require('./abi');
+const util = require('./util')
+const abi = require('./abi')
 
 const TYPED_MESSAGE_SCHEMA = {
   type: 'object',
@@ -12,19 +11,19 @@ const TYPED_MESSAGE_SCHEMA = {
         items: {
           type: 'object',
           properties: {
-            name: { type: 'string' },
-            type: { type: 'string' },
+            name: {type: 'string'},
+            type: {type: 'string'},
           },
           required: ['name', 'type'],
         },
       },
     },
-    primaryType: { type: 'string' },
-    domain: { type: 'object' },
-    message: { type: 'object' },
+    primaryType: {type: 'string'},
+    domain: {type: 'object'},
+    message: {type: 'object'},
   },
   required: ['types', 'primaryType', 'domain', 'message'],
-};
+}
 
 /**
  * A collection of utility functions used for signing typed data
@@ -38,88 +37,82 @@ const TypedDataUtils = {
    * @param {Object} types - Type definitions
    * @returns {string} - Encoded representation of an object
    */
-  encodeData(primaryType, data, types, useV4 = true) {
-    const encodedTypes = ['bytes32'];
-    const encodedValues = [this.hashType(primaryType, types)];
+  encodeData (primaryType, data, types, useV4 = true) {
+    const encodedTypes = ['bytes32']
+    const encodedValues = [this.hashType(primaryType, types)]
 
-    if (useV4) {
+    if(useV4) {
       const encodeField = (name, type, value) => {
         if (types[type] !== undefined) {
-          return [
-            'bytes32',
-            value == null
-              ? '0x0000000000000000000000000000000000000000000000000000000000000000'
-              : util.keccak(this.encodeData(type, value, types, useV4)),
-          ];
+          return ['bytes32', value == null ?
+            '0x0000000000000000000000000000000000000000000000000000000000000000' :
+            util.keccak(this.encodeData(type, value, types, useV4))]
         }
 
-        if (value === undefined) throw new Error(`missing value for field ${name} of type ${type}`);
+        if(value === undefined)
+          throw new Error(`missing value for field ${name} of type ${type}`)
 
         if (type === 'bytes') {
-          return ['bytes32', util.keccak(value)];
+          return ['bytes32', util.keccak(value)]
         }
 
         if (type === 'string') {
           // convert string to buffer - prevents ethUtil from interpreting strings like '0xabcd' as hex
           if (typeof value === 'string') {
-            value = Buffer.from(value, 'utf8');
+            value = Buffer.from(value, 'utf8')
           }
-          return ['bytes32', util.keccak(value)];
+          return ['bytes32', util.keccak(value)]
         }
 
         if (type.lastIndexOf(']') === type.length - 1) {
-          const parsedType = type.slice(0, type.lastIndexOf('['));
-          const typeValuePairs = value.map((item) => encodeField(name, parsedType, item));
-          return [
-            'bytes32',
-            util.keccak(
-              abi.rawEncode(
-                typeValuePairs.map(([type]) => type),
-                typeValuePairs.map(([, value]) => value)
-              )
-            ),
-          ];
+          const parsedType = type.slice(0, type.lastIndexOf('['))
+          const typeValuePairs = value.map(item =>
+            encodeField(name, parsedType, item))
+          return ['bytes32', util.keccak(abi.rawEncode(
+            typeValuePairs.map(([type]) => type),
+            typeValuePairs.map(([, value]) => value),
+          ))]
         }
 
-        return [type, value];
-      };
+        return [type, value]
+      }
 
       for (const field of types[primaryType]) {
-        const [type, value] = encodeField(field.name, field.type, data[field.name]);
-        encodedTypes.push(type);
-        encodedValues.push(value);
+        const [type, value] = encodeField(field.name, field.type, data[field.name])
+        encodedTypes.push(type)
+        encodedValues.push(value)
       }
     } else {
       for (const field of types[primaryType]) {
-        let value = data[field.name];
+        let value = data[field.name]
         if (value !== undefined) {
           if (field.type === 'bytes') {
-            encodedTypes.push('bytes32');
-            value = util.keccak(value);
-            encodedValues.push(value);
+            encodedTypes.push('bytes32')
+            value = util.keccak(value)
+            encodedValues.push(value)
           } else if (field.type === 'string') {
-            encodedTypes.push('bytes32');
+            encodedTypes.push('bytes32')
             // convert string to buffer - prevents ethUtil from interpreting strings like '0xabcd' as hex
             if (typeof value === 'string') {
-              value = Buffer.from(value, 'utf8');
+              value = Buffer.from(value, 'utf8')
             }
-            value = util.keccak(value);
-            encodedValues.push(value);
+            value = util.keccak(value)
+            encodedValues.push(value)
           } else if (types[field.type] !== undefined) {
-            encodedTypes.push('bytes32');
-            value = util.keccak(this.encodeData(field.type, value, types, useV4));
-            encodedValues.push(value);
+            encodedTypes.push('bytes32')
+            value = util.keccak(this.encodeData(field.type, value, types, useV4))
+            encodedValues.push(value)
           } else if (field.type.lastIndexOf(']') === field.type.length - 1) {
-            throw new Error('Arrays currently unimplemented in encodeData');
+            throw new Error('Arrays currently unimplemented in encodeData')
           } else {
-            encodedTypes.push(field.type);
-            encodedValues.push(value);
+            encodedTypes.push(field.type)
+            encodedValues.push(value)
           }
         }
       }
     }
 
-    return abi.rawEncode(encodedTypes, encodedValues);
+    return abi.rawEncode(encodedTypes, encodedValues)
   },
 
   /**
@@ -129,18 +122,18 @@ const TypedDataUtils = {
    * @param {Object} types - Type definitions
    * @returns {string} - Encoded representation of the type of an object
    */
-  encodeType(primaryType, types) {
-    let result = '';
-    let deps = this.findTypeDependencies(primaryType, types).filter((dep) => dep !== primaryType);
-    deps = [primaryType].concat(deps.sort());
+  encodeType (primaryType, types) {
+    let result = ''
+    let deps = this.findTypeDependencies(primaryType, types).filter(dep => dep !== primaryType)
+    deps = [primaryType].concat(deps.sort())
     for (const type of deps) {
-      const children = types[type];
+      const children = types[type]
       if (!children) {
-        throw new Error('No type definition specified: ' + type);
+        throw new Error('No type definition specified: ' + type)
       }
-      result += type + '(' + types[type].map(({ name, type }) => type + ' ' + name).join(',') + ')';
+      result += type + '(' + types[type].map(({ name, type }) => type + ' ' + name).join(',') + ')'
     }
-    return result;
+    return result
   },
 
   /**
@@ -151,18 +144,16 @@ const TypedDataUtils = {
    * @param {Array} results - current set of accumulated types
    * @returns {Array} - Set of all types found in the type definition
    */
-  findTypeDependencies(primaryType, types, results = []) {
-    primaryType = primaryType.match(/^\w*/)[0];
-    if (results.includes(primaryType) || types[primaryType] === undefined) {
-      return results;
-    }
-    results.push(primaryType);
+  findTypeDependencies (primaryType, types, results = []) {
+    primaryType = primaryType.match(/^\w*/)[0]
+    if (results.includes(primaryType) || types[primaryType] === undefined) { return results }
+    results.push(primaryType)
     for (const field of types[primaryType]) {
       for (const dep of this.findTypeDependencies(field.type, types, results)) {
-        !results.includes(dep) && results.push(dep);
+        !results.includes(dep) && results.push(dep)
       }
     }
-    return results;
+    return results
   },
 
   /**
@@ -173,8 +164,8 @@ const TypedDataUtils = {
    * @param {Object} types - Type definitions
    * @returns {Buffer} - Hash of an object
    */
-  hashStruct(primaryType, data, types, useV4 = true) {
-    return util.keccak(this.encodeData(primaryType, data, types, useV4));
+  hashStruct (primaryType, data, types, useV4 = true) {
+    return util.keccak(this.encodeData(primaryType, data, types, useV4))
   },
 
   /**
@@ -184,8 +175,8 @@ const TypedDataUtils = {
    * @param {Object} types - Type definitions
    * @returns {string} - Hash of an object
    */
-  hashType(primaryType, types) {
-    return util.keccak(this.encodeType(primaryType, types));
+  hashType (primaryType, types) {
+    return util.keccak(this.encodeType(primaryType, types))
   },
 
   /**
@@ -194,15 +185,15 @@ const TypedDataUtils = {
    * @param {Object} data - typed message object
    * @returns {Object} - typed message object with only allowed fields
    */
-  sanitizeData(data) {
-    const sanitizedData = {};
+  sanitizeData (data) {
+    const sanitizedData = {}
     for (const key in TYPED_MESSAGE_SCHEMA.properties) {
-      data[key] && (sanitizedData[key] = data[key]);
+      data[key] && (sanitizedData[key] = data[key])
     }
     if (sanitizedData.types) {
-      sanitizedData.types = Object.assign({ EIP712Domain: [] }, sanitizedData.types);
+      sanitizedData.types = Object.assign({ EIP712Domain: [] }, sanitizedData.types)
     }
-    return sanitizedData;
+    return sanitizedData
   },
 
   /**
@@ -211,65 +202,56 @@ const TypedDataUtils = {
    * @param {Object} typedData - Types message data to sign
    * @returns {string} - sha3 hash for signing
    */
-  hash(typedData, useV4 = true) {
-    const sanitizedData = this.sanitizeData(typedData);
-    const parts = [Buffer.from('1901', 'hex')];
-    parts.push(this.hashStruct('EIP712Domain', sanitizedData.domain, sanitizedData.types, useV4));
+  hash (typedData, useV4 = true) {
+    const sanitizedData = this.sanitizeData(typedData)
+    const parts = [Buffer.from('1901', 'hex')]
+    parts.push(this.hashStruct('EIP712Domain', sanitizedData.domain, sanitizedData.types, useV4))
     if (sanitizedData.primaryType !== 'EIP712Domain') {
-      parts.push(
-        this.hashStruct(
-          sanitizedData.primaryType,
-          sanitizedData.message,
-          sanitizedData.types,
-          useV4
-        )
-      );
+      parts.push(this.hashStruct(sanitizedData.primaryType, sanitizedData.message, sanitizedData.types, useV4))
     }
-    return util.keccak(Buffer.concat(parts));
+    return util.keccak(Buffer.concat(parts))
   },
-};
+}
 
 module.exports = {
   TYPED_MESSAGE_SCHEMA,
   TypedDataUtils,
 
   hashForSignTypedDataLegacy: function (msgParams) {
-    return typedSignatureHashLegacy(msgParams.data);
+    return typedSignatureHashLegacy(msgParams.data)
   },
 
   hashForSignTypedData_v3: function (msgParams) {
-    return TypedDataUtils.hash(msgParams.data, false);
+    return TypedDataUtils.hash(msgParams.data, false)
   },
 
   hashForSignTypedData_v4: function (msgParams) {
-    return TypedDataUtils.hash(msgParams.data);
+    return TypedDataUtils.hash(msgParams.data)
   },
-};
+}
 
 /**
  * @param typedData - Array of data along with types, as per EIP712.
  * @returns Buffer
  */
 function typedSignatureHashLegacy(typedData) {
-  const error = new Error('Expect argument to be non-empty array');
-  if (typeof typedData !== 'object' || !typedData.length) throw error;
+  const error = new Error('Expect argument to be non-empty array')
+  if (typeof typedData !== 'object' || !typedData.length) throw error
 
   const data = typedData.map(function (e) {
-    return e.type === 'bytes' ? util.toBuffer(e.value) : e.value;
-  });
-  const types = typedData.map(function (e) {
-    return e.type;
-  });
+    return e.type === 'bytes' ? util.toBuffer(e.value) : e.value
+  })
+  const types = typedData.map(function (e) { return e.type })
   const schema = typedData.map(function (e) {
-    if (!e.name) throw error;
-    return e.type + ' ' + e.name;
-  });
+    if (!e.name) throw error
+    return e.type + ' ' + e.name
+  })
 
   return abi.soliditySHA3(
     ['bytes32', 'bytes32'],
     [
       abi.soliditySHA3(new Array(typedData.length).fill('string'), schema),
-      abi.soliditySHA3(types, data),
+      abi.soliditySHA3(types, data)
     ]
-  );
+  )
 }

--- a/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.js
+++ b/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.js
@@ -3,7 +3,7 @@
 
 /* eslint-disable */
 //prettier-ignore
-const createKeccakHash = require('keccak/js')
+const { keccak_256 } = require('@noble/hashes/sha3')
 
 /**
  * Returns a buffer filled with 0s
@@ -139,7 +139,7 @@ function keccak (a, bits) {
   a = toBuffer(a)
   if (!bits) bits = 256
 
-  return createKeccakHash('keccak' + bits).update(a).digest()
+  return Buffer.from(keccak_256('keccak' + bits))
 }
 
 function padToEven (str) {

--- a/packages/wallet-sdk/yarn.lock
+++ b/packages/wallet-sdk/yarn.lock
@@ -1386,6 +1386,11 @@
   dependencies:
     eslint-scope "5.1.1"
 
+"@noble/hashes@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1650,13 +1655,6 @@
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
-
-"@types/sha.js@^2.4.1":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@types/sha.js/-/sha.js-2.4.4.tgz#36be3d0bbc02f790617181709831fd4fc4be942d"
-  integrity sha512-Qukd+D6S2Hm0wLVt2Vh+/eWBIoUt+wF8jWjBsG4F8EFQRwKtYvtXCPcNl2OEUQ1R+eTr3xuSaBYUyM3WD1x/Qw==
-  dependencies:
-    "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
@@ -3419,7 +3417,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4273,15 +4271,6 @@ json5@2.x, json5@^2.2.3:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-keccak@^3.0.3:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.4.tgz#edc09b89e633c0549da444432ecf062ffadee86d"
-  integrity sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==
-  dependencies:
-    node-addon-api "^2.0.0"
-    node-gyp-build "^4.2.0"
-    readable-stream "^3.6.0"
-
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -4457,16 +4446,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
-
-node-addon-api@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
-  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
-
-node-gyp-build@^4.2.0:
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.1.tgz#976d3ad905e71b76086f4f0b0d3637fe79b6cda5"
-  integrity sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4837,15 +4816,6 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-readable-stream@^3.6.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
-  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -5006,11 +4976,6 @@ safe-array-concat@^1.1.2:
     has-symbols "^1.0.3"
     isarray "^2.0.5"
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
 safe-regex-test@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.3.tgz#a5b4c0f06e0ab50ea2c395c14d8371232924c377"
@@ -5072,14 +5037,6 @@ set-function-name@^2.0.1, set-function-name@^2.0.2:
     es-errors "^1.3.0"
     functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.2"
-
-sha.js@^2.4.11:
-  version "2.4.11"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -5222,13 +5179,6 @@ string.prototype.trimstart@^1.0.8:
     call-bind "^1.0.7"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -5587,11 +5537,6 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/packages/wallet-sdk/yarn.lock
+++ b/packages/wallet-sdk/yarn.lock
@@ -2178,11 +2178,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
@@ -2243,14 +2238,6 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
-buffer@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
-  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.2.1"
 
 call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6, call-bind@^1.0.7:
   version "1.0.7"
@@ -3362,11 +3349,6 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-ieee754@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore-by-default@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### _Summary_

This PR replaces keccak and sha.js with a smaller, audited and more secure `@noble/hashes`, thus removing 11 deps.

Before (15 deps):

![image](https://github.com/user-attachments/assets/18126cd7-e973-4a40-b96e-a669d3b1c0fb)


After (4 deps):

![image](https://github.com/user-attachments/assets/a34003bc-8ffa-4ff5-88be-0e06abe1e44a)


### _How did you test your changes?_

All tests passed.
