### PR TITLE
Revert #1383: Remove non-standard parameters from basic requests

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -111,53 +111,6 @@ describe('Signer configuration', () => {
     expect(mockHandshake).toHaveBeenCalledWith();
   });
 
-  it('should support scwOnboardMode create', async () => {
-    mockFetchSignerType.mockResolvedValue('scw');
-
-    await provider.request({
-      method: 'eth_requestAccounts',
-      params: [{ scwOnboardMode: 'create' }],
-    });
-    expect(mockFetchSignerType).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: {
-          scwOnboardMode: 'create',
-        },
-      })
-    );
-  });
-
-  it('should support scwOnboardMode default', async () => {
-    mockFetchSignerType.mockResolvedValue('scw');
-
-    await provider.request({
-      method: 'eth_requestAccounts',
-      params: [{ scwOnboardMode: 'default' }],
-    });
-    expect(mockFetchSignerType).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: {
-          scwOnboardMode: 'default',
-        },
-      })
-    );
-  });
-
-  it('should support no scwOnboardMode passed', async () => {
-    mockFetchSignerType.mockResolvedValue('scw');
-
-    await provider.request({
-      method: 'eth_requestAccounts',
-    });
-    expect(mockFetchSignerType).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: {
-          scwOnboardMode: 'default',
-        },
-      })
-    );
-  });
-
   it('should throw error if signer selection failed', async () => {
     const error = new Error('Signer selection failed');
     mockFetchSignerType.mockRejectedValue(error);

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -9,13 +9,7 @@ import {
   RequestArguments,
 } from './core/provider/interface';
 import { Signer } from './sign/interface';
-import {
-  createSigner,
-  fetchSignerType,
-  loadSignerType,
-  ScwOnboardMode,
-  storeSignerType,
-} from './sign/util';
+import { createSigner, fetchSignerType, loadSignerType, storeSignerType } from './sign/util';
 import { checkErrorForInvalidRequestArgs } from './util/provider';
 import { Communicator } from ':core/communicator/Communicator';
 import { SignerType } from ':core/message';
@@ -55,11 +49,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
       if (!this.signer) {
         switch (args.method) {
           case 'eth_requestAccounts': {
-            const scwOnboardMode = Array.isArray(args?.params)
-              ? (args.params[0]?.scwOnboardMode as ScwOnboardMode)
-              : undefined;
-            const options = { scwOnboardMode: scwOnboardMode ?? 'default' };
-            const signerType = await this.requestSignerSelection(options);
+            const signerType = await this.requestSignerSelection();
             const signer = await this.initSigner(signerType);
             await signer.handshake();
             this.signer = signer;
@@ -109,12 +99,11 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
     await this.initPromise; // resolves immediately if already initialized
   }
 
-  private requestSignerSelection(options: Record<string, unknown>): Promise<SignerType> {
+  private requestSignerSelection(): Promise<SignerType> {
     return fetchSignerType({
       communicator: this.communicator,
       preference: this.preference,
       metadata: this.metadata,
-      options,
     });
   }
 

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -17,13 +17,10 @@ export async function storeSignerType(signerType: SignerType): Promise<void> {
   return storage.setItem(SIGNER_TYPE_KEY, signerType);
 }
 
-export type ScwOnboardMode = 'default' | 'create';
-
 export async function fetchSignerType(params: {
   communicator: Communicator;
   preference: Preference;
   metadata: AppMetadata; // for WalletLink
-  options?: Record<string, unknown>;
 }): Promise<SignerType> {
   const { communicator, metadata } = params;
   listenForWalletLinkSessionRequest(communicator, metadata).catch(() => {});
@@ -33,11 +30,6 @@ export async function fetchSignerType(params: {
     event: 'selectSignerType',
     data: params.preference,
   };
-
-  if (params.options?.scwOnboardMode) {
-    (request.data as { scwOnboardMode: ScwOnboardMode }).scwOnboardMode = params.options
-      .scwOnboardMode as ScwOnboardMode;
-  }
   const { data } = await communicator.postRequestAndWaitForResponse(request);
   return data as SignerType;
 }


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

This PR reverts the change from https://github.com/coinbase/coinbase-wallet-sdk/pull/1383 that adds non-standard parameters to eth_requestAccounts.
- These params seem misplaced and introduce complexity at the wrong abstraction layer.
- eth_requestAccounts should remain simple and align with standard usage.

This revert is intended to preserve the integrity of the basic request structure and to maintain alignment with standards that developers expect when integrating with our SDK.
Looking forward to hearing more context around this decision and any further discussions that can help clarify the intended direction. cc @nateReiners @spencerstock 

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
