### PR TITLE
Fix export to account for basePath

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: yarn
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: "20"
           cache: yarn
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
         with:
           static_site_generator: next
       - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
       - name: Build and export with Next.js
         run: yarn deploy
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./examples/testapp/out
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/examples/testapp/next.config.mjs
+++ b/examples/testapp/next.config.mjs
@@ -1,3 +1,4 @@
 export default {
   output: 'export',
+  basePath: process.env.NODE_ENV === 'production' ? '/coinbase-wallet-sdk' : undefined,
 };

--- a/examples/testapp/package.json
+++ b/examples/testapp/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
-    "export": "next build"
+    "export": "yarn build && touch ./out/.nojekyll"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",


### PR DESCRIPTION
### _Summary_

Fix export to account for basePath

### _How did you test your changes?_

From the root run `yarn deploy`

Validate there is an `out` directory inside the sdk playground directory. Make sure it has a `.nojekyll` file inside the out dir
