### PR TITLE
Signer `request` should be generic for consumers

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -40,7 +40,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
     }
   }
 
-  public async request(args: RequestArguments): Promise<unknown> {
+  public async request<T>(args: RequestArguments): Promise<T> {
     try {
       checkErrorForInvalidRequestArgs(args);
       if (!this.signer) {
@@ -54,9 +54,9 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
             break;
           }
           case 'net_version':
-            return 1; // default value
+            return 1 as T; // default value
           case 'eth_chainId':
-            return hexStringFromNumber(1); // default value
+            return hexStringFromNumber(1) as T; // default value
           default: {
             throw standardErrors.provider.unauthorized(
               "Must call 'eth_requestAccounts' before other methods"

--- a/packages/wallet-sdk/src/sign/interface.ts
+++ b/packages/wallet-sdk/src/sign/interface.ts
@@ -2,6 +2,6 @@ import { RequestArguments } from ':core/provider/interface.js';
 
 export interface Signer {
   handshake(_: RequestArguments): Promise<void>;
-  request(_: RequestArguments): Promise<unknown>;
+  request<T>(_: RequestArguments): Promise<T>;
   cleanup: () => Promise<void>;
 }

--- a/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.cjs
+++ b/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.cjs
@@ -24,7 +24,7 @@ function bufferBEFromBigInt(num, length) {
   // Ensure the hex string length is even
   if (hex.length % 2 !== 0) hex = '0' + hex;
   // Convert hex string to a byte array
-  const byteArray = hex.match(/.{1,2}/g).map(byte => Number.parseInt(byte, 16));
+  const byteArray = hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16));
   // Ensure the byte array is of the specified length
   while (byteArray.length < length) {
     byteArray.unshift(0); // Prepend with zeroes if shorter than required length


### PR DESCRIPTION
### _Summary_

At some point signer `request` was generic but was recently made to return `unknown`. 

### _How did you test your changes?_

Manually tested.
