### PR TITLE
[BW-857] Abstract handshake into `coinbase_handshake`

### DIFF
--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -75,17 +75,15 @@ export function RpcMethodCard({ format, method, params, shortcuts }) {
       const dataToSubmit = { ...data };
       let values = dataToSubmit;
       if (format) {
-        // fill active address to the request
-        const addresses = await provider.request({ method: 'eth_accounts' });
-        const chainId = await provider.request({ method: 'eth_chainId' });
-
         for (const key in dataToSubmit) {
           if (Object.prototype.hasOwnProperty.call(data, key)) {
             if (dataToSubmit[key] === ADDR_TO_FILL) {
+              const addresses = await provider.request({ method: 'eth_accounts' });
               dataToSubmit[key] = addresses[0];
             }
 
             if (dataToSubmit[key] === CHAIN_ID_TO_FILL) {
+              const chainId = await provider.request({ method: 'eth_chainId' });
               dataToSubmit[key] = chainId;
             }
           }

--- a/examples/testapp/src/components/RpcMethods/method/ephemeralMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/ephemeralMethods.ts
@@ -1,0 +1,19 @@
+import { RpcRequestInput } from './RpcRequestInput';
+
+const walletSignEphemeral: RpcRequestInput = {
+  method: 'wallet_sign',
+  params: [
+    { key: 'version', required: true },
+    { key: 'chainId', required: true },
+    { key: 'calls', required: true },
+  ],
+  format: (data: Record<string, string>) => [
+    {
+      chainId: data.chainId,
+      calls: data.calls,
+      version: data.version,
+    },
+  ],
+};
+
+export const ephemeralMethods = [walletSignEphemeral];

--- a/examples/testapp/src/components/RpcMethods/method/ephemeralMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/ephemeralMethods.ts
@@ -1,7 +1,7 @@
 import { RpcRequestInput } from './RpcRequestInput';
 
-const walletSignEphemeral: RpcRequestInput = {
-  method: 'wallet_sign',
+const walletSendCallsEphemeral: RpcRequestInput = {
+  method: 'wallet_sendCalls',
   params: [
     { key: 'version', required: true },
     { key: 'chainId', required: true },
@@ -16,4 +16,12 @@ const walletSignEphemeral: RpcRequestInput = {
   ],
 };
 
-export const ephemeralMethods = [walletSignEphemeral];
+const walletSignEphemeral: RpcRequestInput = {
+  method: 'wallet_sign',
+  params: [{ key: 'message', required: true }],
+  format: (data: Record<string, string>) => [
+    `0x${Buffer.from(data.message, 'utf8').toString('hex')}`,
+  ],
+};
+
+export const ephemeralMethods = [walletSendCallsEphemeral, walletSignEphemeral];

--- a/examples/testapp/src/components/RpcMethods/shortcut/ephemeralMethodShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/ephemeralMethodShortcuts.ts
@@ -1,8 +1,8 @@
 import { ShortcutType } from './ShortcutType';
 
-const walletSignEphemeralShortcuts: ShortcutType[] = [
+const walletSendCallsEphemeralShortcuts: ShortcutType[] = [
   {
-    key: 'wallet_sign',
+    key: 'wallet_sendCalls',
     data: {
       chainId: '84532',
       calls: [],
@@ -11,6 +11,16 @@ const walletSignEphemeralShortcuts: ShortcutType[] = [
   },
 ];
 
+const walletSignEphemeralShortcuts: ShortcutType[] = [
+  {
+    key: 'wallet_sign',
+    data: {
+      message: 'Hello, world!',
+    },
+  },
+];
+
 export const ephemeralMethodShortcutsMap = {
+  wallet_sendCalls: walletSendCallsEphemeralShortcuts,
   wallet_sign: walletSignEphemeralShortcuts,
 };

--- a/examples/testapp/src/components/RpcMethods/shortcut/ephemeralMethodShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/ephemeralMethodShortcuts.ts
@@ -1,0 +1,16 @@
+import { ShortcutType } from './ShortcutType';
+
+const walletSignEphemeralShortcuts: ShortcutType[] = [
+  {
+    key: 'wallet_sign',
+    data: {
+      chainId: '84532',
+      calls: [],
+      version: '1',
+    },
+  },
+];
+
+export const ephemeralMethodShortcutsMap = {
+  wallet_sign: walletSignEphemeralShortcuts,
+};

--- a/examples/testapp/src/pages/index.tsx
+++ b/examples/testapp/src/pages/index.tsx
@@ -5,11 +5,13 @@ import { EventListenersCard } from '../components/EventListeners/EventListenersC
 import { WIDTH_2XL } from '../components/Layout';
 import { MethodsSection } from '../components/MethodsSection/MethodsSection';
 import { connectionMethods } from '../components/RpcMethods/method/connectionMethods';
+import { ephemeralMethods } from '../components/RpcMethods/method/ephemeralMethods';
 import { multiChainMethods } from '../components/RpcMethods/method/multiChainMethods';
 import { readonlyJsonRpcMethods } from '../components/RpcMethods/method/readonlyJsonRpcMethods';
 import { sendMethods } from '../components/RpcMethods/method/sendMethods';
 import { signMessageMethods } from '../components/RpcMethods/method/signMessageMethods';
 import { walletTxMethods } from '../components/RpcMethods/method/walletTxMethods';
+import { ephemeralMethodShortcutsMap } from '../components/RpcMethods/shortcut/ephemeralMethodShortcuts';
 import { multiChainShortcutsMap } from '../components/RpcMethods/shortcut/multipleChainShortcuts';
 import { readonlyJsonRpcShortcutsMap } from '../components/RpcMethods/shortcut/readonlyJsonRpcShortcuts';
 import { sendShortcutsMap } from '../components/RpcMethods/shortcut/sendShortcuts';
@@ -70,6 +72,11 @@ export default function Home() {
         </>
       )}
       <MethodsSection title="Wallet Connection" methods={connectionMethods} />
+      <MethodsSection
+        title="Ephemeral Methods"
+        methods={ephemeralMethods}
+        shortcutsMap={ephemeralMethodShortcutsMap}
+      />
       {shouldShowMethodsRequiringConnection && (
         <>
           <MethodsSection

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -1,6 +1,7 @@
 import { Signer } from './sign/interface.js';
 import { createSigner, fetchSignerType, loadSignerType, storeSignerType } from './sign/util.js';
 import { Communicator } from ':core/communicator/Communicator.js';
+import { CB_WALLET_RPC_URL } from ':core/constants.js';
 import { standardErrorCodes } from ':core/error/constants.js';
 import { standardErrors } from ':core/error/errors.js';
 import { serializeError } from ':core/error/serialize.js';
@@ -15,7 +16,7 @@ import {
 } from ':core/provider/interface.js';
 import { ScopedLocalStorage } from ':core/storage/ScopedLocalStorage.js';
 import { hexStringFromNumber } from ':core/type/util.js';
-import { checkErrorForInvalidRequestArgs } from ':util/provider.js';
+import { checkErrorForInvalidRequestArgs, fetchRPCRequest } from ':util/provider.js';
 
 export class CoinbaseWalletProvider extends ProviderEventEmitter implements ProviderInterface {
   private readonly metadata: AppMetadata;
@@ -61,6 +62,8 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
             await ephemeralSigner.cleanup(); // clean up (rotate) the ephemeral session keys
             return result as T;
           }
+          case 'wallet_getCallsStatus':
+            return fetchRPCRequest(args, CB_WALLET_RPC_URL);
           case 'net_version':
             return 1 as T; // default value
           case 'eth_chainId':

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -53,6 +53,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
             storeSignerType(signerType);
             break;
           }
+          case 'wallet_sendCalls':
           case 'wallet_sign': {
             const ephemeralSigner = this.initSigner('scw');
             await ephemeralSigner.handshake({ method: 'coinbase_handshake' }); // exchange session keys

--- a/packages/wallet-sdk/src/core/constants.ts
+++ b/packages/wallet-sdk/src/core/constants.ts
@@ -1,3 +1,4 @@
 export const CB_KEYS_URL = 'https://keys.coinbase.com/connect';
+export const CB_WALLET_RPC_URL = 'http://rpc.wallet.coinbase.com';
 export const WALLETLINK_URL = 'https://www.walletlink.org';
 export const CBW_MOBILE_DEEPLINK_URL = 'https://go.cb-w.com/walletlink';

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -124,6 +124,7 @@ export class SCWSigner implements Signer {
         return this.handleSwitchChainRequest(request);
       case 'eth_ecRecover':
       case 'personal_sign':
+      case 'wallet_sign':
       case 'personal_ecRecover':
       case 'eth_signTransaction':
       case 'eth_sendTransaction':

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -96,14 +96,14 @@ export class SCWSigner implements Signer {
   }
 
   async request(request: RequestArguments) {
-    switch (request.method) {
-      case 'wallet_sendCalls':
-      case 'wallet_sign':
-        return this.sendRequestToPopup(request);
-    }
-
     if (this.accounts.length === 0) {
-      throw standardErrors.provider.unauthorized();
+      switch (request.method) {
+        case 'wallet_sendCalls':
+        case 'wallet_sign':
+          return this.sendRequestToPopup(request);
+        default:
+          throw standardErrors.provider.unauthorized();
+      }
     }
 
     switch (request.method) {


### PR DESCRIPTION
### _Summary_

We used to see `eth_requestAccounts` as the handshake method, which does 2 things essentially:
- Authorizing the connection (by exchanging keys) and
- Returning the address

When exploring `wallet_sign`(`wallet_sendCalls`) and `wallet_connect`, the original idea was to merge another signing request with `eth_requestAccounts`, so we do 3 things at a time
- Authorizing the connection (by exchanging keys) and
- Returning the address
- Signing something

However, since the first request is for requesting trusted connection, the request itself is unencrypted. Hence, due to security reason, we couldn't request signing in this untrusted context.

This PR, is using @lukasrosario's idea, to create a `"Light Handshake"`, which will be used for establish a trusted communication channel, so subsequent requests can be transmitted in a trusted channel. In another word, instead, we are abstracting the connection authorization out from `eth_requestAccounts` to be its own request. Due to this is a concept used in Coinbase Wallet SDK only, we are naming it as `coinbase_handshake` tentatively.

#### Formula
- `eth_requestAccounts` = `coinbase_handshake` + request account effect
- ephemeral `wallet_sign` = `coinbase_handshake` + `personal_sign`
- ephemeral `wallet_sendCalls` = `coinbase_handshake` + `wallet_sendCalls`
- `wallet_connect` =  `coinbase_handshake` + wallet connect defined effect

### _How did you test your changes?_

Tested this works on desktop Chrome + mobile Safari

| Desktop Chrome | Mobile Safari |
| ---------- | --------- |
| <video src="https://github.com/user-attachments/assets/02ce9297-f126-426d-ba96-7d485c52dac3" /> | <video src="https://github.com/user-attachments/assets/d0b60db9-c908-4b04-b3dd-c6e0ffd762ba" /> |





