### PR TITLE
Pass raw request args to handshake

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -99,8 +99,9 @@ describe('Signer configuration', () => {
   it('should complete signerType selection correctly', async () => {
     mockFetchSignerType.mockResolvedValue('scw');
 
-    await provider.request({ method: 'eth_requestAccounts' });
-    expect(mockHandshake).toHaveBeenCalledWith();
+    const args = { method: 'eth_requestAccounts' };
+    await provider.request(args);
+    expect(mockHandshake).toHaveBeenCalledWith(args);
   });
 
   it('should support enable', async () => {
@@ -108,7 +109,22 @@ describe('Signer configuration', () => {
     jest.spyOn(console, 'warn').mockImplementation();
 
     await provider.enable();
-    expect(mockHandshake).toHaveBeenCalledWith();
+    expect(mockHandshake).toHaveBeenCalledWith({ method: 'eth_requestAccounts' });
+  });
+
+  it('should pass handshake request args', async () => {
+    mockFetchSignerType.mockResolvedValue('scw');
+
+    const argsWithCustomParams = {
+      method: 'eth_requestAccounts',
+      params: [{ scwOnboardMode: 'create' }],
+    };
+    await provider.request(argsWithCustomParams);
+    expect(mockFetchSignerType).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handshakeRequest: argsWithCustomParams,
+      })
+    );
   });
 
   it('should throw error if signer selection failed', async () => {

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -39,9 +39,9 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
       if (!this.signer) {
         switch (args.method) {
           case 'eth_requestAccounts': {
-            const signerType = await this.requestSignerSelection();
-            const signer = this.initSigner(signerType);
-            await signer.handshake();
+            const signerType = await this.requestSignerSelection(args);
+            const signer = await this.initSigner(signerType);
+            await signer.handshake(args);
             this.signer = signer;
             storeSignerType(signerType);
             break;
@@ -84,11 +84,12 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
 
   readonly isCoinbaseWallet = true;
 
-  private requestSignerSelection(): Promise<SignerType> {
+  private requestSignerSelection(handshakeRequest: RequestArguments): Promise<SignerType> {
     return fetchSignerType({
       communicator: this.communicator,
       preference: this.preference,
       metadata: this.metadata,
+      handshakeRequest,
     });
   }
 

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -40,7 +40,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
         switch (args.method) {
           case 'eth_requestAccounts': {
             const signerType = await this.requestSignerSelection(args);
-            const signer = await this.initSigner(signerType);
+            const signer = this.initSigner(signerType);
             await signer.handshake(args);
             this.signer = signer;
             storeSignerType(signerType);

--- a/packages/wallet-sdk/src/core/message/RPCMessage.ts
+++ b/packages/wallet-sdk/src/core/message/RPCMessage.ts
@@ -20,7 +20,6 @@ export type MobileEncryptedData = {
 };
 
 export interface RPCRequestMessage extends RPCMessage {
-  sdkVersion: string;
   callbackUrl?: string;
   content:
     | {

--- a/packages/wallet-sdk/src/core/message/RPCMessage.ts
+++ b/packages/wallet-sdk/src/core/message/RPCMessage.ts
@@ -15,7 +15,6 @@ export type EncryptedData = {
 };
 
 export interface RPCRequestMessage extends RPCMessage {
-  callbackUrl?: string;
   content:
     | {
         handshake: RequestArguments;

--- a/packages/wallet-sdk/src/core/message/RPCMessage.ts
+++ b/packages/wallet-sdk/src/core/message/RPCMessage.ts
@@ -14,11 +14,6 @@ export type EncryptedData = {
   cipherText: ArrayBuffer;
 };
 
-export type MobileEncryptedData = {
-  iv: Uint8Array;
-  cipherText: Uint8Array;
-};
-
 export interface RPCRequestMessage extends RPCMessage {
   callbackUrl?: string;
   content:
@@ -35,17 +30,6 @@ export interface RPCResponseMessage extends RPCMessage {
   content:
     | {
         encrypted: EncryptedData;
-      }
-    | {
-        failure: SerializedEthereumRpcError;
-      };
-}
-
-export interface MobileRPCResponseMessage extends RPCMessage {
-  requestId: MessageID;
-  content:
-    | {
-        encrypted: MobileEncryptedData;
       }
     | {
         failure: SerializedEthereumRpcError;

--- a/packages/wallet-sdk/src/core/message/RPCMessage.ts
+++ b/packages/wallet-sdk/src/core/message/RPCMessage.ts
@@ -1,6 +1,6 @@
 import { Message, MessageID } from './Message';
 import { SerializedEthereumRpcError } from ':core/error';
-import { AppMetadata } from ':core/provider/interface';
+import { RequestArguments } from ':core/provider/interface';
 
 interface RPCMessage extends Message {
   id: MessageID;
@@ -14,10 +14,17 @@ export type EncryptedData = {
   cipherText: ArrayBuffer;
 };
 
+export type MobileEncryptedData = {
+  iv: Uint8Array;
+  cipherText: Uint8Array;
+};
+
 export interface RPCRequestMessage extends RPCMessage {
+  sdkVersion: string;
+  callbackUrl?: string;
   content:
     | {
-        handshake: RequestAccountsAction;
+        handshake: RequestArguments;
       }
     | {
         encrypted: EncryptedData;
@@ -35,7 +42,13 @@ export interface RPCResponseMessage extends RPCMessage {
       };
 }
 
-type RequestAccountsAction = {
-  method: 'eth_requestAccounts';
-  params: AppMetadata;
-};
+export interface MobileRPCResponseMessage extends RPCMessage {
+  requestId: MessageID;
+  content:
+    | {
+        encrypted: MobileEncryptedData;
+      }
+    | {
+        failure: SerializedEthereumRpcError;
+      };
+}

--- a/packages/wallet-sdk/src/sign/interface.ts
+++ b/packages/wallet-sdk/src/sign/interface.ts
@@ -1,7 +1,7 @@
 import { RequestArguments } from ':core/provider/interface';
 
 export interface Signer {
-  handshake(): Promise<void>;
-  request(request: RequestArguments): Promise<unknown>;
+  handshake(_: RequestArguments): Promise<void>;
+  request(_: RequestArguments): Promise<unknown>;
   cleanup: () => Promise<void>;
 }

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -97,7 +97,7 @@ describe('SCWSigner', () => {
         },
       });
 
-      await signer.handshake();
+      await signer.handshake({ method: 'eth_requestAccounts' });
 
       expect(importKeyFromHexString).toHaveBeenCalledWith('public', '0xPublicKey');
       expect(mockKeyManager.setPeerPublicKey).toHaveBeenCalledWith(mockCryptoKey);
@@ -125,7 +125,9 @@ describe('SCWSigner', () => {
       };
       mockCommunicator.postRequestAndWaitForResponse.mockResolvedValue(mockResponse);
 
-      await expect(signer.handshake()).rejects.toThrowError(mockError);
+      await expect(signer.handshake({ method: 'eth_requestAccounts' })).rejects.toThrowError(
+        mockError
+      );
     });
   });
 

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -58,11 +58,11 @@ export class SCWSigner implements Signer {
     this.decryptResponseMessage = this.decryptResponseMessage.bind(this);
   }
 
-  async handshake() {
+  async handshake(args: RequestArguments) {
     const handshakeMessage = await this.createRequestMessage({
       handshake: {
-        method: 'eth_requestAccounts',
-        params: this.metadata,
+        method: args.method,
+        params: Object.assign({}, this.metadata, args.params ?? {}),
       },
     });
     const response: RPCResponseMessage =

--- a/packages/wallet-sdk/src/sign/util.test.ts
+++ b/packages/wallet-sdk/src/sign/util.test.ts
@@ -51,6 +51,7 @@ describe('util', () => {
         communicator,
         preference,
         metadata,
+        handshakeRequest: { method: 'eth_requestAccounts' },
       });
       expect(signerType).toEqual('scw');
     });

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -3,7 +3,12 @@ import { SCWSigner } from './scw/SCWSigner';
 import { WalletLinkSigner } from './walletlink/WalletLinkSigner';
 import { Communicator } from ':core/communicator/Communicator';
 import { ConfigMessage, MessageID, SignerType } from ':core/message';
-import { AppMetadata, Preference, ProviderEventCallback } from ':core/provider/interface';
+import {
+  AppMetadata,
+  Preference,
+  ProviderEventCallback,
+  RequestArguments,
+} from ':core/provider/interface';
 import { ScopedLocalStorage } from ':core/storage/ScopedLocalStorage';
 
 const SIGNER_TYPE_KEY = 'SignerType';
@@ -21,14 +26,18 @@ export async function fetchSignerType(params: {
   communicator: Communicator;
   preference: Preference;
   metadata: AppMetadata; // for WalletLink
+  handshakeRequest: RequestArguments;
 }): Promise<SignerType> {
-  const { communicator, metadata } = params;
+  const { communicator, metadata, handshakeRequest } = params;
   listenForWalletLinkSessionRequest(communicator, metadata).catch(() => {});
 
   const request: ConfigMessage & { id: MessageID } = {
     id: crypto.randomUUID(),
     event: 'selectSignerType',
-    data: params.preference,
+    data: {
+      ...params.preference,
+      handshakeRequest,
+    },
   };
   const { data } = await communicator.postRequestAndWaitForResponse(request);
   return data as SignerType;


### PR DESCRIPTION
### _Summary_
**What**
- This PR makes a change to pass raw request args to our signer selection and handshake methods
**Why**
- To enable smart wallet onboarding optimization through the passing of request params

### _How did you test your changes?_
Locally
Unit Tests