### PR TITLE
Pass preferences with popuploaded event

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -27,7 +27,11 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
     super();
     this.metadata = metadata;
     this.preference = preference;
-    this.communicator = new Communicator(keysUrl, metadata);
+    this.communicator = new Communicator({
+      url: keysUrl,
+      metadata,
+      preference,
+    });
 
     const signerType = loadSignerType();
     if (signerType) {

--- a/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
@@ -1,4 +1,4 @@
-import { AppMetadata } from 'src/index';
+import { AppMetadata, Preference } from 'src/index';
 
 import { LIB_VERSION } from '../../version';
 import { Message, MessageID } from '../message';
@@ -49,6 +49,8 @@ const appMetadata: AppMetadata = {
   appChainIds: [1],
 };
 
+const preference: Preference = { keysUrl: CB_KEYS_URL, options: 'all' };
+
 describe('Communicator', () => {
   let urlOrigin: string;
   let communicator: Communicator;
@@ -61,7 +63,11 @@ describe('Communicator', () => {
     jest.clearAllMocks();
 
     // url defaults to CB_KEYS_URL
-    communicator = new Communicator(CB_KEYS_URL, appMetadata);
+    communicator = new Communicator({
+      url: CB_KEYS_URL,
+      metadata: appMetadata,
+      preference,
+    });
     urlOrigin = new URL(CB_KEYS_URL).origin;
 
     mockPopup = {
@@ -109,6 +115,7 @@ describe('Communicator', () => {
           data: {
             version: LIB_VERSION,
             metadata: appMetadata,
+            preference,
           },
         },
         urlOrigin
@@ -135,6 +142,7 @@ describe('Communicator', () => {
           data: {
             version: LIB_VERSION,
             metadata: appMetadata,
+            preference,
           },
         },
         urlOrigin
@@ -156,6 +164,7 @@ describe('Communicator', () => {
           data: {
             version: LIB_VERSION,
             metadata: appMetadata,
+            preference,
           },
         },
         urlOrigin

--- a/packages/wallet-sdk/src/core/communicator/Communicator.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.ts
@@ -2,8 +2,14 @@ import { LIB_VERSION } from '../../version';
 import { ConfigMessage, Message, MessageID } from '../message';
 import { CB_KEYS_URL } from ':core/constants';
 import { standardErrors } from ':core/error';
-import { AppMetadata } from ':core/provider/interface';
+import { AppMetadata, Preference } from ':core/provider/interface';
 import { closePopup, openPopup } from ':util/web';
+
+export type CommunicatorOptions = {
+  url?: string;
+  metadata: AppMetadata;
+  preference: Preference;
+};
 
 /**
  * Communicates with a popup window for Coinbase keys.coinbase.com (or another url)
@@ -16,13 +22,15 @@ import { closePopup, openPopup } from ':util/web';
  */
 export class Communicator {
   private readonly metadata: AppMetadata;
+  private readonly preference: Preference;
   private readonly url: URL;
   private popup: Window | null = null;
   private listeners = new Map<(_: MessageEvent) => void, { reject: (_: Error) => void }>();
 
-  constructor(url: string = CB_KEYS_URL, metadata: AppMetadata) {
+  constructor({ url = CB_KEYS_URL, metadata, preference }: CommunicatorOptions) {
     this.url = new URL(url);
     this.metadata = metadata;
+    this.preference = preference;
   }
 
   /**
@@ -100,7 +108,11 @@ export class Communicator {
       .then((message) => {
         this.postMessage({
           requestId: message.id,
-          data: { version: LIB_VERSION, metadata: this.metadata },
+          data: {
+            version: LIB_VERSION,
+            metadata: this.metadata,
+            preference: this.preference,
+          },
         });
       })
       .then(() => {

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -64,7 +64,12 @@ describe('SCWSigner', () => {
       appChainIds: [1],
     };
 
-    mockCommunicator = new Communicator(CB_KEYS_URL, mockMetadata) as jest.Mocked<Communicator>;
+    mockCommunicator = new Communicator({
+      url: CB_KEYS_URL,
+      metadata: mockMetadata,
+      preference: { keysUrl: CB_KEYS_URL, options: 'all' },
+    }) as jest.Mocked<Communicator>;
+
     mockCommunicator.waitForPopupLoaded.mockResolvedValue({} as Window);
     mockCommunicator.postRequestAndWaitForResponse.mockResolvedValue(mockSuccessResponse);
 

--- a/packages/wallet-sdk/src/sign/util.test.ts
+++ b/packages/wallet-sdk/src/sign/util.test.ts
@@ -42,7 +42,11 @@ describe('util', () => {
     const preference: Preference = { options: 'all' };
 
     it('should complete signerType selection correctly', async () => {
-      const communicator = new Communicator(CB_KEYS_URL, metadata);
+      const communicator = new Communicator({
+        url: CB_KEYS_URL,
+        metadata,
+        preference: { keysUrl: CB_KEYS_URL, options: 'all' },
+      });
       communicator.postMessage = jest.fn();
       communicator.onMessage = jest.fn().mockResolvedValue({
         data: 'scw',


### PR DESCRIPTION
### _Summary_

Update the PopupLoaded event to pass preferences for new SDK config

### _How did you test your changes?_

* Start the dev server from the root. yarn dev
* visit http://localhost:3001/config
* Place a log inside the Communicator and validate that preferences are properly passed to the postMessage data
