### PR TITLE
Dynamically update chainid for send calls requests

### DIFF
--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -25,7 +25,7 @@ import { mainnet } from 'viem/chains';
 
 import { useCBWSDK } from '../../context/CBWSDKReactContextProvider';
 import { verifySignMsg } from './method/signMessageMethods';
-import { ADDR_TO_FILL } from './shortcut/const';
+import { ADDR_TO_FILL, CHAIN_ID_TO_FILL } from './shortcut/const';
 import { multiChainShortcutsMap } from './shortcut/multipleChainShortcuts';
 
 type ResponseType = string;
@@ -71,18 +71,26 @@ export function RpcMethodCard({ format, method, params, shortcuts }) {
       setVerifyResult(null);
       setResponse(null);
       if (!provider) return;
-      let values = data;
+
+      const dataToSubmit = { ...data };
+      let values = dataToSubmit;
       if (format) {
         // fill active address to the request
         const addresses = await provider.request({ method: 'eth_accounts' });
-        for (const key in data) {
+        const chainId = await provider.request({ method: 'eth_chainId' });
+
+        for (const key in dataToSubmit) {
           if (Object.prototype.hasOwnProperty.call(data, key)) {
-            if (data[key] === ADDR_TO_FILL) {
-              data[key] = addresses[0];
+            if (dataToSubmit[key] === ADDR_TO_FILL) {
+              dataToSubmit[key] = addresses[0];
+            }
+
+            if (dataToSubmit[key] === CHAIN_ID_TO_FILL) {
+              dataToSubmit[key] = chainId;
             }
           }
         }
-        values = format(data);
+        values = format(dataToSubmit);
       }
       try {
         const response = await provider.request({

--- a/examples/testapp/src/components/RpcMethods/shortcut/const.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/const.ts
@@ -1,3 +1,4 @@
 export const EXAMPLE_MESSAGE = `Example Message`;
 
 export const ADDR_TO_FILL = 'ADDR_TO_FILL';
+export const CHAIN_ID_TO_FILL = 'CHAIN_ID_TO_FILL';

--- a/examples/testapp/src/components/RpcMethods/shortcut/walletTxShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/walletTxShortcuts.ts
@@ -1,11 +1,11 @@
-import { ADDR_TO_FILL } from './const';
+import { ADDR_TO_FILL, CHAIN_ID_TO_FILL } from './const';
 import { ShortcutType } from './ShortcutType';
 
 const walletSendCallsShortcuts: ShortcutType[] = [
   {
     key: 'wallet_sendCalls',
     data: {
-      chainId: '84532',
+      chainId: CHAIN_ID_TO_FILL,
       from: ADDR_TO_FILL,
       calls: [],
       version: '1',


### PR DESCRIPTION
### _Summary_
This PR makes it so that the chainId passed in a wallet_sendCalls requests is the chainId that is connected
<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

https://github.com/user-attachments/assets/fbc793be-828b-419c-88f8-3db8d0387aa3



