### PR TITLE
Pass raw request args during handshake

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -111,6 +111,53 @@ describe('Signer configuration', () => {
     expect(mockHandshake).toHaveBeenCalledWith();
   });
 
+  it('should support scwOnboardMode create', async () => {
+    mockFetchSignerType.mockResolvedValue('scw');
+
+    await provider.request({
+      method: 'eth_requestAccounts',
+      params: [{ scwOnboardMode: 'create' }],
+    });
+    expect(mockFetchSignerType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {
+          scwOnboardMode: 'create',
+        },
+      })
+    );
+  });
+
+  it('should support scwOnboardMode default', async () => {
+    mockFetchSignerType.mockResolvedValue('scw');
+
+    await provider.request({
+      method: 'eth_requestAccounts',
+      params: [{ scwOnboardMode: 'default' }],
+    });
+    expect(mockFetchSignerType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {
+          scwOnboardMode: 'default',
+        },
+      })
+    );
+  });
+
+  it('should support no scwOnboardMode passed', async () => {
+    mockFetchSignerType.mockResolvedValue('scw');
+
+    await provider.request({
+      method: 'eth_requestAccounts',
+    });
+    expect(mockFetchSignerType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: {
+          scwOnboardMode: 'default',
+        },
+      })
+    );
+  });
+
   it('should throw error if signer selection failed', async () => {
     const error = new Error('Signer selection failed');
     mockFetchSignerType.mockRejectedValue(error);

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -99,8 +99,9 @@ describe('Signer configuration', () => {
   it('should complete signerType selection correctly', async () => {
     mockFetchSignerType.mockResolvedValue('scw');
 
-    await provider.request({ method: 'eth_requestAccounts' });
-    expect(mockHandshake).toHaveBeenCalledWith();
+    const args = { method: 'eth_requestAccounts' };
+    await provider.request(args);
+    expect(mockHandshake).toHaveBeenCalledWith(args);
   });
 
   it('should support enable', async () => {
@@ -108,52 +109,20 @@ describe('Signer configuration', () => {
     jest.spyOn(console, 'warn').mockImplementation();
 
     await provider.enable();
-    expect(mockHandshake).toHaveBeenCalledWith();
+    expect(mockHandshake).toHaveBeenCalledWith({ method: 'eth_requestAccounts' });
   });
 
-  it('should support scwOnboardMode create', async () => {
+  it('should pass handshake request args', async () => {
     mockFetchSignerType.mockResolvedValue('scw');
 
-    await provider.request({
+    const argsWithCustomParams = {
       method: 'eth_requestAccounts',
       params: [{ scwOnboardMode: 'create' }],
-    });
+    };
+    await provider.request(argsWithCustomParams);
     expect(mockFetchSignerType).toHaveBeenCalledWith(
       expect.objectContaining({
-        options: {
-          scwOnboardMode: 'create',
-        },
-      })
-    );
-  });
-
-  it('should support scwOnboardMode default', async () => {
-    mockFetchSignerType.mockResolvedValue('scw');
-
-    await provider.request({
-      method: 'eth_requestAccounts',
-      params: [{ scwOnboardMode: 'default' }],
-    });
-    expect(mockFetchSignerType).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: {
-          scwOnboardMode: 'default',
-        },
-      })
-    );
-  });
-
-  it('should support no scwOnboardMode passed', async () => {
-    mockFetchSignerType.mockResolvedValue('scw');
-
-    await provider.request({
-      method: 'eth_requestAccounts',
-    });
-    expect(mockFetchSignerType).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: {
-          scwOnboardMode: 'default',
-        },
+        handshakeRequest: argsWithCustomParams,
       })
     );
   });

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -48,8 +48,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
       checkErrorForInvalidRequestArgs(args);
       if (!this.signer) {
         switch (args.method) {
-          case 'eth_requestAccounts':
-          case 'wallet_connect': /* forward compatibility */ {
+          case 'eth_requestAccounts': {
             const signerType = await this.requestSignerSelection(args);
             const signer = await this.initSigner(signerType);
             await signer.handshake(args);

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -9,7 +9,13 @@ import {
   RequestArguments,
 } from './core/provider/interface';
 import { Signer } from './sign/interface';
-import { createSigner, fetchSignerType, loadSignerType, storeSignerType } from './sign/util';
+import {
+  createSigner,
+  fetchSignerType,
+  loadSignerType,
+  ScwOnboardMode,
+  storeSignerType,
+} from './sign/util';
 import { checkErrorForInvalidRequestArgs } from './util/provider';
 import { Communicator } from ':core/communicator/Communicator';
 import { SignerType } from ':core/message';
@@ -49,7 +55,11 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
       if (!this.signer) {
         switch (args.method) {
           case 'eth_requestAccounts': {
-            const signerType = await this.requestSignerSelection();
+            const scwOnboardMode = Array.isArray(args?.params)
+              ? (args.params[0]?.scwOnboardMode as ScwOnboardMode)
+              : undefined;
+            const options = { scwOnboardMode: scwOnboardMode ?? 'default' };
+            const signerType = await this.requestSignerSelection(options);
             const signer = await this.initSigner(signerType);
             await signer.handshake();
             this.signer = signer;
@@ -99,11 +109,12 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
     await this.initPromise; // resolves immediately if already initialized
   }
 
-  private requestSignerSelection(): Promise<SignerType> {
+  private requestSignerSelection(options: Record<string, unknown>): Promise<SignerType> {
     return fetchSignerType({
       communicator: this.communicator,
       preference: this.preference,
       metadata: this.metadata,
+      options,
     });
   }
 

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -9,13 +9,7 @@ import {
   RequestArguments,
 } from './core/provider/interface';
 import { Signer } from './sign/interface';
-import {
-  createSigner,
-  fetchSignerType,
-  loadSignerType,
-  ScwOnboardMode,
-  storeSignerType,
-} from './sign/util';
+import { createSigner, fetchSignerType, loadSignerType, storeSignerType } from './sign/util';
 import { checkErrorForInvalidRequestArgs } from './util/provider';
 import { Communicator } from ':core/communicator/Communicator';
 import { SignerType } from ':core/message';
@@ -54,14 +48,11 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
       checkErrorForInvalidRequestArgs(args);
       if (!this.signer) {
         switch (args.method) {
-          case 'eth_requestAccounts': {
-            const scwOnboardMode = Array.isArray(args?.params)
-              ? (args.params[0]?.scwOnboardMode as ScwOnboardMode)
-              : undefined;
-            const options = { scwOnboardMode: scwOnboardMode ?? 'default' };
-            const signerType = await this.requestSignerSelection(options);
+          case 'eth_requestAccounts':
+          case 'wallet_connect': /* forward compatibility */ {
+            const signerType = await this.requestSignerSelection(args);
             const signer = await this.initSigner(signerType);
-            await signer.handshake();
+            await signer.handshake(args);
             this.signer = signer;
             storeSignerType(signerType);
             break;
@@ -109,12 +100,12 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
     await this.initPromise; // resolves immediately if already initialized
   }
 
-  private requestSignerSelection(options: Record<string, unknown>): Promise<SignerType> {
+  private requestSignerSelection(handshakeRequest: RequestArguments): Promise<SignerType> {
     return fetchSignerType({
       communicator: this.communicator,
       preference: this.preference,
       metadata: this.metadata,
-      options,
+      handshakeRequest,
     });
   }
 

--- a/packages/wallet-sdk/src/core/message/RPCMessage.ts
+++ b/packages/wallet-sdk/src/core/message/RPCMessage.ts
@@ -1,6 +1,6 @@
 import { Message, MessageID } from './Message';
 import { SerializedEthereumRpcError } from ':core/error';
-import { AppMetadata } from ':core/provider/interface';
+import { RequestArguments } from ':core/provider/interface';
 
 interface RPCMessage extends Message {
   id: MessageID;
@@ -24,7 +24,7 @@ export interface RPCRequestMessage extends RPCMessage {
   callbackUrl?: string;
   content:
     | {
-        handshake: RequestAccountsAction;
+        handshake: RequestArguments;
       }
     | {
         encrypted: EncryptedData;
@@ -52,8 +52,3 @@ export interface MobileRPCResponseMessage extends RPCMessage {
         failure: SerializedEthereumRpcError;
       };
 }
-
-type RequestAccountsAction = {
-  method: 'eth_requestAccounts';
-  params: AppMetadata;
-};

--- a/packages/wallet-sdk/src/sign/interface.ts
+++ b/packages/wallet-sdk/src/sign/interface.ts
@@ -1,7 +1,7 @@
 import { RequestArguments } from ':core/provider/interface';
 
 export interface Signer {
-  handshake(): Promise<void>;
-  request(request: RequestArguments): Promise<unknown>;
+  handshake(_: RequestArguments): Promise<void>;
+  request(_: RequestArguments): Promise<unknown>;
   cleanup: () => Promise<void>;
 }

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -95,7 +95,7 @@ describe('SCWSigner', () => {
         },
       });
 
-      await signer.handshake();
+      await signer.handshake({ method: 'eth_requestAccounts' });
 
       expect(importKeyFromHexString).toHaveBeenCalledWith('public', '0xPublicKey');
       expect(mockKeyManager.setPeerPublicKey).toHaveBeenCalledWith(mockCryptoKey);
@@ -123,7 +123,9 @@ describe('SCWSigner', () => {
       };
       (mockCommunicator.postRequestAndWaitForResponse as jest.Mock).mockResolvedValue(mockResponse);
 
-      await expect(signer.handshake()).rejects.toThrowError(mockError);
+      await expect(signer.handshake({ method: 'eth_requestAccounts' })).rejects.toThrowError(
+        mockError
+      );
     });
   });
 

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -82,10 +82,7 @@ export class SCWSigner implements Signer {
     const handshakeMessage = await this.createRequestMessage({
       handshake: {
         method: args.method,
-        params: {
-          ...this.metadata,
-          ...(args.params ?? {}),
-        },
+        params: Object.assign({}, this.metadata, args.params ?? {}),
       },
     });
     const response: RPCResponseMessage =

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -78,11 +78,14 @@ export class SCWSigner implements Signer {
     return instance;
   }
 
-  async handshake() {
+  async handshake(args: RequestArguments) {
     const handshakeMessage = await this.createRequestMessage({
       handshake: {
-        method: 'eth_requestAccounts',
-        params: this.metadata,
+        method: args.method,
+        params: {
+          ...this.metadata,
+          ...(args.params ?? {}),
+        },
       },
     });
     const response: RPCResponseMessage =

--- a/packages/wallet-sdk/src/sign/util.test.ts
+++ b/packages/wallet-sdk/src/sign/util.test.ts
@@ -58,6 +58,7 @@ describe('util', () => {
         communicator,
         preference,
         metadata,
+        handshakeRequest: { method: 'eth_requestAccounts' },
       });
       expect(signerType).toEqual('scw');
     });

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -30,7 +30,7 @@ export async function fetchSignerType(params: {
   metadata: AppMetadata; // for WalletLink
   handshakeRequest: RequestArguments;
 }): Promise<SignerType> {
-  const { communicator, metadata } = params;
+  const { communicator, metadata, handshakeRequest } = params;
   listenForWalletLinkSessionRequest(communicator, metadata).catch(() => {});
 
   const request: ConfigMessage & { id: MessageID } = {
@@ -38,7 +38,7 @@ export async function fetchSignerType(params: {
     event: 'selectSignerType',
     data: {
       ...params.preference,
-      handshakeRequest: params.handshakeRequest,
+      handshakeRequest,
     },
   };
 

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -17,10 +17,13 @@ export async function storeSignerType(signerType: SignerType): Promise<void> {
   return storage.setItem(SIGNER_TYPE_KEY, signerType);
 }
 
+export type ScwOnboardMode = 'default' | 'create';
+
 export async function fetchSignerType(params: {
   communicator: Communicator;
   preference: Preference;
   metadata: AppMetadata; // for WalletLink
+  options?: Record<string, unknown>;
 }): Promise<SignerType> {
   const { communicator, metadata } = params;
   listenForWalletLinkSessionRequest(communicator, metadata).catch(() => {});
@@ -30,6 +33,11 @@ export async function fetchSignerType(params: {
     event: 'selectSignerType',
     data: params.preference,
   };
+
+  if (params.options?.scwOnboardMode) {
+    (request.data as { scwOnboardMode: ScwOnboardMode }).scwOnboardMode = params.options
+      .scwOnboardMode as ScwOnboardMode;
+  }
   const { data } = await communicator.postRequestAndWaitForResponse(request);
   return data as SignerType;
 }


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
- made some changes to the PR https://github.com/coinbase/coinbase-wallet-sdk/pull/1383 which was to add custom param to handshake requests for SCW onboarding optimization
- instead of unwrapping individual arguments (non-standard arguments), this PR proposes passing the whole raw argument to avoid having custom decoding logic.
- also support wallet_connect cases moving forward without requiring sdk changes

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

 unit tests