### PR TITLE
Add coop warning

### DIFF
--- a/examples/testapp/next.config.js
+++ b/examples/testapp/next.config.js
@@ -9,7 +9,7 @@ module.exports = {
         headers: [
           {
             key: "Cross-Origin-Opener-Policy",
-            value: "unsafe-none", // Or 'unsafe-none' if you want to disable COOP
+            value: "unsafe-none", // Or 'same-origin' to test COOP errors
           },
         ],
       },

--- a/examples/testapp/next.config.js
+++ b/examples/testapp/next.config.js
@@ -1,0 +1,18 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: "/",
+        headers: [
+          {
+            key: "Cross-Origin-Opener-Policy",
+            value: "unsafe-none", // Or 'unsafe-none' if you want to disable COOP
+          },
+        ],
+      },
+    ];
+  },
+};

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.test.ts
@@ -7,6 +7,7 @@ import { getCoinbaseInjectedProvider } from ':util/provider';
 jest.mock(':core/type/util');
 jest.mock(':util/provider');
 jest.mock('./CoinbaseWalletProvider');
+jest.mock('./util/crossOriginOpenerPolicy');
 
 describe('CoinbaseWalletSDK', () => {
   test('@makeWeb3Provider - return Coinbase Injected Provider', () => {

--- a/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletSDK.ts
@@ -6,6 +6,7 @@ import { AppMetadata, Preference, ProviderInterface } from './core/provider/inte
 import { LIB_VERSION } from './version';
 import { ScopedLocalStorage } from ':core/storage/ScopedLocalStorage';
 import { getFavicon } from ':core/type/util';
+import { checkCrossOriginOpenerPolicy } from ':util/crossOriginOpenerPolicy';
 import { getCoinbaseInjectedProvider } from ':util/provider';
 
 // for backwards compatibility
@@ -27,6 +28,7 @@ export class CoinbaseWalletSDK {
       appChainIds: metadata.appChainIds || [],
     };
     this.storeLatestVersion();
+    this.checkCrossOriginOpenerPolicy();
   }
 
   public makeWeb3Provider(preference: Preference = { options: 'all' }): ProviderInterface {
@@ -47,5 +49,9 @@ export class CoinbaseWalletSDK {
   private storeLatestVersion() {
     const versionStorage = new ScopedLocalStorage('CBWSDK');
     versionStorage.setItem('VERSION', LIB_VERSION);
+  }
+
+  private checkCrossOriginOpenerPolicy() {
+    void checkCrossOriginOpenerPolicy();
   }
 }

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.test.ts
@@ -7,6 +7,8 @@ const options: CreateCoinbaseWalletSDKOptions = {
   preference: { options: 'all' },
 };
 
+jest.mock('./util/crossOriginOpenerPolicy');
+
 describe('createCoinbaseWalletSDK', () => {
   it('should return an object with a getProvider method', () => {
     const sdk = createCoinbaseWalletSDK(options);

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
@@ -7,6 +7,7 @@ import {
   ProviderInterface,
 } from ':core/provider/interface';
 import { ScopedLocalStorage } from ':core/storage/ScopedLocalStorage';
+import { checkCrossOriginOpenerPolicy } from ':util/crossOriginOpenerPolicy';
 
 export type CreateCoinbaseWalletSDKOptions = Partial<AppMetadata> & {
   preference?: Preference;
@@ -19,6 +20,8 @@ const DEFAULT_PREFERENCE: Preference = {
 export function createCoinbaseWalletSDK(params: CreateCoinbaseWalletSDKOptions) {
   const versionStorage = new ScopedLocalStorage('CBWSDK');
   versionStorage.setItem('VERSION', LIB_VERSION);
+
+  void checkCrossOriginOpenerPolicy();
 
   const options: ConstructorOptions = {
     metadata: {

--- a/packages/wallet-sdk/src/util/crossOriginOpenerPolicy.test.ts
+++ b/packages/wallet-sdk/src/util/crossOriginOpenerPolicy.test.ts
@@ -1,0 +1,63 @@
+import { checkCrossOriginOpenerPolicy } from './crossOriginOpenerPolicy';
+
+describe('checkCrossOriginOpenerPolicy', () => {
+  beforeEach(() => {
+    // Clear all mocks before each test
+    jest.clearAllMocks();
+  });
+
+  it('should not run if window is undefined', () => {
+    const originalWindow = global.window;
+    // @ts-expect-error delete window property
+    delete global.window;
+
+    expect(checkCrossOriginOpenerPolicy()).toBeUndefined();
+
+    // Restore the original window object
+    global.window = originalWindow;
+  });
+
+  it('should fetch the current origin', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      headers: {
+        get: jest.fn().mockReturnValue(null),
+      },
+    });
+
+    checkCrossOriginOpenerPolicy();
+
+    expect(global.fetch).toHaveBeenCalledWith(window.location.origin, {});
+  });
+
+  it('should log an error if Cross-Origin-Opener-Policy is same-origin', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = jest.fn().mockResolvedValue({
+      headers: {
+        get: jest.fn().mockReturnValue('same-origin'),
+      },
+    });
+
+    await checkCrossOriginOpenerPolicy();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Coinbase Wallet SDK requires the Cross-Origin-Opener-Policy header to not be set to 'same-origin'."
+      )
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should not log an error if Cross-Origin-Opener-Policy is not same-origin', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = jest.fn().mockResolvedValue({
+      headers: {
+        get: jest.fn().mockReturnValue('unsafe-none'),
+      },
+    });
+
+    await checkCrossOriginOpenerPolicy();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/wallet-sdk/src/util/crossOriginOpenerPolicy.ts
+++ b/packages/wallet-sdk/src/util/crossOriginOpenerPolicy.ts
@@ -1,0 +1,15 @@
+export function checkCrossOriginOpenerPolicy() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  fetch(window.location.origin, {}).then((response) => {
+    const headers = response.headers;
+    const crossOriginOpenerPolicy = headers.get('Cross-Origin-Opener-Policy');
+    if (crossOriginOpenerPolicy === 'same-origin') {
+      console.error(`Coinbase Wallet SDK requires the Cross-Origin-Opener-Policy header to NOT be set to 'same-origin'. This is to ensure that the SDK can communicate with the Coinbase Smart Wallet app.
+
+Please see https://www.smartwallet.dev/guides/tips/popup-tips#cross-origin-opener-policy for more information.`);
+    }
+  });
+}

--- a/packages/wallet-sdk/src/util/crossOriginOpenerPolicy.ts
+++ b/packages/wallet-sdk/src/util/crossOriginOpenerPolicy.ts
@@ -7,7 +7,7 @@ export function checkCrossOriginOpenerPolicy() {
     const headers = response.headers;
     const crossOriginOpenerPolicy = headers.get('Cross-Origin-Opener-Policy');
     if (crossOriginOpenerPolicy === 'same-origin') {
-      console.error(`Coinbase Wallet SDK requires the Cross-Origin-Opener-Policy header to NOT be set to 'same-origin'. This is to ensure that the SDK can communicate with the Coinbase Smart Wallet app.
+      console.error(`Coinbase Wallet SDK requires the Cross-Origin-Opener-Policy header to not be set to 'same-origin'. This is to ensure that the SDK can communicate with the Coinbase Smart Wallet app.
 
 Please see https://www.smartwallet.dev/guides/tips/popup-tips#cross-origin-opener-policy for more information.`);
     }


### PR DESCRIPTION
### _Summary_

Add additional coop warning for developers. This is meant to help resolve coop issues

### _How did you test your changes?_

1. Spin up the playground
2. Set the next.config.js COOP header to same-origin
3. Verify the warning is present inside the console when running the app.
4. You'll know the coop is properly set if you see the coop warning when interacting with the popup

https://github.com/user-attachments/assets/c5440e3c-20b5-4d50-be22-cfd111b06d73
