### PR TITLE
Improve favicon fetching by guessing favicon url based on convention

### DIFF
--- a/packages/wallet-sdk/src/core/type/util.ts
+++ b/packages/wallet-sdk/src/core/type/util.ts
@@ -185,7 +185,7 @@ export function getFavicon(): string | null {
   const { protocol, host } = document.location;
   const href = el ? el.getAttribute('href') : null;
   if (!href || href.startsWith('javascript:') || href.startsWith('vbscript:')) {
-    return null;
+    return `${protocol}//${host}/favicon.ico`; // fallback
   }
   if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('data:')) {
     return href;


### PR DESCRIPTION
### _Summary_

- Our favicon fetching script worked sometimes, but in other cases where sites did not add a favicon via a <link> tag, the favicon was not found and null was returned. 
- This changes the script to guess the favicon url based on convention
- The frontend handles malformed urls just in case

### _How did you test your changes?_
Locally 
