### PR TITLE
#trivial error serialization, request type check

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -32,6 +32,7 @@ describe('CoinbaseWalletProvider', () => {
     test('throws error when handling invalid request', async () => {
       const provider = createProvider();
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error // testing invalid request args
       await expect(provider.request({})).rejects.toMatchObject({
         code: -32602,
         message: "'args.method' must be a non-empty string.",

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -1,5 +1,5 @@
 import { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
-import { standardErrors } from './core/error';
+import { standardErrorCodes, standardErrors } from './core/error';
 import { fetchSignerType, loadSignerType, storeSignerType } from './sign/util';
 
 function createProvider() {
@@ -71,7 +71,11 @@ describe('signer configuration', () => {
     (fetchSignerType as jest.Mock).mockRejectedValue(error);
 
     const provider = createProvider();
-    await expect(provider.request({ method: 'eth_requestAccounts' })).rejects.toThrow(error);
+    await expect(provider.request({ method: 'eth_requestAccounts' })).rejects.toMatchObject(
+      expect.objectContaining({
+        message: error.message,
+      })
+    );
     expect(mockHandshake).not.toHaveBeenCalled();
     expect(storeSignerType as jest.Mock).not.toHaveBeenCalled();
   });
@@ -82,7 +86,11 @@ describe('signer configuration', () => {
     mockHandshake.mockRejectedValueOnce(error);
 
     const provider = createProvider();
-    await expect(provider.request({ method: 'eth_requestAccounts' })).rejects.toThrow(error);
+    await expect(provider.request({ method: 'eth_requestAccounts' })).rejects.toMatchObject(
+      expect.objectContaining({
+        message: error.message,
+      })
+    );
     expect(mockHandshake).toHaveBeenCalled();
     expect(storeSignerType as jest.Mock).not.toHaveBeenCalled();
   });
@@ -99,8 +107,9 @@ describe('signer configuration', () => {
 
   it('should throw error if signer is not initialized', async () => {
     const provider = createProvider();
-    await expect(provider.request({ method: 'personal_sign' })).rejects.toThrow(
-      `Must call 'eth_requestAccounts' before other methods`
-    );
+    await expect(provider.request({ method: 'personal_sign' })).rejects.toMatchObject({
+      code: standardErrorCodes.provider.unauthorized,
+      message: `Must call 'eth_requestAccounts' before other methods`,
+    });
   });
 });

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -32,7 +32,6 @@ describe('CoinbaseWalletProvider', () => {
     test('throws error when handling invalid request', async () => {
       const provider = createProvider();
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error // testing invalid request args
       await expect(provider.request({})).rejects.toMatchObject({
         code: -32602,
         message: "'args.method' must be a non-empty string.",

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -36,7 +36,7 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
     this.signer = signerType ? this.initSigner(signerType) : null;
   }
 
-  public async request<T>(args: unknown): Promise<T> {
+  public async request<T>(args: RequestArguments): Promise<T> {
     try {
       checkErrorForInvalidRequestArgs(args);
       return (await this.handleRequest(args)) as T;

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -36,15 +36,20 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
     this.signer = signerType ? this.initSigner(signerType) : null;
   }
 
-  public async request<T>(args: RequestArguments): Promise<T> {
+  public async request<T>(args: unknown): Promise<T> {
     try {
       checkErrorForInvalidRequestArgs(args);
-      const category = determineMethodCategory(args.method) ?? 'fetch';
-      return this.handlers[category](args) as T;
+      return (await this.handleRequest(args)) as T;
     } catch (error) {
-      this.handleUnauthorizedError(error);
-      return Promise.reject(serializeError(error, args.method));
+      const { code } = error as { code?: number };
+      if (code === standardErrorCodes.provider.unauthorized) this.disconnect();
+      return Promise.reject(serializeError(error));
     }
+  }
+
+  protected async handleRequest(request: RequestArguments) {
+    const category = determineMethodCategory(request.method) ?? 'fetch';
+    return this.handlers[category](request);
   }
 
   protected readonly handlers = {
@@ -102,13 +107,8 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
     },
   };
 
-  private handleUnauthorizedError(error: unknown) {
-    const e = error as { code?: number };
-    if (e.code === standardErrorCodes.provider.unauthorized) this.disconnect();
-  }
-
   /** @deprecated Use `.request({ method: 'eth_requestAccounts' })` instead. */
-  public async enable(): Promise<unknown> {
+  public async enable() {
     console.warn(
       `.enable() has been deprecated. Please use .request({ method: "eth_requestAccounts" }) instead.`
     );
@@ -117,7 +117,7 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
     });
   }
 
-  async disconnect(): Promise<void> {
+  async disconnect() {
     this.signer?.disconnect();
     ScopedLocalStorage.clearAll();
     this.emit('disconnect', standardErrors.provider.disconnected('User initiated disconnection'));
@@ -139,8 +139,8 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
       metadata: this.metadata,
       communicator: this.communicator,
       updateListener: {
-        onAccountsUpdate: (accounts: AddressString[]) => this.emit('accountsChanged', accounts),
-        onChainIdUpdate: (id: number) => this.emit('chainChanged', hexStringFromNumber(id)),
+        onAccountsUpdate: (accounts) => this.emit('accountsChanged', accounts),
+        onChainIdUpdate: (id) => this.emit('chainChanged', hexStringFromNumber(id)),
       },
     });
   }

--- a/packages/wallet-sdk/src/core/error/serialize.test.ts
+++ b/packages/wallet-sdk/src/core/error/serialize.test.ts
@@ -11,7 +11,7 @@ describe('serializeError', () => {
       errorCode: standardErrorCodes.provider.unsupportedMethod,
     };
 
-    const serialized = serializeError(errorResponse, '');
+    const serialized = serializeError(errorResponse);
     expect(serialized.code).toEqual(standardErrorCodes.provider.unsupportedMethod);
     expect(serialized.message).toEqual('test ErrorResponse object');
     expect(serialized.docUrl).toMatch(/.*version=\d+\.\d+\.\d+.*/);
@@ -21,7 +21,7 @@ describe('serializeError', () => {
   test('with standardError', () => {
     const error = standardErrors.provider.userRejectedRequest({});
 
-    const serialized = serializeError(error, 'test_request');
+    const serialized = serializeError(error);
     expect(serialized.code).toEqual(standardErrorCodes.provider.userRejectedRequest);
     expect(serialized.message).toEqual(error.message);
     expect(serialized.stack).toEqual(expect.stringContaining('User rejected'));
@@ -43,7 +43,7 @@ describe('serializeError', () => {
   test('with Error object', () => {
     const error = new Error('test Error object');
 
-    const serialized = serializeError(error, 'test_request');
+    const serialized = serializeError(error);
     expect(serialized.code).toEqual(standardErrorCodes.rpc.internal);
     expect(serialized.message).toEqual('test Error object');
     expect(serialized.stack).toEqual(expect.stringContaining('test Error object'));
@@ -54,7 +54,7 @@ describe('serializeError', () => {
   test('with string', () => {
     const error = 'test error with just string';
 
-    const serialized = serializeError(error, 'test_request');
+    const serialized = serializeError(error);
     expect(serialized.code).toEqual(standardErrorCodes.rpc.internal);
     expect(serialized.message).toEqual('test error with just string');
     expect(serialized.docUrl).toMatch(/.*version=\d+\.\d+\.\d+.*/);
@@ -63,60 +63,10 @@ describe('serializeError', () => {
 
   test('with unknown type', () => {
     const error = { unknown: 'error' };
-    const serialized = serializeError(error, 'test_request');
+    const serialized = serializeError(error);
     expect(serialized.code).toEqual(standardErrorCodes.rpc.internal);
     expect(serialized.message).toEqual('Unspecified error message.');
     expect(serialized.docUrl).toMatch(/.*version=\d+\.\d+\.\d+.*/);
     expect(serialized.docUrl).toContain(`code=${standardErrorCodes.rpc.internal}`);
-  });
-});
-
-describe('serializeError to retrieve the request method', () => {
-  test('with JSONRPCRequest object', () => {
-    const jsonRpcRequest = {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'requestEthereumAccounts',
-      params: [],
-    };
-
-    const error = standardErrors.provider.userRejectedRequest({});
-
-    const serialized = serializeError(error, jsonRpcRequest);
-    expect(serialized.code).toEqual(standardErrorCodes.provider.userRejectedRequest);
-    expect(serialized.docUrl).toContain('method=requestEthereumAccounts');
-  });
-
-  test('with string', () => {
-    const method = 'test_method';
-
-    const error = standardErrors.provider.userRejectedRequest({});
-
-    const serialized = serializeError(error, method);
-    expect(serialized.code).toEqual(standardErrorCodes.provider.userRejectedRequest);
-    expect(serialized.docUrl).toContain(`method=${method}`);
-  });
-
-  test('with JSONRPCRequest array', () => {
-    const jsonRpcRequests = [
-      {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'requestEthereumAccounts',
-        params: [],
-      },
-      {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'signEthereumMessage',
-        params: [],
-      },
-    ];
-
-    const error = standardErrors.provider.userRejectedRequest({});
-
-    const serialized = serializeError(error, jsonRpcRequests);
-    expect(serialized.code).toEqual(standardErrorCodes.provider.userRejectedRequest);
-    expect(serialized.docUrl).toContain('method=requestEthereumAccounts');
   });
 });

--- a/packages/wallet-sdk/src/core/error/serialize.ts
+++ b/packages/wallet-sdk/src/core/error/serialize.ts
@@ -2,17 +2,14 @@
 import { isErrorResponse, Web3Response } from '../../sign/walletlink/relay/type/Web3Response';
 import { LIB_VERSION } from '../../version';
 import { standardErrorCodes } from './constants';
-import { serialize, SerializedEthereumRpcError } from './utils';
+import { serialize } from './utils';
 
 /**
  * Serializes an error to a format that is compatible with the Ethereum JSON RPC error format.
  * See https://docs.cloud.coinbase.com/wallet-sdk/docs/errors
  * for more information.
  */
-export function serializeError(
-  error: unknown,
-  requestOrMethod?: JSONRPCRequest | JSONRPCRequest[] | string
-): SerializedError {
+export function serializeError(error: unknown) {
   const serialized = serialize(getErrorObject(error), {
     shouldIncludeStack: true,
   });
@@ -20,10 +17,6 @@ export function serializeError(
   const docUrl = new URL('https://docs.cloud.coinbase.com/wallet-sdk/docs/errors');
   docUrl.searchParams.set('version', LIB_VERSION);
   docUrl.searchParams.set('code', serialized.code.toString());
-  const method = getMethod(serialized.data, requestOrMethod);
-  if (method) {
-    docUrl.searchParams.set('method', method);
-  }
   docUrl.searchParams.set('message', serialized.message);
 
   return {
@@ -50,36 +43,4 @@ function getErrorObject(error: string | Web3Response | unknown) {
     };
   }
   return error;
-}
-
-/**
- * Gets the method name from the serialized data or the request.
- */
-function getMethod(
-  serializedData: unknown,
-  request?: JSONRPCRequest | JSONRPCRequest[] | string
-): string | undefined {
-  const methodInData = (serializedData as { method: string })?.method;
-  if (methodInData) {
-    return methodInData;
-  }
-
-  if (request === undefined) {
-    return undefined;
-  } else if (typeof request === 'string') {
-    return request;
-  } else if (!Array.isArray(request)) {
-    return request.method;
-  } else if (request.length > 0) {
-    return request[0].method;
-  }
-  return undefined;
-}
-
-export interface SerializedError extends SerializedEthereumRpcError {
-  docUrl: string;
-}
-
-interface JSONRPCRequest {
-  method: string;
 }

--- a/packages/wallet-sdk/src/util/provider.ts
+++ b/packages/wallet-sdk/src/util/provider.ts
@@ -27,7 +27,7 @@ export async function fetchRPCRequest(request: RequestArguments, chain?: Chain) 
  * @param args The request arguments to validate.
  * @returns An error object if the arguments are invalid, otherwise undefined.
  */
-export function checkErrorForInvalidRequestArgs(args: unknown) {
+export function checkErrorForInvalidRequestArgs(args: unknown): asserts args is RequestArguments {
   if (!args || typeof args !== 'object' || Array.isArray(args)) {
     throw standardErrors.rpc.invalidParams({
       message: 'Expected a single, non-array, object argument.',


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
- Fix missing error serialization
- Fix request arg type check
- Remove unnecessary `method` parsing on `serializeError`
- Syntax cleanup
- Prep for signer refactor

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

existing unit tests
