### PR TITLE
ERC7846 `wallet_connect` Support

### DIFF
--- a/examples/testapp/src/components/RpcMethods/method/connectionMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/connectionMethods.ts
@@ -10,4 +10,17 @@ const ethAccounts: RpcRequestInput = {
   params: [],
 };
 
-export const connectionMethods = [ethRequestAccounts, ethAccounts];
+const walletConnect: RpcRequestInput = {
+  method: 'wallet_connect',
+  params: [
+    {
+      key: 'version',
+      required: true,
+    },
+    {
+      key: 'capabilities',
+    },
+  ],
+};
+
+export const connectionMethods = [ethRequestAccounts, ethAccounts, walletConnect];

--- a/examples/testapp/src/components/RpcMethods/method/connectionMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/connectionMethods.ts
@@ -21,6 +21,12 @@ const walletConnect: RpcRequestInput = {
       key: 'capabilities',
     },
   ],
+  format: (data: Record<string, string>) => [
+    {
+      version: data.version,
+      capabilities: data.capabilities,
+    },
+  ],
 };
 
 export const connectionMethods = [ethRequestAccounts, ethAccounts, walletConnect];

--- a/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
@@ -1,0 +1,21 @@
+import { ShortcutType } from './ShortcutType';
+
+const walletConnectShortcuts: ShortcutType[] = [
+  {
+    key: 'SIWE',
+    data: {
+      chainId: '84532',
+      version: '1',
+      capabilities: {
+        signInWithEthereum: {
+          chainId: 84532,
+          nonce: Math.random().toString(36).substring(2, 15),
+        },
+      },
+    },
+  },
+];
+
+export const connectionMethodShortcutsMap = {
+  wallet_connect: walletConnectShortcuts,
+};

--- a/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
@@ -4,7 +4,6 @@ const walletConnectShortcuts: ShortcutType[] = [
   {
     key: 'SIWE',
     data: {
-      chainId: '84532',
       version: '1',
       capabilities: {
         signInWithEthereum: {

--- a/examples/testapp/src/pages/index.page.tsx
+++ b/examples/testapp/src/pages/index.page.tsx
@@ -11,6 +11,7 @@ import { readonlyJsonRpcMethods } from '../components/RpcMethods/method/readonly
 import { sendMethods } from '../components/RpcMethods/method/sendMethods';
 import { signMessageMethods } from '../components/RpcMethods/method/signMessageMethods';
 import { walletTxMethods } from '../components/RpcMethods/method/walletTxMethods';
+import { connectionMethodShortcutsMap } from '../components/RpcMethods/shortcut/connectionMethodShortcuts';
 import { ephemeralMethodShortcutsMap } from '../components/RpcMethods/shortcut/ephemeralMethodShortcuts';
 import { multiChainShortcutsMap } from '../components/RpcMethods/shortcut/multipleChainShortcuts';
 import { readonlyJsonRpcShortcutsMap } from '../components/RpcMethods/shortcut/readonlyJsonRpcShortcuts';
@@ -71,7 +72,11 @@ export default function Home() {
           </Box>
         </>
       )}
-      <MethodsSection title="Wallet Connection" methods={connectionMethods} />
+      <MethodsSection
+        title="Wallet Connection"
+        methods={connectionMethods}
+        shortcutsMap={connectionMethodShortcutsMap}
+      />
       <MethodsSection
         title="Ephemeral Methods"
         methods={ephemeralMethods}

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -54,6 +54,13 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
             storeSignerType(signerType);
             break;
           }
+          case 'wallet_connect': {
+            const signer = this.initSigner('scw');
+            this.signer = signer;
+            await signer.handshake({ method: 'handshake' }); // exchange session keys
+            const result = await signer.request(args); // send diffie-hellman encrypted request
+            return result as T;
+          }
           case 'wallet_sendCalls': {
             const ephemeralSigner = this.initSigner('scw');
             await ephemeralSigner.handshake({ method: 'handshake' }); // exchange session keys

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -56,9 +56,9 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
           }
           case 'wallet_connect': {
             const signer = this.initSigner('scw');
-            this.signer = signer;
             await signer.handshake({ method: 'handshake' }); // exchange session keys
             const result = await signer.request(args); // send diffie-hellman encrypted request
+            this.signer = signer;
             return result as T;
           }
           case 'wallet_sendCalls': {

--- a/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
@@ -1,0 +1,73 @@
+import { SubAccountInfo } from ':stores/sub-accounts/store.js';
+
+export type SignInWithEthereumCapabilityRequest = {
+  nonce: string;
+  chainId: string; // EIP-155 hex-encoded
+  version?: string;
+  scheme?: string;
+  domain?: string;
+  uri?: string;
+  statement?: string;
+  issuedAt?: string;
+  expirationTime?: string;
+  notBefore?: string;
+  requestId?: string;
+  resources?: string[];
+};
+
+export type SignInWithEthereumCapabilityResponse = {
+  message: string;
+  signature: `0x${string}`;
+};
+
+export type SpendPermissionsCapabilityRequest = {
+  token: `0x${string}`;
+  allowance: string;
+  period: number;
+  salt?: `0x${string}`;
+  extraData?: `0x${string}`;
+};
+
+export type SpendPermissionsCapabilityResponse = {
+  signature: `0x${string}`;
+};
+
+export type AddAddressCapabilityRequest = {
+  address?: `0x${string}`;
+  chainId: number;
+  createAccount?: {
+    signer: `0x${string}`;
+  };
+  // TODO: initcode will be added for import
+};
+
+export type AddAddressCapabilityResponse = SubAccountInfo;
+
+export type WalletConnectRequest = {
+  method: 'wallet_connect';
+  params: [
+    {
+      // JSON-RPC method version.
+      version: string;
+      // Optional capabilities to request (e.g. Sign In With Ethereum).
+      capabilities?: {
+        addAddress: AddAddressCapabilityRequest;
+        spendPermissions: SpendPermissionsCapabilityRequest;
+        signInWithEthereum: SignInWithEthereumCapabilityRequest;
+      };
+    },
+  ];
+};
+
+export type WalletConnectResponse = {
+  accounts: {
+    // Address of the connected account.
+    address: `0x${string}`;
+    // Capabilities granted that is associated with this account.
+    capabilities: {
+      addAddress: AddAddressCapabilityResponse;
+      spendPermissions: SpendPermissionsCapabilityResponse;
+      signInWithEthereum: SignInWithEthereumCapabilityResponse;
+    };
+  }[];
+};

--- a/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
@@ -51,9 +51,9 @@ export type WalletConnectRequest = {
       version: string;
       // Optional capabilities to request (e.g. Sign In With Ethereum).
       capabilities?: {
-        addAddress: AddAddressCapabilityRequest;
-        spendPermissions: SpendPermissionsCapabilityRequest;
-        signInWithEthereum: SignInWithEthereumCapabilityRequest;
+        addAddress?: AddAddressCapabilityRequest;
+        spendPermissions?: SpendPermissionsCapabilityRequest;
+        signInWithEthereum?: SignInWithEthereumCapabilityRequest;
       };
     },
   ];
@@ -64,10 +64,10 @@ export type WalletConnectResponse = {
     // Address of the connected account.
     address: `0x${string}`;
     // Capabilities granted that is associated with this account.
-    capabilities: {
-      addAddress: AddAddressCapabilityResponse;
-      spendPermissions: SpendPermissionsCapabilityResponse;
-      signInWithEthereum: SignInWithEthereumCapabilityResponse;
+    capabilities?: {
+      addAddress?: AddAddressCapabilityResponse;
+      spendPermissions?: SpendPermissionsCapabilityResponse;
+      signInWithEthereum?: SignInWithEthereumCapabilityResponse;
     };
   }[];
 };

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -186,17 +186,18 @@ export class SCWSigner implements Signer {
         const accounts = response.accounts.map((account) => account.address);
         this.accounts = accounts;
         this.storage.storeObject(ACCOUNTS_KEY, accounts);
-        this.callback?.('accountsChanged', accounts);
 
         // TODO: in future PR update state to support multiple accounts
         const account = response.accounts[0];
         const capabilities = account.capabilities;
         if (capabilities && capabilities.addAddress) {
-          const subAccount = capabilities.addAddress;
           subaccounts.setState({
-            account: subAccount,
+            account: capabilities.addAddress,
           });
         }
+        this.callback?.('accountsChanged', [
+          subaccounts.getState().account?.address ?? this.accounts[0],
+        ]);
         break;
       }
       default:

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -191,7 +191,7 @@ export class SCWSigner implements Signer {
         // TODO: in future PR update state to support multiple accounts
         const account = response.accounts[0];
         const capabilities = account.capabilities;
-        if (capabilities.addAddress) {
+        if (capabilities && capabilities.addAddress) {
           const subAccount = capabilities.addAddress;
           subaccounts.setState({
             account: subAccount,


### PR DESCRIPTION
### _Summary_

This PR adds basic support for `wallet_connect`

To ensure requests are encrypted we use the handshake before sending the request to the popup. This ensures the request and response is encrypted. There may need to be modifications once landing the first round of support on the keys popup side

### _How did you test your changes?_
Manually

![Feb-06-2025 12-59-22](https://github.com/user-attachments/assets/04c0f516-5f61-446a-a653-0767d847c30e)

