### PR TITLE
update sdk to pass location in postmessage

### DIFF
--- a/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.test.ts
@@ -118,6 +118,7 @@ describe('Communicator', () => {
             version: VERSION,
             metadata: appMetadata,
             preference,
+            location: 'http://localhost:3000/',
           },
         },
         urlOrigin
@@ -145,6 +146,7 @@ describe('Communicator', () => {
             version: VERSION,
             metadata: appMetadata,
             preference,
+            location: 'http://localhost:3000/',
           },
         },
         urlOrigin
@@ -167,6 +169,7 @@ describe('Communicator', () => {
             version: VERSION,
             metadata: appMetadata,
             preference,
+            location: 'http://localhost:3000/',
           },
         },
         urlOrigin

--- a/packages/wallet-sdk/src/core/communicator/Communicator.ts
+++ b/packages/wallet-sdk/src/core/communicator/Communicator.ts
@@ -113,6 +113,7 @@ export class Communicator {
             version: VERSION,
             metadata: this.metadata,
             preference: this.preference,
+            location: window.location.toString(),
           },
         });
       })


### PR DESCRIPTION
### _Summary_

When connecting to the dapp browser with linkdrop pathname and query params did not persist. This includes the full location for keysdot to process

### _How did you test your changes?_

1. Start keysdot (See corresponding PR on keys side) and sdk playground.
2. Set the keys url to localhost
3. Using the sim (needs cbw mobile on it) or ngrok with actual device, open the playground in a browser window. (add some random query params)
4. Open the onboarding flow and select mobile. This should open in the dapp browser. Verify the query params persist. 