### PR TITLE
Fix chainChanged event emitting for walletlink connection

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -92,6 +92,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
       preference: this.preference,
       metadata: this.metadata,
       handshakeRequest,
+      callback: this.emit.bind(this),
     });
   }
 

--- a/packages/wallet-sdk/src/sign/util.test.ts
+++ b/packages/wallet-sdk/src/sign/util.test.ts
@@ -52,6 +52,7 @@ describe('util', () => {
         preference,
         metadata,
         handshakeRequest: { method: 'eth_requestAccounts' },
+        callback: jest.fn(),
       });
       expect(signerType).toEqual('scw');
     });

--- a/packages/wallet-sdk/src/sign/util.ts
+++ b/packages/wallet-sdk/src/sign/util.ts
@@ -27,9 +27,10 @@ export async function fetchSignerType(params: {
   preference: Preference;
   metadata: AppMetadata; // for WalletLink
   handshakeRequest: RequestArguments;
+  callback: ProviderEventCallback;
 }): Promise<SignerType> {
-  const { communicator, metadata, handshakeRequest } = params;
-  listenForWalletLinkSessionRequest(communicator, metadata).catch(() => {});
+  const { communicator, metadata, handshakeRequest, callback } = params;
+  listenForWalletLinkSessionRequest(communicator, metadata, callback).catch(() => {});
 
   const request: ConfigMessage & { id: MessageID } = {
     id: crypto.randomUUID(),
@@ -69,7 +70,8 @@ export function createSigner(params: {
 
 async function listenForWalletLinkSessionRequest(
   communicator: Communicator,
-  metadata: AppMetadata
+  metadata: AppMetadata,
+  callback: ProviderEventCallback
 ) {
   await communicator.onMessage<ConfigMessage>(({ event }) => event === 'WalletLinkSessionRequest');
 
@@ -77,6 +79,7 @@ async function listenForWalletLinkSessionRequest(
   // will revisit this when refactoring the walletlink signer
   const walletlink = new WalletLinkSigner({
     metadata,
+    callback,
   });
 
   // send wallet link session to popup


### PR DESCRIPTION
### _Summary_
This fixes a bug where the first 'chainChanged' was not being emitted because no emitter callback was being passed to the WalletLinkSigner created by `listenForWalletLinkSessionRequest` 

### _How did you test your changes?_
Locally 

Here's a video showing the bug in 4.1.0 and this fix in HEAD
https://github.com/user-attachments/assets/e762a9d1-69f1-4124-a844-cf0dc346e9df

