### PR TITLE
Append SDK path to appDeeplinkUrl

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.native.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.native.ts
@@ -18,7 +18,9 @@ export class CoinbaseWalletSDK {
     }
 
     const url = new URL(metadata.appDeeplinkUrl);
-    url.pathname = `/${MOBILE_SDK_RESPONSE_PATH}`;
+    url.pathname += url.pathname.endsWith('/')
+      ? MOBILE_SDK_RESPONSE_PATH
+      : `/${MOBILE_SDK_RESPONSE_PATH}`;
 
     this.metadata = {
       appName: metadata.appName || 'Dapp',


### PR DESCRIPTION
### _Summary_
Appends the SDK path to the appDeeplinkUrl instead of replacing the path
<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
