### PR TITLE
add option to pass scwOnboardMode to eth_requestAccounts

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -111,6 +111,22 @@ describe('Signer configuration', () => {
     expect(mockHandshake).toHaveBeenCalledWith();
   });
 
+  it('should support scwOnboardMode', async () => {
+    mockFetchSignerType.mockResolvedValue('scw');
+
+    await provider.request({
+      method: 'eth_requestAccounts',
+      params: [{ scwOnboardMode: 'create' }],
+    });
+    expect(mockFetchSignerType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {
+          scwOnboardMode: 'create',
+        },
+      })
+    );
+  });
+
   it('should throw error if signer selection failed', async () => {
     const error = new Error('Signer selection failed');
     mockFetchSignerType.mockRejectedValue(error);

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -111,7 +111,7 @@ describe('Signer configuration', () => {
     expect(mockHandshake).toHaveBeenCalledWith();
   });
 
-  it('should support scwOnboardMode', async () => {
+  it('should support scwOnboardMode create', async () => {
     mockFetchSignerType.mockResolvedValue('scw');
 
     await provider.request({
@@ -122,6 +122,37 @@ describe('Signer configuration', () => {
       expect.objectContaining({
         options: {
           scwOnboardMode: 'create',
+        },
+      })
+    );
+  });
+
+  it('should support scwOnboardMode default', async () => {
+    mockFetchSignerType.mockResolvedValue('scw');
+
+    await provider.request({
+      method: 'eth_requestAccounts',
+      params: [{ scwOnboardMode: 'default' }],
+    });
+    expect(mockFetchSignerType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {
+          scwOnboardMode: 'default',
+        },
+      })
+    );
+  });
+
+  it('should support no scwOnboardMode passed', async () => {
+    mockFetchSignerType.mockResolvedValue('scw');
+
+    await provider.request({
+      method: 'eth_requestAccounts',
+    });
+    expect(mockFetchSignerType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {
+          scwOnboardMode: 'default',
         },
       })
     );

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -58,9 +58,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
             const scwOnboardMode = Array.isArray(args?.params)
               ? (args.params[0]?.scwOnboardMode as ScwOnboardMode)
               : undefined;
-            const options: { scwOnboardMode: ScwOnboardMode } = scwOnboardMode
-              ? { scwOnboardMode }
-              : { scwOnboardMode: 'default' };
+            const options = { scwOnboardMode: scwOnboardMode ?? 'default' };
             const signerType = await this.requestSignerSelection(options);
             const signer = await this.initSigner(signerType);
             await signer.handshake();

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -17,10 +17,13 @@ export async function storeSignerType(signerType: SignerType): Promise<void> {
   return storage.setItem(SIGNER_TYPE_KEY, signerType);
 }
 
+export type ScwOnboardMode = 'default' | 'create';
+
 export async function fetchSignerType(params: {
   communicator: Communicator;
   preference: Preference;
   metadata: AppMetadata; // for WalletLink
+  options?: Record<string, unknown>;
 }): Promise<SignerType> {
   const { communicator, metadata } = params;
   listenForWalletLinkSessionRequest(communicator, metadata).catch(() => {});
@@ -30,6 +33,11 @@ export async function fetchSignerType(params: {
     event: 'selectSignerType',
     data: params.preference,
   };
+
+  if (params.options?.scwOnboardMode) {
+    (request.data as { scwOnboardMode: ScwOnboardMode }).scwOnboardMode = params.options
+      .scwOnboardMode as ScwOnboardMode;
+  }
   const { data } = await communicator.postRequestAndWaitForResponse(request);
   return data as SignerType;
 }


### PR DESCRIPTION
### _Summary_
Adding the option for dapps to take users directly to Smart Wallet creation by passing a custom `scwOnboardMode` param to eth_requestAccounts

```
const [address] = await provider.request({ method: 'eth_requestAccounts', params: [{scwOnboardMode: 'create'}] })
```

### _How did you test your changes?_
unit tests & locally 

Create Button manual test

https://github.com/user-attachments/assets/20dc415c-eadb-4d3b-87ff-2e9b3cb741fe


Manual test of all 3 param possibilities 



https://github.com/user-attachments/assets/224280b5-fa68-450d-8813-23ed3717edaf

