### PR TITLE
fix noble hash keccak256 usage

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
@@ -208,7 +208,7 @@ describe('LegacyProvider', () => {
     const sendRequestSpy = jest.spyOn(relay, 'sendRequest');
     const provider = createAdapter({ relay });
 
-    const ENCODED_MESSAGE = '0xb7845733ba102a68c6eb21c3cd2feafafd1130de581d7e73be60b76d775b6704';
+    const ENCODED_MESSAGE = '0x421b6e328c574f0ee83a68d51d01be3597d8b5391c7725dfa80247a60b5cd390';
     const ENCODED_TYPED_DATA_JSON = JSON.stringify(MOCK_TYPED_DATA);
 
     beforeEach(() => {

--- a/packages/wallet-sdk/src/vendor-js/eth-eip712-util/index.js
+++ b/packages/wallet-sdk/src/vendor-js/eth-eip712-util/index.js
@@ -1,3 +1,6 @@
+/* eslint-disable */
+//prettier-ignore
+
 const util = require('./util')
 const abi = require('./abi')
 

--- a/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.js
+++ b/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.js
@@ -141,7 +141,7 @@ function keccak (a, bits) {
   if (bits !== 256) {
     throw new Error('unsupported')
   }
-  return Buffer.from(keccak_256(a))
+  return Buffer.from(keccak_256(new Uint8Array(a)))
 }
 
 function padToEven (str) {

--- a/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.js
+++ b/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.js
@@ -138,8 +138,10 @@ function bufferToHex (buf) {
 function keccak (a, bits) {
   a = toBuffer(a)
   if (!bits) bits = 256
-
-  return Buffer.from(keccak_256('keccak' + bits))
+  if (bits !== 256) {
+    throw new Error('unsupported')
+  }
+  return Buffer.from(keccak_256(a))
 }
 
 function padToEven (str) {


### PR DESCRIPTION
### _Summary_

This PR https://github.com/coinbase/coinbase-wallet-sdk/pull/1336 removed sha.js and keccak/js in in favor of @noble/hashes but implemented the keccak256 hash incorrectly. This resulted in EIP712 messages failing for walletlink.

This fixes the change by using the functions how theyre intended to be used.

### _How did you test your changes?_

1. Create a local build (`cd ./packages/wallet-sdk && rm -rf dist && yarn build && cd ../../`) 
2. Start the dev server from root (`yarn dev`)
3. Open up the playground `localhost:3000`
4. Connect to the playground using walletlink
5. Test signed typed data v3 and v4 and ensure you're able to sign on mobile (Note v1 doesn't work on sdk v4.0.4 either)

