### PR TITLE
fix: default import from cjs files causing module resolution errors in webpack

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
@@ -1,7 +1,7 @@
 import { fireEvent } from '@testing-library/preact';
 import { vi } from 'vitest';
 
-import * as eip712 from '../../vendor-js/eth-eip712-util/index.cjs';
+import eip712 from '../../vendor-js/eth-eip712-util/index.cjs';
 import { LOCAL_STORAGE_ADDRESSES_KEY } from './relay/constants.js';
 import { MOCK_ADDERESS, MOCK_SIGNED_TX, MOCK_TX, MOCK_TYPED_DATA } from './relay/mocks/fixtures.js';
 import { mockedWalletLinkRelay } from './relay/mocks/relay.js';

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.test.ts
@@ -1,6 +1,8 @@
 import { fireEvent } from '@testing-library/preact';
 import { vi } from 'vitest';
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import eip712 from '../../vendor-js/eth-eip712-util/index.cjs';
 import { LOCAL_STORAGE_ADDRESSES_KEY } from './relay/constants.js';
 import { MOCK_ADDERESS, MOCK_SIGNED_TX, MOCK_TX, MOCK_TYPED_DATA } from './relay/mocks/fixtures.js';

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
@@ -1,5 +1,4 @@
 // Copyright (c) 2018-2024 Coinbase, Inc. <https://www.coinbase.com/>
-
 import eip712 from '../../vendor-js/eth-eip712-util/index.cjs';
 import { Signer } from '../interface.js';
 import { LOCAL_STORAGE_ADDRESSES_KEY } from './relay/constants.js';

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2018-2024 Coinbase, Inc. <https://www.coinbase.com/>
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import * as eip712 from '../../vendor-js/eth-eip712-util/index.cjs';
+import eip712 from '../../vendor-js/eth-eip712-util/index.cjs';
 import { Signer } from '../interface.js';
 import { LOCAL_STORAGE_ADDRESSES_KEY } from './relay/constants.js';
 import { EthereumTransactionParams } from './relay/type/EthereumTransactionParams.js';

--- a/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/WalletLinkSigner.ts
@@ -1,4 +1,7 @@
 // Copyright (c) 2018-2024 Coinbase, Inc. <https://www.coinbase.com/>
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import eip712 from '../../vendor-js/eth-eip712-util/index.cjs';
 import { Signer } from '../interface.js';
 import { LOCAL_STORAGE_ADDRESSES_KEY } from './relay/constants.js';


### PR DESCRIPTION
### _Summary_

fix: default import from cjs files causing module resolution errors in webpack

Note: we should remove the vendor-js files in favor of viem or similar

### _How did you test your changes?_

1. start the sdk playground
2. connect with walletlink
3. test EIP712 functions 

---  Going the extra mile:

1. spin up an app with vite, webpack, your favorite bundler of choice
2. connect with walletlink
3. test EIP712 functions 

Everything should load correctly and all EIP712 functions should sign successfully.

