### PR TITLE
fix: invalid params passed to personal_sign Example Message action

### DIFF
--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -98,7 +98,7 @@ export function RpcMethodCard({ format, method, params, shortcuts }) {
           params: values,
         });
         setResponse(response);
-        await verify(response, data);
+        await verify(response, dataToSubmit);
       } catch (err) {
         const { code, message, data } = err;
         setError({ code, message, data });


### PR DESCRIPTION
### _Summary_
- `data` was being passed into `verify`  instead of `dataToSubmit` which is the mapped variable to translates ADDR_TO_FILL to the connected address.

### _How did you test your changes?_

Tested manually -- the "example message" action under the personal_sign section works without errors now after the fix 
<img width="412" alt="Screenshot 2025-01-02 at 9 12 59 AM" src="https://github.com/user-attachments/assets/ad8e4315-a520-4609-96b7-527b374d2404" />


