### PR TITLE
Disable next config headers

### DIFF
--- a/examples/testapp/config/headers.js
+++ b/examples/testapp/config/headers.js
@@ -1,0 +1,17 @@
+function getCrossOriginOpenerPolicyHeaders() {
+    return {
+        source: "/",
+        headers: [
+          {
+            key: "Cross-Origin-Opener-Policy",
+            value: "same-origin", 
+            },
+        ]
+    }
+}
+
+// To test these headers in your local environment, 
+// add the following rules to the next.config.js headers property.
+module.exports = {
+    getCrossOriginOpenerPolicyHeaders
+}

--- a/examples/testapp/next.config.js
+++ b/examples/testapp/next.config.js
@@ -1,18 +1,4 @@
 /**
  * @type {import('next').NextConfig}
  */
-module.exports = {
-  // async headers() {
-  //   return [
-  //     {
-  //       source: "/",
-  //       headers: [
-  //         {
-  //           key: "Cross-Origin-Opener-Policy",
-  //           value: "unsafe-none", // Or 'same-origin' to test COOP errors
-  //         },
-  //       ],
-  //     },
-  //   ];
-  // },
-};
+module.exports = {};

--- a/examples/testapp/next.config.js
+++ b/examples/testapp/next.config.js
@@ -2,17 +2,17 @@
  * @type {import('next').NextConfig}
  */
 module.exports = {
-  async headers() {
-    return [
-      {
-        source: "/",
-        headers: [
-          {
-            key: "Cross-Origin-Opener-Policy",
-            value: "unsafe-none", // Or 'same-origin' to test COOP errors
-          },
-        ],
-      },
-    ];
-  },
+  // async headers() {
+  //   return [
+  //     {
+  //       source: "/",
+  //       headers: [
+  //         {
+  //           key: "Cross-Origin-Opener-Policy",
+  //           value: "unsafe-none", // Or 'same-origin' to test COOP errors
+  //         },
+  //       ],
+  //     },
+  //   ];
+  // },
 };

--- a/examples/testapp/tsconfig.json
+++ b/examples/testapp/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -18,15 +14,7 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ],
-  "references": [
-    
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"],
+  "references": []
 }


### PR DESCRIPTION
### _Summary_

Remove the next.config headers for the SDK playground

### _How did you test your changes?_

Manually. SDK playground should load normally
