### PR TITLE
Update Communicator to include app metadata

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -28,7 +28,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
     super();
     this.metadata = metadata;
     this.preference = preference;
-    this.communicator = Communicator.getInstance(keysUrl);
+    this.communicator = Communicator.getInstance(keysUrl, metadata);
 
     // Async initialize
     this.initPromise = this.initialize();

--- a/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
@@ -1,3 +1,5 @@
+import { AppMetadata } from 'src/index';
+
 import { LIB_VERSION } from '../../version';
 import { Message, MessageID } from '../message';
 import { Communicator } from './Communicator';
@@ -41,6 +43,13 @@ function queueMessageEvent({
 const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
 const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
 
+const appMetadata: AppMetadata = {
+  appName: 'Test App',
+  appLogoUrl: null,
+  appChainIds: [1],
+  appDeeplinkUrl: null,
+};
+
 describe('Communicator', () => {
   let urlOrigin: string;
   let communicator: Communicator;
@@ -54,7 +63,7 @@ describe('Communicator', () => {
     Communicator.communicators.clear();
 
     // url defaults to CB_KEYS_URL
-    communicator = Communicator.getInstance();
+    communicator = Communicator.getInstance(CB_KEYS_URL, appMetadata);
     urlOrigin = new URL(CB_KEYS_URL).origin;
 
     mockPopup = {
@@ -101,6 +110,7 @@ describe('Communicator', () => {
         {
           data: {
             version: LIB_VERSION,
+            metadata: appMetadata,
           },
         },
         urlOrigin
@@ -126,6 +136,7 @@ describe('Communicator', () => {
         {
           data: {
             version: LIB_VERSION,
+            metadata: appMetadata,
           },
         },
         urlOrigin
@@ -146,6 +157,7 @@ describe('Communicator', () => {
         {
           data: {
             version: LIB_VERSION,
+            metadata: appMetadata,
           },
         },
         urlOrigin

--- a/packages/wallet-sdk/src/core/communicator/Communicator.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.ts
@@ -2,6 +2,7 @@ import { LIB_VERSION } from '../../version';
 import { ConfigMessage, Message, MessageID } from '../message';
 import { CB_KEYS_URL } from ':core/constants';
 import { standardErrors } from ':core/error';
+import { AppMetadata } from ':core/provider/interface';
 import { closePopup, openPopup } from ':util/web';
 
 /**
@@ -16,17 +17,19 @@ import { closePopup, openPopup } from ':util/web';
 export class Communicator {
   static communicators = new Map<string, Communicator>();
 
+  private readonly metadata: AppMetadata;
   private readonly url: URL;
   private popup: Window | null = null;
   private listeners = new Map<(_: MessageEvent) => void, { reject: (_: Error) => void }>();
 
-  private constructor(url: string = CB_KEYS_URL) {
+  private constructor(url: string = CB_KEYS_URL, metadata: AppMetadata) {
     this.url = new URL(url);
+    this.metadata = metadata;
   }
 
-  static getInstance(url: string = CB_KEYS_URL): Communicator {
+  static getInstance(url: string = CB_KEYS_URL, metadata: AppMetadata): Communicator {
     if (!this.communicators.has(url)) {
-      this.communicators.set(url, new Communicator(url));
+      this.communicators.set(url, new Communicator(url, metadata));
     }
 
     return this.communicators.get(url)!;
@@ -107,7 +110,7 @@ export class Communicator {
       .then((message) => {
         this.postMessage({
           requestId: message.id,
-          data: { version: LIB_VERSION },
+          data: { version: LIB_VERSION, metadata: this.metadata },
         });
       })
       .then(() => {

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -1,6 +1,7 @@
 import { SCWKeyManager } from './SCWKeyManager';
 import { SCWSigner } from './SCWSigner';
 import { Communicator } from ':core/communicator/Communicator';
+import { CB_KEYS_URL } from ':core/constants';
 import { standardErrors } from ':core/error';
 import { EncryptedData, RPCResponseMessage } from ':core/message';
 import { AppMetadata, ProviderEventCallback, RequestArguments } from ':core/provider/interface';
@@ -59,7 +60,7 @@ describe('SCWSigner', () => {
     };
 
     Communicator.communicators.clear();
-    mockCommunicator = Communicator.getInstance();
+    mockCommunicator = Communicator.getInstance(CB_KEYS_URL, mockMetadata);
     jest.spyOn(mockCommunicator, 'waitForPopupLoaded').mockResolvedValue({} as Window);
     jest
       .spyOn(mockCommunicator, 'postRequestAndWaitForResponse')

--- a/packages/wallet-sdk/src/sign/util.test.ts
+++ b/packages/wallet-sdk/src/sign/util.test.ts
@@ -1,5 +1,6 @@
 import { fetchSignerType, loadSignerType, storeSignerType } from './util';
 import { Communicator } from ':core/communicator/Communicator';
+import { CB_KEYS_URL } from ':core/constants';
 import { Preference } from ':core/provider/interface';
 import { ScopedAsyncStorage } from ':core/storage/ScopedAsyncStorage';
 
@@ -48,7 +49,7 @@ describe('util', () => {
     const preference: Preference = { options: 'all' };
 
     it('should complete signerType selection correctly', async () => {
-      const communicator = Communicator.getInstance();
+      const communicator = Communicator.getInstance(CB_KEYS_URL, metadata);
       communicator.postMessage = jest.fn();
       communicator.onMessage = jest.fn().mockResolvedValue({
         data: 'scw',


### PR DESCRIPTION
### _Summary_

This change initializes the communicator with the app metadata. This provides app metadata to the onboarding screen on keys.coinbase.com

### _How did you test your changes?_

Testing these changes requires running a few apps:

* Playground
* SCW.

1. build a version of the sdk and install it into the playground. Make sure the playground is using the newly built version
2. run the playground and scw locally (place a log where the communicator is initialized)
3. Check the message event from the sdks communicator and validate appName, and appLogoUrl are available inside of scw.

![setting-metadata-scw](https://github.com/user-attachments/assets/8ac53721-da04-48ae-9915-2460ca741360)