### PR TITLE
Send app location in WalletLink request

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkConnection.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkConnection.ts
@@ -273,6 +273,7 @@ export class WalletLinkConnection {
       JSON.stringify({
         ...unencryptedData,
         origin: location.origin,
+        location: location.href,
         relaySource:
           'coinbaseWalletExtension' in window && window.coinbaseWalletExtension
             ? 'injected_sdk'


### PR DESCRIPTION
### _Summary_
This PR adds the app's `window.location` to the WalletLink event. We already do this for the origin, but there's cases where Wallet needs the full path.

### _How did you test your changes?_
Tested manually and verified that adding the field doesn't cause issues with older versions of Wallet.
