### PR TITLE
Fix SDK Playground Deploys

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: yarn
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/examples/testapp/package.json
+++ b/examples/testapp/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
-    "export": "next build"
+    "export": "yarn build && touch ./out/.nojekyll"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",


### PR DESCRIPTION
### _Summary_

Static deploys started failing after upgrading to Next.js 14+. This should fix the SDK Playground deploys

See https://github.com/vercel/next.js/discussions/33751

### _How did you test your changes?_
 
From the root run `yarn export`.

Validate the out director inside the sdk playground director and make sure it has a `.nojekyll` file inside the out dir
