### PR TITLE
Update spend permission call to use eth and number for chainId

### DIFF
--- a/examples/testapp/src/components/RpcMethods/shortcut/signMessageShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/signMessageShortcuts.ts
@@ -137,7 +137,7 @@ const ethSignTypedDataV4Shortcuts: (chainId: number) => ShortcutType[] = (chainI
         domain: {
           name: 'Spend Permission Manager',
           version: '1',
-          chainId,
+          chainId: Number(chainId),
           verifyingContract: '0xf85210B21cC50302F477BA56686d2019dC9b67Ad',
         },
         types: {
@@ -157,7 +157,7 @@ const ethSignTypedDataV4Shortcuts: (chainId: number) => ShortcutType[] = (chainI
         message: {
           account: 'YOUR_ADDRESS_HERE',
           spender: '0xd4e17478581878A967aA22d45a5158A9fE96AA08',
-          token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
           allowance: '1000000',
           period: 86400,
           start: 1724264802,


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

We expect a number, but the prior implementation is using the hex representation of chainId

Also updated to use the native token instead of an ERC20 since the ERC20 address is only applicable to a specific chain

### _How did you test your changes?_
Manually
<!--
  Verify changes. Include relevant screenshots/videos
-->
<img width="426" alt="Screenshot 2025-01-27 at 12 39 47 PM" src="https://github.com/user-attachments/assets/5b21618e-9931-4a56-9cf4-31b30a84f50e" />

