### PR TITLE
Parse typed data response if it's a string

### DIFF
--- a/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/signMessageMethods.ts
@@ -100,14 +100,17 @@ export const verifySignMsg = async ({
         transport: http(),
       });
 
+      // Parse the message if it's a string
+      const typedData = typeof message === 'string' ? JSON.parse(message) : message;
+
       const valid = await client.verifyTypedData({
         address: from as `0x${string}`,
-        domain: message['domain'] as TypedDataDomain,
+        domain: typedData['domain'] as TypedDataDomain,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        types: message['types'] as any,
-        primaryType: message['primaryType'] as string,
+        types: typedData['types'] as any,
+        primaryType: typedData['primaryType'] as string,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        message: message['message'] as any,
+        message: typedData['message'] as any,
         signature: sign as `0x${string}`,
       });
       if (valid) {


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

Serialized responses are not being properly handled. This fix will parse out serialized responses during signature validation. I'd expect viem to do this internally but it does not.

### _How did you test your changes?_
Manually

<!--
  Verify changes. Include relevant screenshots/videos
-->

Before

<img width="985" alt="Screenshot 2025-02-06 at 10 46 58 AM" src="https://github.com/user-attachments/assets/d786fd7d-c71a-46fd-be71-1fbed765c2a4" />

After

<img width="1108" alt="Screenshot 2025-02-06 at 10 47 53 AM" src="https://github.com/user-attachments/assets/eb782d50-76e3-4810-9f0e-290a36001fd1" />

