### PR TITLE
[WL cleanup] simplify ecRecover requests handling

### DIFF
--- a/packages/wallet-sdk/src/core/type/util.test.ts
+++ b/packages/wallet-sdk/src/core/type/util.test.ts
@@ -1,6 +1,7 @@
 import { HexString } from '.';
 import {
   bigIntStringFromBigInt,
+  encodeToHexString,
   ensureAddressString,
   ensureBigInt,
   ensureBuffer,
@@ -46,6 +47,14 @@ describe('util', () => {
   test('hexStringFromBuffer', () => {
     expect(hexStringFromBuffer(Buffer.alloc(3))).toEqual('000000');
     expect(hexStringFromBuffer(Buffer.alloc(3), true)).toEqual('0x000000');
+  });
+
+  test('endcodeToHexString', () => {
+    expect(encodeToHexString('')).toEqual('0x');
+    expect(encodeToHexString('713')).toEqual('0x0713');
+    expect(
+      encodeToHexString('My name is Giovanni Giorgio, but everybody calls me... Jungho')
+    ).toEqual(expect.stringContaining('0x4d79206e'));
   });
 
   test('bigIntStringFromBigInt', () => {

--- a/packages/wallet-sdk/src/core/type/util.ts
+++ b/packages/wallet-sdk/src/core/type/util.ts
@@ -27,6 +27,10 @@ export function hexStringFromBuffer(buf: Buffer, includePrefix = false): HexStri
   return HexString(includePrefix ? `0x${hex}` : hex);
 }
 
+export function encodeToHexString(str: unknown): HexString {
+  return hexStringFromBuffer(ensureBuffer(str), true);
+}
+
 export function bigIntStringFromBigInt(bi: bigint): BigIntString {
   return BigIntString(bi.toString(10));
 }

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
@@ -119,6 +119,46 @@ describe('LegacyProvider', () => {
     expect(response[0]).toBe(MOCK_ADDERESS.toLowerCase());
   });
 
+  describe('ecRecover', () => {
+    const relay = mockedWalletLinkRelay();
+    const sendRequestSpy = jest.spyOn(relay, 'sendRequest').mockResolvedValue({
+      result: AddressString(MOCK_ADDERESS),
+    });
+    const provider = createAdapter({ relay });
+
+    test('eth_ecRecover', async () => {
+      const response = await provider?.request({
+        method: 'eth_ecRecover',
+        params: ['Super safe message', '0x'],
+      });
+      expect(sendRequestSpy).toBeCalledWith({
+        method: 'ethereumAddressFromSignedMessage',
+        params: {
+          addPrefix: false,
+          message: '0x53757065722073616665206d657373616765',
+          signature: '0x',
+        },
+      });
+      expect(response).toBe(MOCK_ADDERESS);
+    });
+
+    test('personal_ecRecover', async () => {
+      const response = await provider?.request({
+        method: 'personal_ecRecover',
+        params: ['Super safe message', '0x'],
+      });
+      expect(sendRequestSpy).toBeCalledWith({
+        method: 'ethereumAddressFromSignedMessage',
+        params: {
+          addPrefix: true,
+          message: '0x53757065722073616665206d657373616765',
+          signature: '0x',
+        },
+      });
+      expect(response).toBe(MOCK_ADDERESS);
+    });
+  });
+
   describe('RPC Methods', () => {
     let provider: WalletLinkSigner | null = null;
     beforeEach(() => {
@@ -165,14 +205,6 @@ describe('LegacyProvider', () => {
       expect(response).toEqual([MOCK_ADDERESS.toLowerCase()]);
     });
 
-    test('eth_ecRecover', async () => {
-      const response = await provider?.request({
-        method: 'eth_ecRecover',
-        params: ['Super safe message', '0x'],
-      });
-      expect(response).toBe(MOCK_ADDERESS);
-    });
-
     test('personal_sign success', async () => {
       const response = await provider?.request({
         method: 'personal_sign',
@@ -191,14 +223,6 @@ describe('LegacyProvider', () => {
         standardErrorCodes.rpc.invalidParams,
         'Invalid Ethereum address: Super safe message'
       );
-    });
-
-    test('personal_ecRecover', async () => {
-      const response = await provider?.request({
-        method: 'personal_ecRecover',
-        params: ['Super safe message', '0x'],
-      });
-      expect(response).toBe(MOCK_ADDERESS);
     });
 
     test('eth_signTransaction', async () => {

--- a/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
@@ -204,17 +204,6 @@ export class WalletLinkRelay implements WalletLinkConnectionUpdateListener {
     });
   }
 
-  public ethereumAddressFromSignedMessage(message: Buffer, signature: Buffer, addPrefix: boolean) {
-    return this.sendRequest({
-      method: 'ethereumAddressFromSignedMessage',
-      params: {
-        message: hexStringFromBuffer(message, true),
-        signature: hexStringFromBuffer(signature, true),
-        addPrefix,
-      },
-    });
-  }
-
   public signEthereumTransaction(params: EthereumTransactionParams) {
     return this.sendRequest({
       method: 'signEthereumTransaction',

--- a/packages/wallet-sdk/src/sign/walletlink/relay/mocks/relay.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/mocks/relay.ts
@@ -50,12 +50,6 @@ const mock = {
       result: HexString('0x'),
     });
   },
-  ethereumAddressFromSignedMessage() {
-    return makeMockReturn({
-      method: 'ethereumAddressFromSignedMessage',
-      result: AddressString(MOCK_ADDERESS),
-    });
-  },
   signEthereumTransaction() {
     return makeMockReturn({
       method: 'signEthereumTransaction',


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

- reduce call stack to process `eth_ecRecover` and `personal_ecRecover`
- deprecate `Relay.ethereumAddressFromSignedMessage`

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

unit tests
