### PR TITLE
Add new utils to interact with the SDK and provider

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -11,6 +11,12 @@ import { getCoinbaseInjectedProvider } from ':util/provider';
 // for backwards compatibility
 type CoinbaseWalletSDKOptions = Partial<AppMetadata>;
 
+/**
+ * CoinbaseWalletSDK
+ *
+ * @deprecated CoinbaseWalletSDK is deprecated and will likely be removed in a future major version release.
+ * It's recommended to use `createCoinbaseWalletSDK` instead.
+ */
 export class CoinbaseWalletSDK {
   private metadata: AppMetadata;
 

--- a/packages/wallet-sdk/src/createCoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletProvider.test.ts
@@ -1,0 +1,18 @@
+import { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
+import { createCoinbaseWalletProvider } from './createCoinbaseWalletProvider';
+import { ConstructorOptions } from ':core/provider/interface';
+
+describe('createCoinbaseWalletProvider', () => {
+  it('should return a provider', () => {
+    const options: ConstructorOptions = {
+      metadata: {
+        appName: 'Dapp',
+        appLogoUrl: 'https://example.com/favicon.ico',
+        appChainIds: [],
+      },
+      preference: { options: 'all' },
+    };
+    const result = createCoinbaseWalletProvider(options);
+    expect(result).toBeInstanceOf(CoinbaseWalletProvider);
+  });
+});

--- a/packages/wallet-sdk/src/createCoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletProvider.ts
@@ -1,0 +1,17 @@
+import { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
+import { AppMetadata, Preference } from ':core/provider/interface';
+import { ConstructorOptions } from ':core/provider/interface';
+import { getCoinbaseInjectedProvider } from ':util/provider';
+
+export type CreateProviderOptions = {
+  metadata: AppMetadata;
+  preference: Preference;
+};
+
+export function createCoinbaseWalletProvider(options: CreateProviderOptions) {
+  const params: ConstructorOptions = {
+    metadata: options.metadata,
+    preference: options.preference,
+  };
+  return getCoinbaseInjectedProvider(params) ?? new CoinbaseWalletProvider(params);
+}

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.test.ts
@@ -1,0 +1,23 @@
+import { createCoinbaseWalletSDK, CreateCoinbaseWalletSDKOptions } from './createCoinbaseWalletSDK';
+
+const options: CreateCoinbaseWalletSDKOptions = {
+  appName: 'Dapp',
+  appLogoUrl: 'https://example.com/favicon.ico',
+  appChainIds: [],
+  preference: { options: 'all' },
+};
+
+describe('createCoinbaseWalletSDK', () => {
+  it('should return an object with a getProvider method', () => {
+    const sdk = createCoinbaseWalletSDK(options);
+    expect(sdk).toHaveProperty('getProvider');
+    expect(typeof sdk.getProvider).toBe('function');
+  });
+
+  it('should return the same provider instance on subsequent calls to getProvider', () => {
+    const sdk = createCoinbaseWalletSDK(options);
+    const provider1 = sdk.getProvider();
+    const provider2 = sdk.getProvider();
+    expect(provider1).toBe(provider2);
+  });
+});

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
@@ -1,0 +1,41 @@
+import { createCoinbaseWalletProvider } from './createCoinbaseWalletProvider';
+import { LIB_VERSION } from './version';
+import {
+  AppMetadata,
+  ConstructorOptions,
+  Preference,
+  ProviderInterface,
+} from ':core/provider/interface';
+import { ScopedLocalStorage } from ':core/storage/ScopedLocalStorage';
+
+export type CreateCoinbaseWalletSDKOptions = Partial<AppMetadata> & {
+  preference?: Preference;
+};
+
+const DEFAULT_PREFERENCE: Preference = {
+  options: 'all',
+};
+
+export function createCoinbaseWalletSDK(params: CreateCoinbaseWalletSDKOptions) {
+  const versionStorage = new ScopedLocalStorage('CBWSDK');
+  versionStorage.setItem('VERSION', LIB_VERSION);
+
+  const options: ConstructorOptions = {
+    metadata: {
+      appName: params.appName || 'Dapp',
+      appLogoUrl: params.appLogoUrl || '',
+      appChainIds: params.appChainIds || [],
+    },
+    preference: Object.assign(DEFAULT_PREFERENCE, params.preference ?? {}),
+  };
+  let provider: ProviderInterface | null = null;
+
+  return {
+    getProvider: () => {
+      if (!provider) {
+        provider = createCoinbaseWalletProvider(options);
+      }
+      return provider;
+    },
+  };
+}

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -5,3 +5,4 @@ export default CoinbaseWalletSDK;
 export type { CoinbaseWalletProvider } from './CoinbaseWalletProvider';
 export { CoinbaseWalletSDK } from './CoinbaseWalletSDK';
 export type { AppMetadata, Preference, ProviderInterface } from './core/provider/interface';
+export { createCoinbaseWalletSDK } from './createCoinbaseWalletSDK';


### PR DESCRIPTION
### _Summary_

This PR adds two new utilities to interact with the SDK and Provider.

This PR also adds a deprecation notice on the SDK class

```tsx
createCoinabseWalletSDK
```

```tsx
createCoinbaseWalletProvider
```

### _How did you test your changes?_

These can be tested by building a local version of the SDK. Importing the SDK into a new project or the playground. Then instantiating the provider and interacting with it.

See this PR for usage https://github.com/coinbase/coinbase-wallet-sdk/pull/1404
