### PR TITLE
Add copy button to message examples

### DIFF
--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -174,9 +174,20 @@ export function RpcMethodCard({ format, method, params, shortcuts }) {
                 <AccordionPanel pb={4}>
                   <HStack spacing={2}>
                     {shortcuts.map((shortcut) => (
-                      <Button key={shortcut.key} onClick={() => submit(shortcut.data)}>
-                        {shortcut.key}
-                      </Button>
+                      <HStack key={shortcut.key} spacing={1}>
+                        <Button onClick={() => submit(shortcut.data)}>
+                          {shortcut.key}
+                        </Button>
+                        {shortcut.data.message && (
+                          <Button
+                            onClick={() => navigator.clipboard.writeText(JSON.stringify(shortcut.data.message, null, 2))}
+                            variant="outline"
+                            size="sm"
+                          >
+                            Copy
+                          </Button>
+                        )}
+                      </HStack>
                     ))}
                   </HStack>
                 </AccordionPanel>


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

Added a copy button next to any example button that provides a message (so for all sign message RPCs)

### _How did you test your changes?_
https://github.com/user-attachments/assets/6193e458-ad83-49cd-8c7d-95b83c176bd0
<!--






  Verify changes. Include relevant screenshots/videos
-->
