### PR TITLE
remove enable call from playground

### DIFF
--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -85,11 +85,6 @@ export function RpcMethodCard({ format, method, params, shortcuts }) {
         values = format(data);
       }
       try {
-        // connection required
-        if (!provider?.connected) {
-          await provider.enable();
-        }
-
         const response = await provider.request({
           method,
           params: values,


### PR DESCRIPTION
### _Summary_

remove enable call from playground from sdk playground submit call.

This was always firing and is not actually useful.

### _How did you test your changes?_

Manually.

Just use the sdk playground. There should be no functional changes to how things work.
