### PR TITLE
Fix TypeScript error for global.TextDecoder

### DIFF
--- a/packages/wallet-sdk/jest.setup.ts
+++ b/packages/wallet-sdk/jest.setup.ts
@@ -7,5 +7,4 @@ global.crypto = new Crypto();
 
 global.TextEncoder = TextEncoder;
 
-// @ts-expect-error Use util TextDecoder
-global.TextDecoder = TextDecoder;
+global.TextDecoder = TextDecoder as typeof global.TextDecoder;


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
This PR fixes a TypeScript error in the jest.setup.ts file within the wallet-sdk package. The TextDecoder was previously throwing a type error, which was bypassed with a @ts-expect-error. This has been resolved by casting TextDecoder to the correct global type.

### _How did you test your changes?_
Ran the existing test suite to ensure no new issues were introduced.
Verified that the TypeScript error is no longer present in the jest.setup.ts file after applying the changes.

<!--
  Verify changes. Include relevant screenshots/videos
-->
