### PR TITLE
add support for any config parameter

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -30,7 +30,9 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
     this.communicator = new Communicator(keysUrl, metadata);
 
     const signerType = loadSignerType();
-    if (signerType) this.signer = this.initSigner(signerType);
+    if (signerType) {
+      this.signer = this.initSigner(signerType);
+    }
   }
 
   public async request(args: RequestArguments): Promise<unknown> {

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -12,6 +12,7 @@ import { Signer } from './sign/interface';
 import { createSigner, fetchSignerType, loadSignerType, storeSignerType } from './sign/util';
 import { checkErrorForInvalidRequestArgs } from './util/provider';
 import { Communicator } from ':core/communicator/Communicator';
+import { CB_KEYS_URL } from ':core/constants';
 import { SignerType } from ':core/message';
 import { ScopedLocalStorage } from ':core/storage/ScopedLocalStorage';
 import { hexStringFromNumber } from ':core/type/util';
@@ -27,7 +28,9 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
     super();
     this.metadata = metadata;
     this.preference = preference;
-    this.communicator = new Communicator(keysUrl, metadata);
+
+    const url = typeof keysUrl === 'string' ? keysUrl : CB_KEYS_URL;
+    this.communicator = new Communicator(url, metadata);
 
     const signerType = loadSignerType();
     if (signerType) {

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -12,7 +12,6 @@ import { Signer } from './sign/interface';
 import { createSigner, fetchSignerType, loadSignerType, storeSignerType } from './sign/util';
 import { checkErrorForInvalidRequestArgs } from './util/provider';
 import { Communicator } from ':core/communicator/Communicator';
-import { CB_KEYS_URL } from ':core/constants';
 import { SignerType } from ':core/message';
 import { ScopedLocalStorage } from ':core/storage/ScopedLocalStorage';
 import { hexStringFromNumber } from ':core/type/util';
@@ -28,9 +27,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
     super();
     this.metadata = metadata;
     this.preference = preference;
-
-    const url = typeof keysUrl === 'string' ? keysUrl : CB_KEYS_URL;
-    this.communicator = new Communicator(url, metadata);
+    this.communicator = new Communicator(keysUrl, metadata);
 
     const signerType = loadSignerType();
     if (signerType) {

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -51,11 +51,10 @@ type OnrampPrefillOptions = {
 };
 
 export type Preference = {
-  options: 'all' | 'smartWalletOnly' | 'eoaOnly';
   /**
-   * @deprecated this is only for internal use
+   * @param options
    */
-  keysUrl?: string;
+  options: 'all' | 'smartWalletOnly' | 'eoaOnly';
   /**
    * @param postOnboardingAction
    * @type {PostOnboardingAction}

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -42,9 +42,46 @@ export interface AppMetadata {
   appChainIds: number[];
 }
 
+type PostOnboardingAction = 'none' | 'onramp' | 'magicspend';
+
+type OnrampPrefillOptions = {
+  contractAddress?: string;
+  amount: string;
+  chainId: number;
+};
+
 export type Preference = {
   options: 'all' | 'smartWalletOnly' | 'eoaOnly';
+  /**
+   * @deprecated this is only for internal use
+   */
   keysUrl?: string;
+  /**
+   * @param postOnboardingAction
+   * @type {PostOnboardingAction}
+   * @description Recommends the action to be taken after the onboarding process to engage users with various flows. Possible values:
+   * - `none`: No action is recommended post-onboarding. (Default experience)
+   * - `onramp`: Recommends initiating the onramp flow, allowing users to prefill their account with a specified asset, chain, and amount.
+   * - `magicspend`: Suggests linking the users retail Coinbase account for seamless transactions.
+   */
+  postOnboardingAction?: PostOnboardingAction;
+  /**
+   * @param onrampPrefillOptions
+   * @type {OnrampPrefillOptions}
+   * @description This option only functions when `postOnboardingAction` is set to `onramp`.
+   * - Prefills the onramp flow with the specified asset, chain, and suggested amount,
+   * allowing users to prefill their account.
+   * - Ensure the asset and chain are supported by the onramp provider
+   * (e.g., Coinbase Pay - CBPay).
+   */
+  onrampPrefillOptions?: OnrampPrefillOptions;
+  /**
+   * @param attributionDataSuffix
+   * @type {Hex}
+   * @description Data suffix to be appended to the initCode or executeBatch calldata
+   * Expects a 4 byte hex string
+   */
+  attributionDataSuffix?: string;
 } & Record<string, unknown>;
 
 export interface ConstructorOptions {

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -58,7 +58,7 @@ export type Preference = {
   /**
    * @param postOnboardingAction
    * @type {PostOnboardingAction}
-   * @description Displays CTAs to the user based on the preference of the dapp.
+   * @description This option only applies to Coinbase Smart Wallet. Displays CTAs to the user based on the preference of the app.
    * These CTAs are part of prebuilt UI components that are available to the Coinbase
    * Smart Wallet.
    *
@@ -71,8 +71,8 @@ export type Preference = {
   /**
    * @param onrampPrefillOptions
    * @type {OnrampPrefillOptions}
-   * @description This option only functions when `postOnboardingAction` is set to `onramp`. Defaults to an asset selector
-   * with 0 as the initial amount
+   * @description This option only applies to Coinbase Smart Wallet. Requires `postOnboardingAction` to be set to `onramp`. When not configured,
+   * The onramp screen defaults to an asset selector with 0 as the initial amount.
    *
    * - Prefills the onramp flow with the specified asset, chain, and suggested amount, allowing users to prefill their account.
    * - Ensure the asset and chain are supported by the onramp provider (e.g., Coinbase Pay - CBPay).
@@ -83,8 +83,9 @@ export type Preference = {
   /**
    * @param attributionDataSuffix
    * @type {Hex}
-   * @description Data suffix to be appended to the initCode or executeBatch calldata
-   * Expects a 4 byte hex string
+   * @note Smart Wallet only
+   * @description This option only applies to Coinbase Smart Wallet. Data suffix to be appended to the initCode or executeBatch calldata
+   * Coinbase Smart Wallet expects a 4 byte hex string. If the suffix is not a 4 byte hex string, the Smart Wallet will not apply the data suffix.
    */
   attributionDataSuffix?: string;
 } & Record<string, unknown>;

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -58,20 +58,26 @@ export type Preference = {
   /**
    * @param postOnboardingAction
    * @type {PostOnboardingAction}
-   * @description Recommends the action to be taken after the onboarding process to engage users with various flows. Possible values:
+   * @description Displays CTAs to the user based on the preference of the dapp.
+   * These CTAs are part of prebuilt UI components that are available to the Coinbase
+   * Smart Wallet.
+   *
+   * Possible values:
    * - `none`: No action is recommended post-onboarding. (Default experience)
-   * - `onramp`: Recommends initiating the onramp flow, allowing users to prefill their account with a specified asset, chain, and amount.
+   * - `onramp`: Recommends initiating the onramp flow, allowing users to prefill their account with an optional asset.
    * - `magicspend`: Suggests linking the users retail Coinbase account for seamless transactions.
    */
   postOnboardingAction?: PostOnboardingAction;
   /**
    * @param onrampPrefillOptions
    * @type {OnrampPrefillOptions}
-   * @description This option only functions when `postOnboardingAction` is set to `onramp`.
-   * - Prefills the onramp flow with the specified asset, chain, and suggested amount,
-   * allowing users to prefill their account.
-   * - Ensure the asset and chain are supported by the onramp provider
-   * (e.g., Coinbase Pay - CBPay).
+   * @description This option only functions when `postOnboardingAction` is set to `onramp`. Defaults to an asset selector
+   * with 0 as the initial amount
+   *
+   * - Prefills the onramp flow with the specified asset, chain, and suggested amount, allowing users to prefill their account.
+   * - Ensure the asset and chain are supported by the onramp provider (e.g., Coinbase Pay - CBPay).
+   *
+   * See https://docs.cdp.coinbase.com/onramp/docs/layer2#available-assets for a list of supported assets and networks.
    */
   onrampPrefillOptions?: OnrampPrefillOptions;
   /**

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -42,10 +42,10 @@ export interface AppMetadata {
   appChainIds: number[];
 }
 
-export interface Preference {
+export type Preference = {
   options: 'all' | 'smartWalletOnly' | 'eoaOnly';
   keysUrl?: string;
-}
+} & Record<string, unknown>;
 
 export interface ConstructorOptions {
   metadata: AppMetadata;

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -52,6 +52,10 @@ type OnrampPrefillOptions = {
 
 export type Preference = {
   /**
+   * @deprecated internal use only.
+   */
+  keysUrl?: string;
+  /**
    * @param options
    */
   options: 'all' | 'smartWalletOnly' | 'eoaOnly';


### PR DESCRIPTION
### _Summary_

This PR extends the preferences object to support any config value. This PR also exposes new methods to get the provider or an new sdk object. 

### _How did you test your changes?_

Manually. In a follow up PR there will be an update to the test app to use the new create SDK object