### PR TITLE
TRIVIAL - rename to handshake

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -113,7 +113,7 @@ describe('Ephemeral methods', () => {
     const args = { method: 'wallet_sign', params: ['0xdeadbeef'] };
     expect(provider['signer']).toBeNull();
     await provider.request(args);
-    expect(mockHandshake).toHaveBeenCalledWith({ method: 'coinbase_handshake' });
+    expect(mockHandshake).toHaveBeenCalledWith({ method: 'handshake' });
     expect(mockRequest).toHaveBeenCalledWith(args);
     expect(mockCleanup).toHaveBeenCalled();
     expect(provider['signer']).toBeNull();

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -57,7 +57,7 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
           case 'wallet_sendCalls':
           case 'wallet_sign': {
             const ephemeralSigner = this.initSigner('scw');
-            await ephemeralSigner.handshake({ method: 'coinbase_handshake' }); // exchange session keys
+            await ephemeralSigner.handshake({ method: 'handshake' }); // exchange session keys
             const result = await ephemeralSigner.request(args); // send diffie-hellman encrypted request
             await ephemeralSigner.cleanup(); // clean up (rotate) the ephemeral session keys
             return result as T;

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -124,14 +124,14 @@ describe('SCWSigner', () => {
       expect(mockCallback).toHaveBeenCalledWith('connect', { chainId: '0x1' });
     });
 
-    it('should perform a successful handshake for coinbase_handshake', async () => {
+    it('should perform a successful handshake for handshake', async () => {
       (decryptContent as Mock).mockResolvedValueOnce({
         result: {
           value: null,
         },
       });
 
-      await signer.handshake({ method: 'coinbase_handshake' });
+      await signer.handshake({ method: 'handshake' });
 
       expect(importKeyFromHexString).toHaveBeenCalledWith('public', '0xPublicKey');
       expect(mockCommunicator.postRequestAndWaitForResponse).toHaveBeenCalledWith(
@@ -139,7 +139,7 @@ describe('SCWSigner', () => {
           sender: '0xPublicKey',
           content: {
             handshake: expect.objectContaining({
-              method: 'coinbase_handshake',
+              method: 'handshake',
             }),
           },
         })
@@ -168,7 +168,7 @@ describe('SCWSigner', () => {
 
   describe('request - using ephemeral SCWSigner', () => {
     it.each(['wallet_sign', 'wallet_sendCalls'])(
-      'should perform a successful request after coinbase_handshake',
+      'should perform a successful request after handshake',
       async (method) => {
         const mockRequest: RequestArguments = { method };
 
@@ -177,7 +177,7 @@ describe('SCWSigner', () => {
             value: null,
           },
         });
-        await signer.handshake({ method: 'coinbase_handshake' });
+        await signer.handshake({ method: 'handshake' });
         expect(signer['accounts']).toEqual([]);
 
         (decryptContent as Mock).mockResolvedValueOnce({


### PR DESCRIPTION
### _Summary_

just renaming an internal RPC method

### _How did you test your changes?_


https://github.com/user-attachments/assets/6fe9363a-7ca1-43b9-addb-74b72cbd2662


