### PR TITLE
handshake refactor

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -58,9 +58,13 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
           case 'eth_chainId':
             return hexStringFromNumber(1) as T; // default value
           default: {
-            throw standardErrors.provider.unauthorized(
-              "Must call 'eth_requestAccounts' before other methods"
-            );
+            const signerType = await this.requestSignerSelection(args);
+            const signer = this.initSigner(signerType);
+            await signer.lightHandshake?.(args);
+            this.signer = signer;
+            storeSignerType(signerType);
+
+            return signer.request(args);
           }
         }
       }

--- a/packages/wallet-sdk/src/core/message/RPCMessage.ts
+++ b/packages/wallet-sdk/src/core/message/RPCMessage.ts
@@ -21,6 +21,9 @@ export interface RPCRequestMessage extends RPCMessage {
       }
     | {
         encrypted: EncryptedData;
+      }
+    | {
+        lightHandshake: RequestArguments;
       };
 }
 

--- a/packages/wallet-sdk/src/sign/interface.ts
+++ b/packages/wallet-sdk/src/sign/interface.ts
@@ -2,6 +2,7 @@ import { RequestArguments } from ':core/provider/interface.js';
 
 export interface Signer {
   handshake(_: RequestArguments): Promise<void>;
+  lightHandshake?: (_: RequestArguments) => Promise<void>;
   request<T>(_: RequestArguments): Promise<T>;
   cleanup: () => Promise<void>;
 }


### PR DESCRIPTION
### _Summary_

- Introduces a "light" handshake that initializes a signer without requiring an `eth_requestAccounts`
- After this light handshake, only `wallet_sendCalls`, `wallet_sign`, and `wallet_getCallsStatus` requests are allowed.
- An app can use `eth_requestAccounts` before or after this light handshake and the rest of the flow will continue to work like usual.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
