### PR TITLE
Allowing Permission Methods in SDK

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -11,6 +11,9 @@ import {
   exportKeyToHexString,
   importKeyFromHexString,
 } from ':util/cipher';
+import { fetchRPCRequest } from ':util/provider';
+
+jest.mock(':util/provider');
 
 jest.mock('./SCWKeyManager');
 const storageStoreSpy = jest.spyOn(ScopedAsyncStorage.prototype, 'storeObject');
@@ -163,6 +166,59 @@ describe('SCWSigner', () => {
         })
       );
       expect(result).toEqual('0xSignature');
+    });
+
+    it.each([
+      'eth_ecRecover',
+      'personal_sign',
+      'personal_ecRecover',
+      'eth_signTransaction',
+      'eth_sendTransaction',
+      'eth_signTypedData_v1',
+      'eth_signTypedData_v3',
+      'eth_signTypedData_v4',
+      'eth_signTypedData',
+      'wallet_addEthereumChain',
+      'wallet_watchAsset',
+      'wallet_sendCalls',
+      'wallet_showCallsStatus',
+      'wallet_grantPermissions',
+    ])('should send request to popup for %s', async (method) => {
+      const mockRequest: RequestArguments = {
+        method,
+        params: [],
+      };
+
+      (decryptContent as jest.Mock).mockResolvedValueOnce({
+        result: {
+          value: '0xSignature',
+        },
+      });
+
+      await signer.request(mockRequest);
+
+      expect(mockCommunicator.postRequestAndWaitForResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sender: '0xPublicKey',
+          content: { encrypted: encryptedData },
+        })
+      );
+    });
+
+    it.each([
+      'wallet_prepareCalls',
+      'wallet_sendPreparedCalls',
+      'eth_getBalance',
+      'eth_getTransactionCount',
+    ])('should fetch rpc request for %s', async (method) => {
+      const mockRequest: RequestArguments = {
+        method,
+        params: [],
+      };
+
+      await signer.request(mockRequest);
+
+      expect(fetchRPCRequest).toHaveBeenCalledWith(mockRequest, 'https://eth-rpc.example.com/1');
     });
 
     it('should throw an error if error in decrypted response', async () => {

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -138,6 +138,7 @@ export class SCWSigner implements Signer {
       case 'wallet_watchAsset':
       case 'wallet_sendCalls':
       case 'wallet_showCallsStatus':
+      case 'wallet_grantPermissions':
         return this.sendRequestToPopup(request);
       default:
         if (!this.chain.rpcUrl) throw standardErrors.rpc.internal('No RPC URL set for chain');


### PR DESCRIPTION
### _Summary_

3 new permission methods were introduced, they are 

* wallet_grantPermissions
* wallet_prepareCalls
* wallet_sendPreparedCalls

Allowing them in SCWSigner.

### _How did you test your changes?_

Unit Tests added
