### PR TITLE
[WL cleanup] simpify sign_typedData/personal_sign

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
@@ -187,23 +187,6 @@ export class WalletLinkRelay implements WalletLinkConnectionUpdateListener {
     this.storage.setItem(key, value);
   }
 
-  public signEthereumMessage(
-    message: Buffer,
-    address: AddressString,
-    addPrefix: boolean,
-    typedDataJson?: string | null
-  ) {
-    return this.sendRequest({
-      method: 'signEthereumMessage',
-      params: {
-        message: hexStringFromBuffer(message, true),
-        address,
-        addPrefix,
-        typedDataJson: typedDataJson || null,
-      },
-    });
-  }
-
   public signEthereumTransaction(params: EthereumTransactionParams) {
     return this.sendRequest({
       method: 'signEthereumTransaction',

--- a/packages/wallet-sdk/src/sign/walletlink/relay/mocks/relay.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/mocks/relay.ts
@@ -44,12 +44,6 @@ const mock = {
       },
     });
   },
-  signEthereumMessage() {
-    return makeMockReturn({
-      method: 'signEthereumMessage',
-      result: HexString('0x'),
-    });
-  },
   signEthereumTransaction() {
     return makeMockReturn({
       method: 'signEthereumTransaction',


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

- consolidate `signTypedData_*` handling
- update `personalSign` handling for consistency
- deprecate `Relay.signEthereumMessage`
- rewrite unit tests

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
unit tests