### PR TITLE
fix: correct error message in WalletLinkHTTP from 'failed' to 'seen'

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkHTTP.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkHTTP.ts
@@ -23,7 +23,7 @@ export class WalletLinkHTTP {
           },
         })
       )
-    ).catch((error) => console.error('Unabled to mark event as failed:', error));
+    ).catch((error) => console.error('Unable to mark events as seen:', error));
   }
 
   async fetchUnseenEvents(): Promise<ServerMessage<'Event'>[]> {


### PR DESCRIPTION
### _Summary_

Updated the error log in `WalletLinkHTTP.ts` to say "Unable to mark events as seen" instead of "Unable to mark event as failed" for more accurate messaging.

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

- Manually triggered an error scenario to confirm the correct message logs.
- Verified there are no regressions (only the log text changed).

<!--
  Verify changes. Include relevant screenshots/videos
-->
