### PR TITLE
Fix bug where wallet send calls wasn't able to parse the calls part of the request

### DIFF
--- a/examples/testapp/src/components/RpcMethods/method/walletTxMethods.ts
+++ b/examples/testapp/src/components/RpcMethods/method/walletTxMethods.ts
@@ -19,7 +19,7 @@ const walletSendCalls: RpcRequestInput = {
     {
       chainId: data.chainId,
       from: data.from,
-      calls: data.calls,
+      calls: parseMessage(data.calls),
       version: data.version,
       capabilities: parseMessage(data.capabilities),
     },


### PR DESCRIPTION
### _Summary_
Parse the calls parameter either as a json or keep it as an object (parsing from the input text field turns it into a string)

### _How did you test your changes?_

Tried this calls request
With change:
![image](https://github.com/user-attachments/assets/85786964-ed4c-4044-a522-255e9799a5fc)

Without change:
![image](https://github.com/user-attachments/assets/235ea22f-8045-42e6-8bf9-4712c130d775)

<!--
  Verify changes. Include relevant screenshots/videos
-->
