### PR TITLE
Simplify Signer state sync

### DIFF
--- a/packages/wallet-sdk/jest.config.ts
+++ b/packages/wallet-sdk/jest.config.ts
@@ -24,9 +24,9 @@ export default {
   // TODO: Increase threshold as additional tests are added
   coverageThreshold: {
     global: {
-      branches: 70,
-      functions: 80,
-      statements: 80,
+      branches: 71,
+      functions: 81,
+      statements: 82,
     },
   },
 

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -38,14 +38,6 @@ beforeEach(() => {
 });
 
 describe('Event handling', () => {
-  it('should emit connect on eth_requestAccounts request', async () => {
-    const connectListener = jest.fn();
-    provider.on('connect', connectListener);
-
-    await provider.request({ method: 'eth_requestAccounts' });
-    expect(connectListener).toHaveBeenCalledWith({ chainId: '0x1' });
-  });
-
   it('emits disconnect event on user initiated disconnection', async () => {
     const disconnectListener = jest.fn();
     provider.on('disconnect', disconnectListener);

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -10,7 +10,7 @@ import {
 } from './core/provider/interface';
 import { Signer } from './sign/interface';
 import { createSigner, fetchSignerType, loadSignerType, storeSignerType } from './sign/util';
-import { checkErrorForInvalidRequest } from './util/provider';
+import { checkErrorForInvalidRequestArgs } from './util/provider';
 import { Communicator } from ':core/communicator/Communicator';
 import { SignerType } from ':core/message';
 import { clearAllStorage } from ':core/storage/util';
@@ -45,7 +45,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
   public async request(args: RequestArguments): Promise<unknown> {
     await this.ensureInitialized();
     try {
-      checkErrorForInvalidRequest(args);
+      checkErrorForInvalidRequestArgs(args);
       if (!this.signer) {
         switch (args.method) {
           case 'eth_requestAccounts': {

--- a/packages/wallet-sdk/src/sign/interface.ts
+++ b/packages/wallet-sdk/src/sign/interface.ts
@@ -1,9 +1,6 @@
 import { RequestArguments } from ':core/provider/interface';
-import { AddressString } from ':core/type';
 
 export interface Signer {
-  readonly accounts: AddressString[];
-  readonly chainId: number;
   handshake(): Promise<void>;
   request(request: RequestArguments): Promise<unknown>;
   disconnect: () => Promise<void>;

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -101,6 +101,10 @@ describe('SCWSigner', () => {
       ]);
       expect(storageStoreSpy).toHaveBeenCalledWith('walletCapabilities', mockCapabilities);
       expect(storageStoreSpy).toHaveBeenCalledWith('accounts', ['0xAddress']);
+
+      expect(signer.request({ method: 'eth_requestAccounts' })).resolves.toEqual(['0xAddress']);
+      expect(mockCallback).toHaveBeenCalledWith('accountsChanged', ['0xAddress']);
+      expect(mockCallback).toHaveBeenCalledWith('connect', { chainId: '0x1' });
     });
 
     it('should throw an error if failure in response.content', async () => {
@@ -129,6 +133,10 @@ describe('SCWSigner', () => {
             return null;
         }
       });
+    });
+
+    afterAll(() => {
+      jest.spyOn(ScopedAsyncStorage.prototype, 'loadObject').mockRestore();
     });
 
     it('should perform a successful request', async () => {

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -119,16 +119,12 @@ describe('SCWSigner', () => {
 
   describe('request', () => {
     beforeAll(() => {
-      jest.spyOn(ScopedAsyncStorage.prototype, 'loadObject').mockImplementation((key) => {
+      jest.spyOn(ScopedAsyncStorage.prototype, 'loadObject').mockImplementation(async (key) => {
         switch (key) {
           case 'accounts':
             return ['0xAddress'];
           case 'activeChain':
             return { id: 1, rpcUrl: 'https://eth-rpc.example.com/1' };
-          case 'availableChains':
-            return mockChains;
-          case 'walletCapabilities':
-            return mockCapabilities;
           default:
             return null;
         }

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -118,6 +118,23 @@ describe('SCWSigner', () => {
   });
 
   describe('request', () => {
+    beforeAll(() => {
+      jest.spyOn(ScopedAsyncStorage.prototype, 'loadObject').mockImplementation((key) => {
+        switch (key) {
+          case 'accounts':
+            return ['0xAddress'];
+          case 'activeChain':
+            return { id: 1, rpcUrl: 'https://eth-rpc.example.com/1' };
+          case 'availableChains':
+            return mockChains;
+          case 'walletCapabilities':
+            return mockCapabilities;
+          default:
+            return null;
+        }
+      });
+    });
+
     it('should perform a successful request', async () => {
       const mockRequest: RequestArguments = {
         method: 'personal_sign',

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
@@ -8,6 +8,7 @@ import { ScopedLocalStorage } from './storage/ScopedLocalStorage';
 import { WalletLinkSigner } from './WalletLinkSigner';
 import { WALLETLINK_URL } from ':core/constants';
 import { standardErrorCodes, standardErrors } from ':core/error';
+import { ProviderEventCallback } from ':core/provider/interface';
 
 jest.mock('./relay/WalletLinkRelay', () => {
   return {
@@ -16,11 +17,12 @@ jest.mock('./relay/WalletLinkRelay', () => {
 });
 
 const testStorage = new ScopedLocalStorage('walletlink', WALLETLINK_URL);
+const mockCallback: ProviderEventCallback = jest.fn();
 
 const createAdapter = (options?: { relay?: WalletLinkRelay }) => {
   const adapter = new WalletLinkSigner({
     metadata: { appName: 'test', appLogoUrl: null, appChainIds: [1] },
-    callback: jest.fn(),
+    callback: mockCallback,
   });
   if (options?.relay) {
     (adapter as any)._relay = options.relay;
@@ -37,6 +39,7 @@ describe('LegacyProvider', () => {
     const provider = createAdapter();
     const response = await provider.request({ method: 'eth_requestAccounts' });
     expect(response[0]).toBe(MOCK_ADDERESS.toLowerCase());
+    expect(mockCallback).toHaveBeenCalledWith('connect', { chainId: '0x1' });
   });
 
   it('handles close', async () => {

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
@@ -84,14 +84,6 @@ export class WalletLinkSigner implements Signer {
     this.initializeRelay();
   }
 
-  get accounts() {
-    return this._addresses;
-  }
-
-  get chainId() {
-    return this.getChainId();
-  }
-
   getSession() {
     const relay = this.initializeRelay();
     const { id, secret } = relay.getWalletLinkSession();
@@ -299,7 +291,7 @@ export class WalletLinkSigner implements Signer {
 
     switch (method) {
       case 'eth_requestAccounts': {
-        await this.handshake();
+        this.callback?.('connect', { chainId: hexStringFromNumber(this.getChainId()) });
         return { jsonrpc: '2.0', id: 0, result: this._addresses };
       }
 

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
@@ -291,6 +291,7 @@ export class WalletLinkSigner implements Signer {
 
     switch (method) {
       case 'eth_requestAccounts': {
+        await this.handshake();
         this.callback?.('connect', { chainId: hexStringFromNumber(this.getChainId()) });
         return { jsonrpc: '2.0', id: 0, result: this._addresses };
       }

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
@@ -90,6 +90,10 @@ export class WalletLinkSigner implements Signer {
     return { id, secret };
   }
 
+  async handshake() {
+    await this._eth_requestAccounts();
+  }
+
   get selectedAddress(): AddressString | undefined {
     return this._addresses[0] || undefined;
   }
@@ -290,11 +294,8 @@ export class WalletLinkSigner implements Signer {
     const params = request.params || [];
 
     switch (method) {
-      case 'eth_requestAccounts': {
-        await this.handshake();
-        this.callback?.('connect', { chainId: hexStringFromNumber(this.getChainId()) });
-        return { jsonrpc: '2.0', id: 0, result: this._addresses };
-      }
+      case 'eth_requestAccounts':
+        return this._eth_requestAccounts();
 
       case 'eth_ecRecover':
         return this._eth_ecRecover(params);
@@ -472,9 +473,14 @@ export class WalletLinkSigner implements Signer {
     return ensureIntNumber(chainId);
   }
 
-  async handshake() {
+  private async _eth_requestAccounts(): Promise<JSONRPCResponse> {
     if (this._isAuthorized()) {
-      return;
+      this.callback?.('connect', { chainId: hexStringFromNumber(this.getChainId()) });
+      return Promise.resolve({
+        jsonrpc: '2.0',
+        id: 0,
+        result: this._addresses,
+      });
     }
 
     let res: Web3Response<'requestEthereumAccounts'>;
@@ -496,6 +502,8 @@ export class WalletLinkSigner implements Signer {
     }
 
     this._setAddresses(res.result);
+    this.callback?.('connect', { chainId: hexStringFromNumber(this.getChainId()) });
+    return { jsonrpc: '2.0', id: 0, result: this._addresses };
   }
 
   private _eth_ecRecover(params: unknown[]): Promise<JSONRPCResponse> {

--- a/packages/wallet-sdk/src/util/provider.test.ts
+++ b/packages/wallet-sdk/src/util/provider.test.ts
@@ -1,4 +1,4 @@
-import { checkErrorForInvalidRequest } from './provider';
+import { checkErrorForInvalidRequestArgs } from './provider';
 import { standardErrors } from ':core/error';
 
 // @ts-expect-error-next-line
@@ -24,61 +24,63 @@ describe('Utils', () => {
   describe('getErrorForInvalidRequestArgs', () => {
     it('should throw if args is not an object', () => {
       const args = 'not an object';
-      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidArgsError(args));
+      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidArgsError(args));
     });
 
     it('should throw if args is an array', () => {
       const args = ['an array'];
-      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidArgsError(args));
+      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidArgsError(args));
     });
 
     it('should throw if args.method is not a string', () => {
       const args = { method: 123 };
-      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidMethodError(args));
+      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidMethodError(args));
       const args2 = { method: { method: 'string' } };
-      expect(() => checkErrorForInvalidRequest(args2)).toThrow(invalidMethodError(args2));
+      expect(() => checkErrorForInvalidRequestArgs(args2)).toThrow(invalidMethodError(args2));
     });
 
     it('should throw if args.method is an empty string', () => {
       const args = { method: '' };
-      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidMethodError(args));
+      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidMethodError(args));
     });
 
     it('should throw if args.params is not an array or object', () => {
       const args = { method: 'foo', params: 'not an array or object' };
-      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidParamsError(args));
+      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidParamsError(args));
       const args2 = { method: 'foo', params: 123 };
-      expect(() => checkErrorForInvalidRequest(args2)).toThrow(invalidParamsError(args2));
+      expect(() => checkErrorForInvalidRequestArgs(args2)).toThrow(invalidParamsError(args2));
     });
 
     it('should throw if args.params is null', () => {
       const args = { method: 'foo', params: null };
-      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidParamsError(args));
+      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidParamsError(args));
     });
 
     it('should not throw if args.params is undefined', () => {
-      expect(() => checkErrorForInvalidRequest({ method: 'foo', params: undefined })).not.toThrow();
-      expect(() => checkErrorForInvalidRequest({ method: 'foo' })).not.toThrow();
+      expect(() =>
+        checkErrorForInvalidRequestArgs({ method: 'foo', params: undefined })
+      ).not.toThrow();
+      expect(() => checkErrorForInvalidRequestArgs({ method: 'foo' })).not.toThrow();
     });
 
     it('should not throw if args.params is an array', () => {
       expect(() =>
-        checkErrorForInvalidRequest({ method: 'foo', params: ['an array'] })
+        checkErrorForInvalidRequestArgs({ method: 'foo', params: ['an array'] })
       ).not.toThrow();
     });
 
     it('should not throw if args.params is an object', () => {
       expect(() =>
-        checkErrorForInvalidRequest({ method: 'foo', params: { foo: 'bar' } })
+        checkErrorForInvalidRequestArgs({ method: 'foo', params: { foo: 'bar' } })
       ).not.toThrow();
     });
 
     it('should not throw if args.params is an empty array', () => {
-      expect(() => checkErrorForInvalidRequest({ method: 'foo', params: [] })).not.toThrow();
+      expect(() => checkErrorForInvalidRequestArgs({ method: 'foo', params: [] })).not.toThrow();
     });
 
     it('should not throw if args.params is an empty object', () => {
-      expect(() => checkErrorForInvalidRequest({ method: 'foo', params: {} })).not.toThrow();
+      expect(() => checkErrorForInvalidRequestArgs({ method: 'foo', params: {} })).not.toThrow();
     });
 
     it('throws error for requests with unsupported or deprecated method', async () => {
@@ -86,7 +88,7 @@ describe('Utils', () => {
       const unsupported = ['eth_subscribe', 'eth_unsubscribe'];
 
       for (const method of [...deprecated, ...unsupported]) {
-        expect(() => checkErrorForInvalidRequest({ method })).toThrow(
+        expect(() => checkErrorForInvalidRequestArgs({ method })).toThrow(
           standardErrors.provider.unsupportedMethod()
         );
       }

--- a/packages/wallet-sdk/src/util/provider.test.ts
+++ b/packages/wallet-sdk/src/util/provider.test.ts
@@ -80,5 +80,16 @@ describe('Utils', () => {
     it('should not throw if args.params is an empty object', () => {
       expect(() => checkErrorForInvalidRequest({ method: 'foo', params: {} })).not.toThrow();
     });
+
+    it('throws error for requests with unsupported or deprecated method', async () => {
+      const deprecated = ['eth_sign', 'eth_signTypedData_v2'];
+      const unsupported = ['eth_subscribe', 'eth_unsubscribe'];
+
+      for (const method of [...deprecated, ...unsupported]) {
+        expect(() => checkErrorForInvalidRequest({ method })).toThrow(
+          standardErrors.provider.unsupportedMethod()
+        );
+      }
+    });
   });
 });

--- a/packages/wallet-sdk/src/util/provider.test.ts
+++ b/packages/wallet-sdk/src/util/provider.test.ts
@@ -1,4 +1,4 @@
-import { checkErrorForInvalidRequestArgs } from './provider';
+import { checkErrorForInvalidRequest } from './provider';
 import { standardErrors } from ':core/error';
 
 // @ts-expect-error-next-line
@@ -24,63 +24,61 @@ describe('Utils', () => {
   describe('getErrorForInvalidRequestArgs', () => {
     it('should throw if args is not an object', () => {
       const args = 'not an object';
-      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidArgsError(args));
+      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidArgsError(args));
     });
 
     it('should throw if args is an array', () => {
       const args = ['an array'];
-      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidArgsError(args));
+      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidArgsError(args));
     });
 
     it('should throw if args.method is not a string', () => {
       const args = { method: 123 };
-      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidMethodError(args));
+      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidMethodError(args));
       const args2 = { method: { method: 'string' } };
-      expect(() => checkErrorForInvalidRequestArgs(args2)).toThrow(invalidMethodError(args2));
+      expect(() => checkErrorForInvalidRequest(args2)).toThrow(invalidMethodError(args2));
     });
 
     it('should throw if args.method is an empty string', () => {
       const args = { method: '' };
-      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidMethodError(args));
+      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidMethodError(args));
     });
 
     it('should throw if args.params is not an array or object', () => {
       const args = { method: 'foo', params: 'not an array or object' };
-      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidParamsError(args));
+      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidParamsError(args));
       const args2 = { method: 'foo', params: 123 };
-      expect(() => checkErrorForInvalidRequestArgs(args2)).toThrow(invalidParamsError(args2));
+      expect(() => checkErrorForInvalidRequest(args2)).toThrow(invalidParamsError(args2));
     });
 
     it('should throw if args.params is null', () => {
       const args = { method: 'foo', params: null };
-      expect(() => checkErrorForInvalidRequestArgs(args)).toThrow(invalidParamsError(args));
+      expect(() => checkErrorForInvalidRequest(args)).toThrow(invalidParamsError(args));
     });
 
     it('should not throw if args.params is undefined', () => {
-      expect(() =>
-        checkErrorForInvalidRequestArgs({ method: 'foo', params: undefined })
-      ).not.toThrow();
-      expect(() => checkErrorForInvalidRequestArgs({ method: 'foo' })).not.toThrow();
+      expect(() => checkErrorForInvalidRequest({ method: 'foo', params: undefined })).not.toThrow();
+      expect(() => checkErrorForInvalidRequest({ method: 'foo' })).not.toThrow();
     });
 
     it('should not throw if args.params is an array', () => {
       expect(() =>
-        checkErrorForInvalidRequestArgs({ method: 'foo', params: ['an array'] })
+        checkErrorForInvalidRequest({ method: 'foo', params: ['an array'] })
       ).not.toThrow();
     });
 
     it('should not throw if args.params is an object', () => {
       expect(() =>
-        checkErrorForInvalidRequestArgs({ method: 'foo', params: { foo: 'bar' } })
+        checkErrorForInvalidRequest({ method: 'foo', params: { foo: 'bar' } })
       ).not.toThrow();
     });
 
     it('should not throw if args.params is an empty array', () => {
-      expect(() => checkErrorForInvalidRequestArgs({ method: 'foo', params: [] })).not.toThrow();
+      expect(() => checkErrorForInvalidRequest({ method: 'foo', params: [] })).not.toThrow();
     });
 
     it('should not throw if args.params is an empty object', () => {
-      expect(() => checkErrorForInvalidRequestArgs({ method: 'foo', params: {} })).not.toThrow();
+      expect(() => checkErrorForInvalidRequest({ method: 'foo', params: {} })).not.toThrow();
     });
   });
 });

--- a/packages/wallet-sdk/src/util/provider.ts
+++ b/packages/wallet-sdk/src/util/provider.ts
@@ -26,7 +26,7 @@ export async function fetchRPCRequest(request: RequestArguments, rpcUrl?: string
  * @param args The request arguments to validate.
  * @returns An error object if the arguments are invalid, otherwise undefined.
  */
-export function checkErrorForInvalidRequestArgs(args: unknown): asserts args is RequestArguments {
+export function checkErrorForInvalidRequest(args: unknown): asserts args is RequestArguments {
   if (!args || typeof args !== 'object' || Array.isArray(args)) {
     throw standardErrors.rpc.invalidParams({
       message: 'Expected a single, non-array, object argument.',
@@ -52,5 +52,13 @@ export function checkErrorForInvalidRequestArgs(args: unknown): asserts args is 
       message: "'args.params' must be an object or array if provided.",
       data: args,
     });
+  }
+
+  switch (method) {
+    case 'eth_sign':
+    case 'eth_signTypedData_v2':
+    case 'eth_subscribe':
+    case 'eth_unsubscribe':
+      throw standardErrors.provider.unsupportedMethod();
   }
 }

--- a/packages/wallet-sdk/src/util/provider.ts
+++ b/packages/wallet-sdk/src/util/provider.ts
@@ -26,7 +26,7 @@ export async function fetchRPCRequest(request: RequestArguments, rpcUrl?: string
  * @param args The request arguments to validate.
  * @returns An error object if the arguments are invalid, otherwise undefined.
  */
-export function checkErrorForInvalidRequest(args: unknown): asserts args is RequestArguments {
+export function checkErrorForInvalidRequestArgs(args: unknown): asserts args is RequestArguments {
   if (!args || typeof args !== 'object' || Array.isArray(args)) {
     throw standardErrors.rpc.invalidParams({
       message: 'Expected a single, non-array, object argument.',


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

- Remove `accounts` and `chain` from `Signer` interface
- Relocate local handling of `eth_requestAccounts` to each signer
- `checkErrorForInvalidRequest` to handle deprecated method error as well
- Revert WalletLink changes on https://github.com/coinbase/coinbase-wallet-sdk/pull/1343

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
 unit tests