### PR TITLE
Make WalletLink session id 16 bytes

### DIFF
--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -22,7 +22,7 @@
     "pretest": "node compile-assets.js",
     "test": "jest",
     "test:coverage": "yarn test:unit && open coverage/lcov-report/index.html",
-    "prebuild": "rm -rf ./build && node -p \"'export const LIB_VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",
+    "prebuild": "rm -rf ./dist && node -p \"'export const LIB_VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",
     "build": "node compile-assets.js && tsc -p ./tsconfig.build.json && tsc-alias && cp -a src/vendor-js dist",
     "dev": "node compile-assets.js && tsc --watch & nodemon --watch dist --delay 1 --exec tsc-alias",
     "typecheck": "tsc --noEmit",

--- a/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/type/WalletLinkSession.ts
@@ -25,7 +25,7 @@ export class WalletLinkSession {
   }
 
   public static create(storage: ScopedLocalStorage): WalletLinkSession {
-    const id = randomBytesHex(32);
+    const id = randomBytesHex(16);
     const secret = randomBytesHex(32);
     return new WalletLinkSession(storage, id, secret).save();
   }


### PR DESCRIPTION
### _Summary_
This [PR](https://github.com/coinbase/coinbase-wallet-sdk/pull/1376/files#diff-9a5f07fb15dec7abb885e5b6e61df8119ede8cb8e1cc456fa562cb91aefcc470R28) introduced a bug where  WalletLink session id's are incorrectly set to be 32 bytes, which is invalid.




<!--
  What changed? Link to relevant issues.
-->

This PR reverts the change and makes it 16 bytes

### _How did you test your changes?_
Tested manually 
<!--
  Verify changes. Include relevant screenshots/videos
-->
