### PR TITLE
Allow consumer to pass in storage object

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -18,7 +18,7 @@ import { SignerType } from ':core/message';
 import { determineMethodCategory } from ':core/provider/method';
 import { hexStringFromNumber } from ':core/type/util';
 import type { BaseStorage } from ':util/BaseStorage';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 export class CoinbaseWalletProvider extends EventEmitter implements ProviderInterface {
   private readonly metadata: AppMetadata;
@@ -126,7 +126,7 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
 
   async disconnect() {
     this.signer?.disconnect();
-    ScopedLocalStorage.clearAll(this.baseStorage);
+    ScopedStorage.clearAll(this.baseStorage);
     this.emit('disconnect', standardErrors.provider.disconnected('User initiated disconnection'));
   }
 

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -17,22 +17,29 @@ import { Communicator } from ':core/communicator/Communicator';
 import { SignerType } from ':core/message';
 import { determineMethodCategory } from ':core/provider/method';
 import { hexStringFromNumber } from ':core/type/util';
+import type { BaseStorage } from ':util/BaseStorage';
 import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
 
 export class CoinbaseWalletProvider extends EventEmitter implements ProviderInterface {
   private readonly metadata: AppMetadata;
   private readonly preference: Preference;
   private readonly communicator: Communicator;
+  private readonly baseStorage?: BaseStorage;
 
   private signer: Signer | null;
 
-  constructor({ metadata, preference: { keysUrl, ...preference } }: Readonly<ConstructorOptions>) {
+  constructor({
+    baseStorage,
+    metadata,
+    preference: { keysUrl, ...preference },
+  }: Readonly<ConstructorOptions>) {
     super();
+    this.baseStorage = baseStorage;
     this.metadata = metadata;
     this.preference = preference;
     this.communicator = new Communicator(keysUrl);
     // Load states from storage
-    const signerType = loadSignerType();
+    const signerType = loadSignerType(baseStorage);
     this.signer = signerType ? this.initSigner(signerType) : null;
   }
 
@@ -60,7 +67,7 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
         const signer = this.initSigner(signerType);
         await signer.handshake();
         this.signer = signer;
-        storeSignerType(signerType);
+        storeSignerType(signerType, this.baseStorage);
       }
       this.emit('connect', { chainId: hexStringFromNumber(this.signer.chain.id) });
       return this.signer.accounts;
@@ -119,7 +126,7 @@ export class CoinbaseWalletProvider extends EventEmitter implements ProviderInte
 
   async disconnect() {
     this.signer?.disconnect();
-    ScopedLocalStorage.clearAll();
+    ScopedLocalStorage.clearAll(this.baseStorage);
     this.emit('disconnect', standardErrors.provider.disconnected('User initiated disconnection'));
   }
 

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -3,7 +3,7 @@
 import { LogoType, walletLogo } from './assets/wallet-logo';
 import { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
 import { AppMetadata, Preference, ProviderInterface } from './core/provider/interface';
-import { ScopedLocalStorage } from './util/ScopedLocalStorage';
+import { ScopedStorage } from './util/ScopedStorage';
 import { LIB_VERSION } from './version';
 import { getFavicon } from ':core/type/util';
 import type { BaseStorage } from ':util/BaseStorage';
@@ -62,7 +62,7 @@ export class CoinbaseWalletSDK {
   }
 
   private storeLatestVersion(storage: BaseStorage | undefined) {
-    const versionStorage = new ScopedLocalStorage('CBWSDK', undefined, storage);
+    const versionStorage = new ScopedStorage('CBWSDK', undefined, storage);
     versionStorage.setItem('VERSION', LIB_VERSION);
   }
 }

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -6,9 +6,14 @@ import { AppMetadata, Preference, ProviderInterface } from './core/provider/inte
 import { ScopedLocalStorage } from './util/ScopedLocalStorage';
 import { LIB_VERSION } from './version';
 import { getFavicon } from ':core/type/util';
+import type { BaseStorage } from ':util/BaseStorage';
 
 // for backwards compatibility
-type CoinbaseWalletSDKOptions = Partial<AppMetadata>;
+type CoinbaseWalletSDKOptions = Partial<
+  AppMetadata & {
+    storage: BaseStorage;
+  }
+>;
 
 interface CBWindow {
   top: CBWindow;
@@ -17,14 +22,16 @@ interface CBWindow {
 
 export class CoinbaseWalletSDK {
   private metadata: AppMetadata;
+  private baseStorage?: BaseStorage;
 
-  constructor(metadata: Readonly<CoinbaseWalletSDKOptions>) {
+  constructor(options: Readonly<CoinbaseWalletSDKOptions>) {
     this.metadata = {
-      appName: metadata.appName || 'Dapp',
-      appLogoUrl: metadata.appLogoUrl || getFavicon(),
-      appChainIds: metadata.appChainIds || [],
+      appName: options.appName || 'Dapp',
+      appLogoUrl: options.appLogoUrl || getFavicon(),
+      appChainIds: options.appChainIds || [],
     };
-    this.storeLatestVersion();
+    this.baseStorage = options.storage;
+    this.storeLatestVersion(options.storage);
   }
 
   public makeWeb3Provider(preference: Preference = { options: 'all' }): ProviderInterface {
@@ -37,7 +44,11 @@ export class CoinbaseWalletSDK {
     } catch {
       // Ignore
     }
-    return new CoinbaseWalletProvider({ metadata: this.metadata, preference });
+    return new CoinbaseWalletProvider({
+      baseStorage: this.baseStorage,
+      metadata: this.metadata,
+      preference,
+    });
   }
 
   /**
@@ -50,8 +61,8 @@ export class CoinbaseWalletSDK {
     return walletLogo(type, width);
   }
 
-  private storeLatestVersion() {
-    const versionStorage = new ScopedLocalStorage('CBWSDK');
+  private storeLatestVersion(storage: BaseStorage | undefined) {
+    const versionStorage = new ScopedLocalStorage('CBWSDK', undefined, storage);
     versionStorage.setItem('VERSION', LIB_VERSION);
   }
 }

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'eventemitter3';
 
 import { Method } from './method';
+import type { BaseStorage } from ':util/BaseStorage';
 
 export interface RequestArguments {
   readonly method: Method | string;
@@ -49,4 +50,5 @@ export interface Preference {
 export interface ConstructorOptions {
   metadata: AppMetadata;
   preference: Preference;
+  baseStorage?: BaseStorage;
 }

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -5,3 +5,4 @@ export default CoinbaseWalletSDK;
 export type { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
 export { CoinbaseWalletSDK } from './CoinbaseWalletSDK';
 export type { AppMetadata, Preference, ProviderInterface } from './core/provider/interface';
+export { type BaseStorage, browserStorageAdapter, mmkvStorageAdapter } from './util/BaseStorage';

--- a/packages/wallet-sdk/src/sign/scw/SCWKeyManager.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWKeyManager.ts
@@ -4,7 +4,7 @@ import {
   generateKeyPair,
   importKeyFromHexString,
 } from ':util/cipher';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 interface StorageItem {
   storageKey: string;
@@ -24,7 +24,7 @@ const PEER_PUBLIC_KEY = {
 } as const;
 
 export class SCWKeyManager {
-  private readonly storage = new ScopedLocalStorage('CBWSDK', 'SCWKeyManager');
+  private readonly storage = new ScopedStorage('CBWSDK', 'SCWKeyManager');
   private ownPrivateKey: CryptoKey | null = null;
   private ownPublicKey: CryptoKey | null = null;
   private peerPublicKey: CryptoKey | null = null;

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -11,10 +11,10 @@ import {
   exportKeyToHexString,
   importKeyFromHexString,
 } from ':util/cipher';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 jest.mock('./SCWKeyManager');
-const storageStoreSpy = jest.spyOn(ScopedLocalStorage.prototype, 'storeObject');
+const storageStoreSpy = jest.spyOn(ScopedStorage.prototype, 'storeObject');
 jest.mock(':core/communicator/Communicator', () => ({
   Communicator: jest.fn(() => ({
     postRequestAndWaitForResponse: jest.fn(),

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -12,7 +12,7 @@ import {
   exportKeyToHexString,
   importKeyFromHexString,
 } from ':util/cipher';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 const ACCOUNTS_KEY = 'accounts';
 const ACTIVE_CHAIN_STORAGE_KEY = 'activeChain';
@@ -30,7 +30,7 @@ export class SCWSigner implements Signer {
   private readonly communicator: Communicator;
   private readonly updateListener: StateUpdateListener;
   private readonly keyManager: SCWKeyManager;
-  private readonly storage: ScopedLocalStorage;
+  private readonly storage: ScopedStorage;
 
   private _accounts: AddressString[];
   get accounts() {
@@ -52,7 +52,7 @@ export class SCWSigner implements Signer {
     this.updateListener = params.updateListener;
     this.keyManager = new SCWKeyManager();
 
-    this.storage = new ScopedLocalStorage('CBWSDK', 'SCWStateManager');
+    this.storage = new ScopedStorage('CBWSDK', 'SCWStateManager');
     this._accounts = this.storage.loadObject(ACCOUNTS_KEY) ?? [];
     this._chain = this.storage.loadObject(ACTIVE_CHAIN_STORAGE_KEY) || {
       id: params.metadata.appChainIds?.[0] ?? 1,

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -6,17 +6,17 @@ import { Communicator } from ':core/communicator/Communicator';
 import { ConfigMessage, MessageID, SignerType } from ':core/message';
 import { AppMetadata, Preference } from ':core/provider/interface';
 import type { BaseStorage } from ':util/BaseStorage';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 const SIGNER_TYPE_KEY = 'SignerType';
 
 export function loadSignerType(baseStorage: BaseStorage | undefined): SignerType | null {
-  const storage = new ScopedLocalStorage('CBWSDK', 'SignerConfigurator', baseStorage);
+  const storage = new ScopedStorage('CBWSDK', 'SignerConfigurator', baseStorage);
   return storage.getItem(SIGNER_TYPE_KEY) as SignerType;
 }
 
 export function storeSignerType(signerType: SignerType, baseStorage: BaseStorage | undefined) {
-  const storage = new ScopedLocalStorage('CBWSDK', 'SignerConfigurator', baseStorage);
+  const storage = new ScopedStorage('CBWSDK', 'SignerConfigurator', baseStorage);
   storage.setItem(SIGNER_TYPE_KEY, signerType);
 }
 

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -5,16 +5,18 @@ import { WalletLinkSigner } from './walletlink/WalletLinkSigner';
 import { Communicator } from ':core/communicator/Communicator';
 import { ConfigMessage, MessageID, SignerType } from ':core/message';
 import { AppMetadata, Preference } from ':core/provider/interface';
+import type { BaseStorage } from ':util/BaseStorage';
 import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
 
 const SIGNER_TYPE_KEY = 'SignerType';
-const storage = new ScopedLocalStorage('CBWSDK', 'SignerConfigurator');
 
-export function loadSignerType(): SignerType | null {
+export function loadSignerType(baseStorage: BaseStorage | undefined): SignerType | null {
+  const storage = new ScopedLocalStorage('CBWSDK', 'SignerConfigurator', baseStorage);
   return storage.getItem(SIGNER_TYPE_KEY) as SignerType;
 }
 
-export function storeSignerType(signerType: SignerType) {
+export function storeSignerType(signerType: SignerType, baseStorage: BaseStorage | undefined) {
+  const storage = new ScopedLocalStorage('CBWSDK', 'SignerConfigurator', baseStorage);
   storage.setItem(SIGNER_TYPE_KEY, signerType);
 }
 
@@ -24,7 +26,7 @@ export async function fetchSignerType(params: {
   metadata: AppMetadata; // for WalletLink
 }): Promise<SignerType> {
   const { communicator, metadata } = params;
-  listenForWalletLinkSessionRequest(communicator, metadata).catch(() => {});
+  listenForWalletLinkSessionRequest(communicator, metadata).catch(() => { });
 
   const request: ConfigMessage & { id: MessageID } = {
     id: crypto.randomUUID(),

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
@@ -7,7 +7,7 @@ import { WalletLinkRelay } from './relay/WalletLinkRelay';
 import { WalletLinkSigner } from './WalletLinkSigner';
 import { WALLETLINK_URL } from ':core/constants';
 import { standardErrorCodes, standardErrors } from ':core/error';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 jest.mock('./relay/WalletLinkRelay', () => {
   return {
@@ -15,7 +15,7 @@ jest.mock('./relay/WalletLinkRelay', () => {
   };
 });
 
-const testStorage = new ScopedLocalStorage('walletlink', WALLETLINK_URL);
+const testStorage = new ScopedStorage('walletlink', WALLETLINK_URL);
 
 const createAdapter = (options?: { relay?: WalletLinkRelay }) => {
   const adapter = new WalletLinkSigner({

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
@@ -21,8 +21,8 @@ const createAdapter = (options?: { relay?: WalletLinkRelay }) => {
   const adapter = new WalletLinkSigner({
     metadata: { appName: 'test', appLogoUrl: null, appChainIds: [1] },
     updateListener: {
-      onAccountsUpdate: () => {},
-      onChainIdUpdate: () => {},
+      onAccountsUpdate: () => { },
+      onChainIdUpdate: () => { },
     },
   });
   if (options?.relay) {

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
@@ -22,7 +22,7 @@ import {
   ensureParsedJSONObject,
   hexStringFromNumber,
 } from ':core/type/util';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 const DEFAULT_CHAIN_ID_KEY = 'DefaultChainId';
 const DEFAULT_JSON_RPC_URL = 'DefaultJsonRpcUrl';
@@ -59,7 +59,7 @@ export class WalletLinkSigner implements Signer {
   private _appName: string;
   private _appLogoUrl: string | null;
   private _relay: WalletLinkRelay | null = null;
-  private readonly _storage: ScopedLocalStorage;
+  private readonly _storage: ScopedStorage;
   private readonly _relayEventManager: RelayEventManager;
   private _jsonRpcUrlFromOpts: string;
   private _addresses: AddressString[] = [];
@@ -69,7 +69,7 @@ export class WalletLinkSigner implements Signer {
     const { appName, appLogoUrl } = options.metadata;
     this._appName = appName;
     this._appLogoUrl = appLogoUrl;
-    this._storage = new ScopedLocalStorage('walletlink', WALLETLINK_URL);
+    this._storage = new ScopedStorage('walletlink', WALLETLINK_URL);
     this.updateListener = options.updateListener;
 
     this._relayEventManager = new RelayEventManager();

--- a/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.test.ts
@@ -7,7 +7,7 @@ import { WALLET_USER_NAME_KEY } from './constants';
 import { ServerMessage } from './type/ServerMessage';
 import { WalletLinkSessionConfig } from './type/WalletLinkSessionConfig';
 import { WalletLinkRelay } from './WalletLinkRelay';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 const decryptMock = jest.fn().mockImplementation((text) => Promise.resolve(`"decrypted ${text}"`));
 
@@ -16,7 +16,7 @@ jest.spyOn(WalletLinkCipher.prototype, 'decrypt').mockImplementation(decryptMock
 describe('WalletLinkRelay', () => {
   const options = {
     linkAPIUrl: 'http://link-api-url',
-    storage: new ScopedLocalStorage('walletlink', 'test'),
+    storage: new ScopedStorage('walletlink', 'test'),
   };
 
   beforeEach(() => {

--- a/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
@@ -19,18 +19,18 @@ import { WLMobileRelayUI } from './ui/WLMobileRelayUI';
 import { standardErrors } from ':core/error';
 import { AddressString, IntNumber, RegExpString } from ':core/type';
 import { bigIntStringFromBigInt, hexStringFromBuffer, randomBytesHex } from ':core/type/util';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 interface WalletLinkRelayOptions {
   linkAPIUrl: string;
-  storage: ScopedLocalStorage;
+  storage: ScopedStorage;
 }
 
 export class WalletLinkRelay implements WalletLinkConnectionUpdateListener {
   private static accountRequestCallbackIds = new Set<string>();
 
   private readonly linkAPIUrl: string;
-  protected readonly storage: ScopedLocalStorage;
+  protected readonly storage: ScopedStorage;
   private _session: WalletLinkSession;
   private readonly relayEventManager: RelayEventManager;
   protected connection: WalletLinkConnection;
@@ -166,7 +166,7 @@ export class WalletLinkRelay implements WalletLinkConnectionUpdateListener {
          */
         const storedSession = WalletLinkSession.load(this.storage);
         if (storedSession?.id === this._session.id) {
-          ScopedLocalStorage.clearAll(undefined);
+          ScopedStorage.clearAll(undefined);
         }
 
         document.location.reload();

--- a/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
@@ -166,12 +166,12 @@ export class WalletLinkRelay implements WalletLinkConnectionUpdateListener {
          */
         const storedSession = WalletLinkSession.load(this.storage);
         if (storedSession?.id === this._session.id) {
-          ScopedLocalStorage.clearAll();
+          ScopedLocalStorage.clearAll(undefined);
         }
 
         document.location.reload();
       })
-      .catch((_) => {});
+      .catch((_) => { });
   }
 
   public setAppInfo(appName: string, appLogoUrl: string | null): void {
@@ -347,7 +347,7 @@ export class WalletLinkRelay implements WalletLinkConnectionUpdateListener {
   protected publishWeb3RequestEvent(id: string, request: Web3Request): void {
     const message: WalletLinkEventData = { type: 'WEB3_REQUEST', id, request };
     this.publishEvent('Web3Request', message, true)
-      .then((_) => {})
+      .then((_) => { })
       .catch((err) => {
         this.handleWeb3ResponseMessage({
           type: 'WEB3_RESPONSE',

--- a/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkConnection.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkConnection.test.ts
@@ -3,14 +3,14 @@ import { WalletLinkSession } from '../type/WalletLinkSession';
 import { WalletLinkSessionConfig } from '../type/WalletLinkSessionConfig';
 import { WalletLinkCipher } from './WalletLinkCipher';
 import { WalletLinkConnection, WalletLinkConnectionUpdateListener } from './WalletLinkConnection';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 const decryptMock = jest.fn().mockImplementation((text) => Promise.resolve(`decrypted ${text}`));
 
 jest.spyOn(WalletLinkCipher.prototype, 'decrypt').mockImplementation(decryptMock);
 
 describe('WalletLinkConnection', () => {
-  const session = new WalletLinkSession(new ScopedLocalStorage('walletlink', 'test'));
+  const session = new WalletLinkSession(new ScopedStorage('walletlink', 'test'));
 
   let connection: WalletLinkConnection;
   let listener: WalletLinkConnectionUpdateListener;

--- a/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
@@ -4,7 +4,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex } from '@noble/hashes/utils';
 
 import { randomBytesHex } from ':core/type/util';
-import { ScopedLocalStorage } from ':util/ScopedLocalStorage';
+import { ScopedStorage } from ':util/ScopedStorage';
 
 const STORAGE_KEY_SESSION_ID = 'session:id';
 const STORAGE_KEY_SESSION_SECRET = 'session:secret';
@@ -14,10 +14,10 @@ export class WalletLinkSession {
   private readonly _id: string;
   private readonly _secret: string;
   private readonly _key: string;
-  private readonly _storage: ScopedLocalStorage;
+  private readonly _storage: ScopedStorage;
   private _linked: boolean;
 
-  constructor(storage: ScopedLocalStorage, id?: string, secret?: string, linked?: boolean) {
+  constructor(storage: ScopedStorage, id?: string, secret?: string, linked?: boolean) {
     this._storage = storage;
     this._id = id || randomBytesHex(16);
     this._secret = secret || randomBytesHex(32);
@@ -27,7 +27,7 @@ export class WalletLinkSession {
     this._linked = !!linked;
   }
 
-  public static load(storage: ScopedLocalStorage): WalletLinkSession | null {
+  public static load(storage: ScopedStorage): WalletLinkSession | null {
     const id = storage.getItem(STORAGE_KEY_SESSION_ID);
     const linked = storage.getItem(STORAGE_KEY_SESSION_LINKED);
     const secret = storage.getItem(STORAGE_KEY_SESSION_SECRET);

--- a/packages/wallet-sdk/src/util/BaseStorage.test.ts
+++ b/packages/wallet-sdk/src/util/BaseStorage.test.ts
@@ -1,0 +1,38 @@
+import { browserStorageAdapter } from './BaseStorage';
+
+describe('BaseStorage', () => {
+  describe('browser storage adapter', () => {
+    const storage = browserStorageAdapter(localStorage);
+
+    afterEach(() => localStorage.clear());
+
+    test('get', () => {
+      localStorage.setItem('foo', 'bar');
+
+      const value = storage.get('foo');
+      expect(value).toBe('bar');
+    });
+
+    test('set', () => {
+      storage.set('foo1', 'bar1');
+
+      expect(localStorage.getItem('foo1')).toBe('bar1');
+    });
+
+    test('delete', () => {
+      localStorage.setItem('foo2', 'bar2');
+
+      storage.delete('foo2');
+      expect(storage.get('foo2')).toBe(null);
+    });
+
+    test('getAllKeys', () => {
+      localStorage.setItem('foo3', 'bar3');
+      localStorage.setItem('foo4', 'bar4');
+      localStorage.setItem('foo5', 'bar5');
+
+      const value = storage.getAllKeys();
+      expect(value).toStrictEqual(['foo3', 'foo4', 'foo5']);
+    });
+  });
+});

--- a/packages/wallet-sdk/src/util/BaseStorage.ts
+++ b/packages/wallet-sdk/src/util/BaseStorage.ts
@@ -1,0 +1,67 @@
+export type BaseStorage = {
+  get: (key: string) => string | null;
+  set: (key: string, value: string) => void;
+  delete: (key: string) => void;
+  getAllKeys: () => string[];
+};
+
+/**
+ * An adapter that transforms a web {@link Storage} object into a {@link BaseStorage}
+ *
+ * @example
+ * let storage = browserStorageAdapter(window.localStorage);
+ * let sdk = new CoinbaseWalletSDK({
+ *   storage,
+ *   // ...options
+ * });
+ *
+ * @param storage A web {@link Storage} object like {@link localStorage}
+ * @returns A {@link BaseStorage} object that wraps the passed in storage
+ */
+export function browserStorageAdapter(storage: Storage): BaseStorage {
+  return {
+    get: (key) => storage.getItem(key),
+    set: (key, value) => storage.setItem(key, value),
+    delete: (key) => storage.removeItem(key),
+    getAllKeys: () => {
+      const keys: string[] = [];
+      for (let i = 0; i < storage.length; i++) {
+        const key = storage.key(i);
+        if (key) {
+          keys.push(key);
+        }
+      }
+      return keys;
+    },
+  };
+}
+
+type MMKVStorage = {
+  getString: (key: string) => string | null;
+  set: <T>(key: string, value: T) => void;
+  delete: (key: string) => void;
+  getAllKeys: () => string[];
+};
+
+/**
+ * An adapter that transforms a React Native MMKV storage object into a {@link BaseStorage}
+ *
+ * @example
+ * let mmkv = new MMKV();
+ * let storage = mmkvStorageAdapter(mmkv);
+ * let sdk = new CoinbaseWalletSDK({
+ *   storage,
+ *   // ...options
+ * });
+ *
+ * @param storage A React Native MMKV storage object
+ * @returns A {@link BaseStorage} object that wraps the passed in storage
+ */
+export function mmkvStorageAdapter(storage: MMKVStorage): BaseStorage {
+  return {
+    get: (key) => storage.getString(key),
+    set: (key, value) => storage.set(key, value),
+    delete: (key) => storage.delete(key),
+    getAllKeys: () => storage.getAllKeys(),
+  };
+}

--- a/packages/wallet-sdk/src/util/BaseStorage.ts
+++ b/packages/wallet-sdk/src/util/BaseStorage.ts
@@ -37,8 +37,8 @@ export function browserStorageAdapter(storage: Storage): BaseStorage {
 }
 
 type MMKVStorage = {
-  getString: (key: string) => string | null;
-  set: <T>(key: string, value: T) => void;
+  getString: (key: string) => string | undefined;
+  set: (key: string, value: string) => void;
   delete: (key: string) => void;
   getAllKeys: () => string[];
 };
@@ -59,7 +59,7 @@ type MMKVStorage = {
  */
 export function mmkvStorageAdapter(storage: MMKVStorage): BaseStorage {
   return {
-    get: (key) => storage.getString(key),
+    get: (key) => storage.getString(key) ?? null,
     set: (key, value) => storage.set(key, value),
     delete: (key) => storage.delete(key),
     getAllKeys: () => storage.getAllKeys(),

--- a/packages/wallet-sdk/src/util/ScopedLocalStorage.test.ts
+++ b/packages/wallet-sdk/src/util/ScopedLocalStorage.test.ts
@@ -1,6 +1,7 @@
+import { browserStorageAdapter } from './BaseStorage';
 import { ScopedLocalStorage } from './ScopedLocalStorage';
 
-describe('ScopedLocalStorage', () => {
+describe('ScopedStorage', () => {
   describe('public methods', () => {
     afterEach(() => localStorage.clear());
 
@@ -33,6 +34,58 @@ describe('ScopedLocalStorage', () => {
 
       scopedLocalStorage.clear();
       expect(localStorage.length).toEqual(0);
+    });
+  });
+
+  describe('with base storage', () => {
+    const scopedLocalStorage = new ScopedLocalStorage(
+      'CBWSDK',
+      'testing',
+      browserStorageAdapter(localStorage)
+    );
+
+    afterEach(() => localStorage.clear());
+
+    test('@setItem', () => {
+      scopedLocalStorage.setItem('foo', 'bar');
+
+      expect(localStorage.getItem('-CBWSDK:testing:foo')).toEqual('bar');
+      expect(localStorage.length).toEqual(1);
+    });
+
+    test('@getItem', () => {
+      scopedLocalStorage.setItem('foo', 'bar');
+      const getVal = scopedLocalStorage.getItem('foo');
+
+      expect(getVal).toEqual('bar');
+    });
+
+    test('@removeItem', () => {
+      scopedLocalStorage.removeItem('foo');
+
+      expect(localStorage.length).toEqual(0);
+    });
+
+    test('@clear', () => {
+      scopedLocalStorage.setItem('foo1', 'bar1');
+      scopedLocalStorage.setItem('foo2', 'bar2');
+      scopedLocalStorage.setItem('foo3', 'bar3');
+      expect(localStorage.length).toEqual(3);
+
+      scopedLocalStorage.clear();
+      expect(localStorage.length).toEqual(0);
+    });
+
+    test('@clear - only clear unscoped items', () => {
+      localStorage.setItem('unscoped-item', 'foo');
+
+      scopedLocalStorage.setItem('foo1', 'bar1');
+      scopedLocalStorage.setItem('foo2', 'bar2');
+      scopedLocalStorage.setItem('foo3', 'bar3');
+      expect(localStorage.length).toEqual(4);
+
+      scopedLocalStorage.clear();
+      expect(localStorage.length).toEqual(1);
     });
   });
 });

--- a/packages/wallet-sdk/src/util/ScopedLocalStorage.ts
+++ b/packages/wallet-sdk/src/util/ScopedLocalStorage.ts
@@ -1,51 +1,63 @@
 // Copyright (c) 2018-2024 Coinbase, Inc. <https://www.coinbase.com/>
 
+import { BaseStorage, browserStorageAdapter } from './BaseStorage';
+
 // TODO: clean up, or possibly deprecate Storage class
 export class ScopedLocalStorage {
+  private baseStorage: BaseStorage;
+
   constructor(
     private scope: 'CBWSDK' | 'walletlink',
-    private module?: string
-  ) {}
+    private module?: string,
+    baseStorage?: BaseStorage
+  ) {
+    if (baseStorage) {
+      this.baseStorage = baseStorage;
+    } else {
+      if (!window.localStorage) {
+        throw new Error('ScopedLocalStorage: baseStorage is required in non-browser contexts');
+      }
+
+      this.baseStorage = browserStorageAdapter(window.localStorage);
+    }
+  }
 
   storeObject<T>(key: string, item: T) {
-    this.setItem(key, JSON.stringify(item));
+    this.baseStorage.set(key, JSON.stringify(item));
   }
 
   loadObject<T>(key: string): T | undefined {
-    const item = this.getItem(key);
+    const item = this.baseStorage.get(key);
     return item ? JSON.parse(item) : undefined;
   }
 
   public setItem(key: string, value: string): void {
-    localStorage.setItem(this.scopedKey(key), value);
+    this.baseStorage.set(this.scopedKey(key), value);
   }
 
   public getItem(key: string): string | null {
-    return localStorage.getItem(this.scopedKey(key));
+    return this.baseStorage.get(this.scopedKey(key));
   }
 
   public removeItem(key: string): void {
-    localStorage.removeItem(this.scopedKey(key));
+    this.baseStorage.delete(this.scopedKey(key));
   }
 
   public clear(): void {
     const prefix = this.scopedKey('');
-    const keysToRemove: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i);
+    for (const key of this.baseStorage.getAllKeys()) {
       if (typeof key === 'string' && key.startsWith(prefix)) {
-        keysToRemove.push(key);
+        this.baseStorage.delete(key);
       }
     }
-    keysToRemove.forEach((key) => localStorage.removeItem(key));
   }
 
   scopedKey(key: string): string {
     return `-${this.scope}${this.module ? `:${this.module}` : ''}:${key}`;
   }
 
-  static clearAll() {
-    new ScopedLocalStorage('CBWSDK').clear();
-    new ScopedLocalStorage('walletlink').clear();
+  static clearAll(baseStorage: BaseStorage | undefined) {
+    new ScopedLocalStorage('CBWSDK', undefined, baseStorage).clear();
+    new ScopedLocalStorage('walletlink', undefined, baseStorage).clear();
   }
 }

--- a/packages/wallet-sdk/src/util/ScopedStorage.test.ts
+++ b/packages/wallet-sdk/src/util/ScopedStorage.test.ts
@@ -1,11 +1,11 @@
 import { browserStorageAdapter } from './BaseStorage';
-import { ScopedLocalStorage } from './ScopedLocalStorage';
+import { ScopedStorage } from './ScopedStorage';
 
 describe('ScopedStorage', () => {
   describe('public methods', () => {
     afterEach(() => localStorage.clear());
 
-    const scopedLocalStorage = new ScopedLocalStorage('CBWSDK', 'testing');
+    const scopedLocalStorage = new ScopedStorage('CBWSDK', 'testing');
     test('@setItem', () => {
       scopedLocalStorage.setItem('foo', 'bar');
 
@@ -38,7 +38,7 @@ describe('ScopedStorage', () => {
   });
 
   describe('with base storage', () => {
-    const scopedLocalStorage = new ScopedLocalStorage(
+    const scopedLocalStorage = new ScopedStorage(
       'CBWSDK',
       'testing',
       browserStorageAdapter(localStorage)

--- a/packages/wallet-sdk/src/util/ScopedStorage.ts
+++ b/packages/wallet-sdk/src/util/ScopedStorage.ts
@@ -3,7 +3,7 @@
 import { BaseStorage, browserStorageAdapter } from './BaseStorage';
 
 // TODO: clean up, or possibly deprecate Storage class
-export class ScopedLocalStorage {
+export class ScopedStorage {
   private baseStorage: BaseStorage;
 
   constructor(
@@ -57,7 +57,7 @@ export class ScopedLocalStorage {
   }
 
   static clearAll(baseStorage: BaseStorage | undefined) {
-    new ScopedLocalStorage('CBWSDK', undefined, baseStorage).clear();
-    new ScopedLocalStorage('walletlink', undefined, baseStorage).clear();
+    new ScopedStorage('CBWSDK', undefined, baseStorage).clear();
+    new ScopedStorage('walletlink', undefined, baseStorage).clear();
   }
 }

--- a/packages/wallet-sdk/src/util/web.test.ts
+++ b/packages/wallet-sdk/src/util/web.test.ts
@@ -1,5 +1,5 @@
-import { standardErrors } from ':core/error';
 import { closePopup, openPopup } from './web';
+import { standardErrors } from ':core/error';
 
 describe('PopupManager', () => {
   beforeAll(() => {


### PR DESCRIPTION
### _Summary_

* Allow consumer dapp to pass in a custom `BaseStorage` object, which will be used by the SDK internally
* Creates `browserStorageAdapter` and `mmkvStorageAdapter` helper functions which can be used to transform `localStorage` or React Native MMKV storage objects into a `BaseStorage`
* Renames `ScopedLocalStorage` to `ScopedStorage`

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_
Tested manually + unit tests

<!--
  Verify changes. Include relevant screenshots/videos
-->
