### PR TITLE
Passing SDK config params to injected provider

### DIFF
--- a/packages/wallet-sdk/src/util/provider.test.ts
+++ b/packages/wallet-sdk/src/util/provider.test.ts
@@ -89,7 +89,12 @@ describe('Utils', () => {
           })
         ).toBe(extensionProvider);
 
-        expect(mockSetAppInfo).toHaveBeenCalledWith('Dapp', null, []);
+        expect(mockSetAppInfo).toHaveBeenCalledWith(
+          'Dapp',
+          null,
+          [],
+          expect.objectContaining({ options: 'all' })
+        );
       });
 
       it('smartWalletOnly - should return undefined', () => {
@@ -113,7 +118,7 @@ describe('Utils', () => {
     describe('Browser Provider', () => {
       const mockCipherProvider = {
         isCoinbaseBrowser: true,
-        setAppParams: vi.fn(),
+        setAppInfo: vi.fn(),
       } as unknown as CBInjectedProvider;
 
       beforeAll(() => {
@@ -138,12 +143,14 @@ describe('Utils', () => {
             },
           })
         ).toBe(mockCipherProvider);
-        expect(mockCipherProvider.setAppParams).toHaveBeenCalledWith({
-          appName: 'Dapp',
-          appChainIds: [],
-          appLogoUrl: null,
-          options: 'all',
-        });
+        expect(mockCipherProvider.setAppInfo).toHaveBeenCalledWith(
+          'Dapp',
+          null,
+          [],
+          expect.objectContaining({
+            options: 'all',
+          })
+        );
       });
 
       it('smartWalletOnly - Should still return injected browser provider', () => {
@@ -159,12 +166,14 @@ describe('Utils', () => {
             },
           })
         ).toBe(mockCipherProvider);
-        expect(mockCipherProvider.setAppParams).toHaveBeenCalledWith({
-          appName: 'Dapp',
-          appChainIds: [],
-          appLogoUrl: null,
-          options: 'smartWalletOnly',
-        });
+        expect(mockCipherProvider.setAppInfo).toHaveBeenCalledWith(
+          'Dapp',
+          null,
+          [],
+          expect.objectContaining({
+            options: 'all',
+          })
+        );
       });
 
       it('should handle exception when accessing window.top', () => {

--- a/packages/wallet-sdk/src/util/provider.test.ts
+++ b/packages/wallet-sdk/src/util/provider.test.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 import {
+  CBInjectedProvider,
   CBWindow,
   checkErrorForInvalidRequestArgs,
   fetchRPCRequest,
@@ -110,11 +111,10 @@ describe('Utils', () => {
     });
 
     describe('Browser Provider', () => {
-      class MockCipherProviderClass {
-        public isCoinbaseBrowser = true;
-      }
-
-      const mockCipherProvider = new MockCipherProviderClass() as unknown as ProviderInterface;
+      const mockCipherProvider = {
+        isCoinbaseBrowser: true,
+        setAppParams: vi.fn(),
+      } as unknown as CBInjectedProvider;
 
       beforeAll(() => {
         window.coinbaseWalletExtension = undefined;
@@ -138,6 +138,12 @@ describe('Utils', () => {
             },
           })
         ).toBe(mockCipherProvider);
+        expect(mockCipherProvider.setAppParams).toHaveBeenCalledWith({
+          appName: 'Dapp',
+          appChainIds: [],
+          appLogoUrl: null,
+          options: 'all',
+        });
       });
 
       it('smartWalletOnly - Should still return injected browser provider', () => {
@@ -153,6 +159,12 @@ describe('Utils', () => {
             },
           })
         ).toBe(mockCipherProvider);
+        expect(mockCipherProvider.setAppParams).toHaveBeenCalledWith({
+          appName: 'Dapp',
+          appChainIds: [],
+          appLogoUrl: null,
+          options: 'smartWalletOnly',
+        });
       });
 
       it('should handle exception when accessing window.top', () => {

--- a/packages/wallet-sdk/src/util/provider.ts
+++ b/packages/wallet-sdk/src/util/provider.ts
@@ -36,6 +36,7 @@ export interface CBWindow {
 export interface CBInjectedProvider extends ProviderInterface {
   isCoinbaseBrowser?: boolean;
   setAppInfo?: (...args: unknown[]) => unknown;
+  setAppParams?: (params: Record<string, unknown>) => void;
 }
 
 function getCoinbaseInjectedLegacyProvider(): CBInjectedProvider | undefined {
@@ -50,6 +51,16 @@ function getInjectedEthereum(): CBInjectedProvider | undefined {
   } catch {
     return undefined;
   }
+}
+
+function flattenParams({
+  metadata,
+  preference,
+}: Readonly<ConstructorOptions>): Record<string, unknown> {
+  return {
+    ...metadata,
+    ...preference,
+  };
 }
 
 export function getCoinbaseInjectedProvider({
@@ -67,6 +78,7 @@ export function getCoinbaseInjectedProvider({
 
   const ethereum = getInjectedEthereum();
   if (ethereum?.isCoinbaseBrowser) {
+    ethereum.setAppParams?.(flattenParams({ metadata, preference }));
     return ethereum;
   }
 

--- a/packages/wallet-sdk/src/util/provider.ts
+++ b/packages/wallet-sdk/src/util/provider.ts
@@ -36,7 +36,6 @@ export interface CBWindow {
 export interface CBInjectedProvider extends ProviderInterface {
   isCoinbaseBrowser?: boolean;
   setAppInfo?: (...args: unknown[]) => unknown;
-  setAppParams?: (params: Record<string, unknown>) => void;
 }
 
 function getCoinbaseInjectedLegacyProvider(): CBInjectedProvider | undefined {
@@ -53,32 +52,23 @@ function getInjectedEthereum(): CBInjectedProvider | undefined {
   }
 }
 
-function flattenParams({
-  metadata,
-  preference,
-}: Readonly<ConstructorOptions>): Record<string, unknown> {
-  return {
-    ...metadata,
-    ...preference,
-  };
-}
-
 export function getCoinbaseInjectedProvider({
   metadata,
   preference,
 }: Readonly<ConstructorOptions>): ProviderInterface | undefined {
+  const { appName, appLogoUrl, appChainIds } = metadata;
+
   if (preference.options !== 'smartWalletOnly') {
     const extension = getCoinbaseInjectedLegacyProvider();
     if (extension) {
-      const { appName, appLogoUrl, appChainIds } = metadata;
-      extension.setAppInfo?.(appName, appLogoUrl, appChainIds);
+      extension.setAppInfo?.(appName, appLogoUrl, appChainIds, preference);
       return extension;
     }
   }
 
   const ethereum = getInjectedEthereum();
   if (ethereum?.isCoinbaseBrowser) {
-    ethereum.setAppParams?.(flattenParams({ metadata, preference }));
+    ethereum.setAppInfo?.(appName, appLogoUrl, appChainIds, preference);
     return ethereum;
   }
 


### PR DESCRIPTION
### _Summary_

extended the setAppInfo pattern to RN's in app browser provider. 
This is used to block EOA account to connect to smartWalletOnly app, and also enables adding data suffix in future RN smart wallet account

we are passing flattened params, including metadata and preference, this is for maximizing compatibility across App SDK version in case of future App SDK config structure change

### _How did you test your changes?_

Manually, demo attached in RN's PR

### Demo: noop on current extension
https://github.com/user-attachments/assets/debb56a9-22d3-4aef-9cc7-f7a08b14436e


