### PR TITLE
Update testapp to use sdk latest

### DIFF
--- a/examples/testapp/package.json
+++ b/examples/testapp/package.json
@@ -15,7 +15,7 @@
     "@coinbase/wallet-sdk": "workspace:*",
     "@coinbase/wallet-sdk-3.7.2": "npm:@coinbase/wallet-sdk@3.7.2",
     "@coinbase/wallet-sdk-3.9.3": "npm:@coinbase/wallet-sdk@3.9.3",
-    "@coinbase/wallet-sdk-4.0.4": "npm:@coinbase/wallet-sdk@latest",
+    "@coinbase/wallet-sdk-latest": "npm:@coinbase/wallet-sdk@latest",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@metamask/eth-sig-util": "^7.0.0",

--- a/examples/testapp/src/components/Layout.tsx
+++ b/examples/testapp/src/components/Layout.tsx
@@ -65,7 +65,7 @@ export function Layout({ children }: LayoutProps) {
             ))}
           </MenuList>
         </Menu>
-        {(sdkVersion === 'HEAD' || sdkVersion === '4.0.4') && (
+        {(sdkVersion === 'HEAD' || sdkVersion === 'Latest') && (
           <>
             <Menu>
               <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>

--- a/examples/testapp/src/components/Layout.tsx
+++ b/examples/testapp/src/components/Layout.tsx
@@ -29,8 +29,6 @@ type LayoutProps = {
 
 export const WIDTH_2XL = '1536px';
 
-console.log('customlogs: latestPkgJson', latestPkgJson.version);
-
 export function Layout({ children }: LayoutProps) {
   const { provider, option, setPreference, sdkVersion, setSDKVersion, scwUrl, setScwUrlAndSave } =
     useCBWSDK();

--- a/examples/testapp/src/components/Layout.tsx
+++ b/examples/testapp/src/components/Layout.tsx
@@ -17,15 +17,19 @@ import {
   useBreakpointValue,
   useDisclosure,
 } from '@chakra-ui/react';
+import latestPkgJson from '@coinbase/wallet-sdk/package.json';
 import { useMemo } from 'react';
 
 import { options, scwUrls, sdkVersions, useCBWSDK } from '../context/CBWSDKReactContextProvider';
+
 
 type LayoutProps = {
   children: React.ReactNode;
 };
 
 export const WIDTH_2XL = '1536px';
+
+console.log('customlogs: latestPkgJson', latestPkgJson.version);
 
 export function Layout({ children }: LayoutProps) {
   const { provider, option, setPreference, sdkVersion, setSDKVersion, scwUrl, setScwUrlAndSave } =
@@ -65,7 +69,7 @@ export function Layout({ children }: LayoutProps) {
             ))}
           </MenuList>
         </Menu>
-        {(sdkVersion === 'HEAD' || sdkVersion === 'Latest') && (
+        {(sdkVersion === 'HEAD' || sdkVersion === latestPkgJson.version) && (
           <>
             <Menu>
               <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>

--- a/examples/testapp/src/context/CBWSDKReactContextProvider.tsx
+++ b/examples/testapp/src/context/CBWSDKReactContextProvider.tsx
@@ -2,6 +2,8 @@ import { CoinbaseWalletSDK as CoinbaseWalletSDKHEAD } from '@coinbase/wallet-sdk
 import { CoinbaseWalletSDK as CoinbaseWalletSDK372 } from '@coinbase/wallet-sdk-3.7.2';
 import { CoinbaseWalletSDK as CoinbaseWalletSDK393 } from '@coinbase/wallet-sdk-3.9.3';
 import { CoinbaseWalletSDK as CoinbaseWalletSDKLatest } from '@coinbase/wallet-sdk-latest';
+import latestPkgJson from '@coinbase/wallet-sdk/package.json';
+
 import React, { useEffect, useMemo } from 'react';
 
 type CBWSDKProviderProps = {
@@ -11,7 +13,7 @@ type CBWSDKProviderProps = {
 const CBWSDKReactContext = React.createContext(null);
 
 const SELECTED_SDK_KEY = 'selected_sdk_version';
-export const sdkVersions = ['HEAD', 'Latest', '3.9.3', '3.7.2'] as const;
+export const sdkVersions = ['HEAD', latestPkgJson.version, '3.9.3', '3.7.2'] as const;
 export type SDKVersionType = (typeof sdkVersions)[number];
 
 const SELECTED_SCW_URL_KEY = 'scw_url';
@@ -74,7 +76,7 @@ export function CBWSDKReactContextProvider({ children }: CBWSDKProviderProps) {
   useEffect(() => {
     let cbwsdk;
     let preference;
-    if (version === 'HEAD' || version === 'Latest') {
+    if (version === 'HEAD' || version === latestPkgJson.version) {
       const SDK = version === 'HEAD' ? CoinbaseWalletSDKHEAD : CoinbaseWalletSDKLatest;
       cbwsdk = new SDK({
         appName: 'SDK Playground',
@@ -101,7 +103,7 @@ export function CBWSDKReactContextProvider({ children }: CBWSDKProviderProps) {
   }, [version, option]);
 
   useEffect(() => {
-    if (version === 'HEAD' || version === 'Latest') {
+    if (version === 'HEAD' || version === latestPkgJson.version) {
       if (scwUrl) window.setPopupUrl?.(scwUrl);
     }
   }, [version, scwUrl, sdk]);

--- a/examples/testapp/src/context/CBWSDKReactContextProvider.tsx
+++ b/examples/testapp/src/context/CBWSDKReactContextProvider.tsx
@@ -1,7 +1,7 @@
 import { CoinbaseWalletSDK as CoinbaseWalletSDKHEAD } from '@coinbase/wallet-sdk';
 import { CoinbaseWalletSDK as CoinbaseWalletSDK372 } from '@coinbase/wallet-sdk-3.7.2';
 import { CoinbaseWalletSDK as CoinbaseWalletSDK393 } from '@coinbase/wallet-sdk-3.9.3';
-import { CoinbaseWalletSDK as CoinbaseWalletSDK404 } from '@coinbase/wallet-sdk-4.0.4';
+import { CoinbaseWalletSDK as CoinbaseWalletSDKLatest } from '@coinbase/wallet-sdk-latest';
 import React, { useEffect, useMemo } from 'react';
 
 type CBWSDKProviderProps = {
@@ -11,7 +11,7 @@ type CBWSDKProviderProps = {
 const CBWSDKReactContext = React.createContext(null);
 
 const SELECTED_SDK_KEY = 'selected_sdk_version';
-export const sdkVersions = ['HEAD', '4.0.4', '3.9.3', '3.7.2'] as const;
+export const sdkVersions = ['HEAD', 'Latest', '3.9.3', '3.7.2'] as const;
 export type SDKVersionType = (typeof sdkVersions)[number];
 
 const SELECTED_SCW_URL_KEY = 'scw_url';
@@ -74,8 +74,8 @@ export function CBWSDKReactContextProvider({ children }: CBWSDKProviderProps) {
   useEffect(() => {
     let cbwsdk;
     let preference;
-    if (version === 'HEAD' || version === '4.0.4') {
-      const SDK = version === 'HEAD' ? CoinbaseWalletSDKHEAD : CoinbaseWalletSDK404;
+    if (version === 'HEAD' || version === 'Latest') {
+      const SDK = version === 'HEAD' ? CoinbaseWalletSDKHEAD : CoinbaseWalletSDKLatest;
       cbwsdk = new SDK({
         appName: 'SDK Playground',
         appChainIds: [84532, 8452],
@@ -101,7 +101,7 @@ export function CBWSDKReactContextProvider({ children }: CBWSDKProviderProps) {
   }, [version, option]);
 
   useEffect(() => {
-    if (version === 'HEAD' || version === '4.0.4') {
+    if (version === 'HEAD' || version === 'Latest') {
       if (scwUrl) window.setPopupUrl?.(scwUrl);
     }
   }, [version, scwUrl, sdk]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2713,17 +2713,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/wallet-sdk-4.0.4@npm:@coinbase/wallet-sdk@latest":
-  version: 4.0.4
-  resolution: "@coinbase/wallet-sdk@npm:4.0.4"
+"@coinbase/wallet-sdk-latest@npm:@coinbase/wallet-sdk@latest":
+  version: 4.1.0
+  resolution: "@coinbase/wallet-sdk@npm:4.1.0"
   dependencies:
-    buffer: "npm:^6.0.3"
-    clsx: "npm:^1.2.1"
-    eventemitter3: "npm:^5.0.1"
-    keccak: "npm:^3.0.3"
-    preact: "npm:^10.16.0"
-    sha.js: "npm:^2.4.11"
-  checksum: 002d03d791683a15b465a285d7293a7994684f6f91d67c01b52ee9a07ba62f555a12d5c9471c964ccae0df048190f9c2e82929aeba9247e6d97ad1a9e9dd4132
+    "@noble/hashes": ^1.4.0
+    clsx: ^1.2.1
+    eventemitter3: ^5.0.1
+    preact: ^10.16.0
+  checksum: 13ccdbf48bc43db5b9285ca4e6d13a81e1d0c7d13735b1695f9c33c4e3bb0b03683adfffc084344aed475832c3613d68e025f029fc8f2b6abe386596aeee39c9
   languageName: node
   linkType: hard
 
@@ -9940,7 +9938,7 @@ __metadata:
     "@coinbase/wallet-sdk": "workspace:*"
     "@coinbase/wallet-sdk-3.7.2": "npm:@coinbase/wallet-sdk@3.7.2"
     "@coinbase/wallet-sdk-3.9.3": "npm:@coinbase/wallet-sdk@3.9.3"
-    "@coinbase/wallet-sdk-4.0.4": "npm:@coinbase/wallet-sdk@latest"
+    "@coinbase/wallet-sdk-latest": "npm:@coinbase/wallet-sdk@latest"
     "@emotion/react": ^11.11.1
     "@emotion/styled": ^11.11.0
     "@metamask/eth-sig-util": ^7.0.0


### PR DESCRIPTION
### _Summary_

This PR renames the internals of the test app to point to HEAD (current master), Latest (current published version), and the previous v3 versions.

### _How did you test your changes?_

* Pull down the repo and start the dev server `yarn dev`
* Test HEAD and Latest. Should be the same version of the SDK

![image](https://github.com/user-attachments/assets/37d3ac9f-af91-47e8-88ab-d3826174acf3)
