### PR TITLE
Fix SDK Playground Export

### DIFF
--- a/examples/testapp/next-env.d.ts
+++ b/examples/testapp/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/examples/testapp/next.config.mjs
+++ b/examples/testapp/next.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  output: 'export',
+};

--- a/examples/testapp/package.json
+++ b/examples/testapp/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
-    "export": "next build && next export"
+    "export": "next build"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",


### PR DESCRIPTION
### _Summary_

Next 14 removed the `next export` command in favor of the `output: export` in the next.config file

### _How did you test your changes?_

Run `yarn build`. Should generate an `out` directory 