### PR TITLE
#trivial simplify handshake return value

### DIFF
--- a/packages/wallet-sdk/src/sign/extension/ExtensionSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/extension/ExtensionSigner.test.ts
@@ -74,12 +74,13 @@ describe('ExtensionSigner', () => {
   });
 
   it('should request accounts during handshake', async () => {
+    // expecting extension provider to return accounts and emit an accountsChanged event
     (mockExtensionProvider.request as jest.Mock).mockImplementation((args) =>
       args.method === 'eth_requestAccounts' ? ['0x123'] : null
     );
+    eventListeners['accountsChanged'](['0x123']);
 
-    const accounts = await signer.handshake();
-    expect(accounts).toEqual(['0x123']);
+    await expect(signer.handshake()).resolves.not.toThrow();
     expect(mockUpdateListener.onAccountsUpdate).toHaveBeenCalledWith(['0x123']);
   });
 

--- a/packages/wallet-sdk/src/sign/extension/ExtensionSigner.ts
+++ b/packages/wallet-sdk/src/sign/extension/ExtensionSigner.ts
@@ -48,11 +48,9 @@ export class ExtensionSigner implements Signer {
   }
 
   async handshake() {
-    const accounts = (await this.request({
+    await this.request({
       method: 'eth_requestAccounts',
-    })) as AddressString[];
-    this.updateListener.onAccountsUpdate(accounts);
-    return accounts;
+    });
   }
 
   async request(request: RequestArguments) {

--- a/packages/wallet-sdk/src/sign/interface.ts
+++ b/packages/wallet-sdk/src/sign/interface.ts
@@ -4,7 +4,7 @@ import { AddressString, Chain } from ':core/type';
 export interface Signer {
   readonly accounts: AddressString[];
   readonly chain: Chain;
-  handshake(): Promise<AddressString[]>;
+  handshake(): Promise<void>;
   request(request: RequestArguments): Promise<unknown>;
   disconnect: () => Promise<void>;
 }

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -88,7 +88,6 @@ export class SCWSigner implements Signer {
     this._accounts = accounts;
     this.storage.storeObject(ACCOUNTS_KEY, accounts);
     this.updateListener.onAccountsUpdate(accounts);
-    return accounts;
   }
 
   async request(request: RequestArguments) {

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
@@ -100,10 +100,6 @@ export class WalletLinkSigner implements Signer {
     return { id, secret };
   }
 
-  async handshake() {
-    return this.request({ method: 'eth_requestAccounts' });
-  }
-
   get selectedAddress(): AddressString | undefined {
     return this._addresses[0] || undefined;
   }
@@ -303,9 +299,6 @@ export class WalletLinkSigner implements Signer {
     const params = request.params || [];
 
     switch (method) {
-      case 'eth_requestAccounts':
-        return this._eth_requestAccounts();
-
       case 'eth_sign':
         return this._eth_sign(params);
 
@@ -492,13 +485,9 @@ export class WalletLinkSigner implements Signer {
     return ensureIntNumber(chainId);
   }
 
-  private async _eth_requestAccounts(): Promise<JSONRPCResponse> {
+  async handshake() {
     if (this._isAuthorized()) {
-      return Promise.resolve({
-        jsonrpc: '2.0',
-        id: 0,
-        result: this._addresses,
-      });
+      return;
     }
 
     let res: Web3Response<'requestEthereumAccounts'>;
@@ -520,8 +509,6 @@ export class WalletLinkSigner implements Signer {
     }
 
     this._setAddresses(res.result);
-
-    return { jsonrpc: '2.0', id: 0, result: this._addresses };
   }
 
   private _eth_sign(params: unknown[]): Promise<JSONRPCResponse> {

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
@@ -299,6 +299,11 @@ export class WalletLinkSigner implements Signer {
     const params = request.params || [];
 
     switch (method) {
+      case 'eth_requestAccounts': {
+        await this.handshake();
+        return { jsonrpc: '2.0', id: 0, result: this._addresses };
+      }
+
       case 'eth_sign':
         return this._eth_sign(params);
 


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

we don't need return value from handshake. it's not being used on provider. we only care if it was successful or not. Promise<void> should be enough

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
 unit tests