### PR TITLE
feat: Add getAppAccounts capability and improve sub-account handling

### DIFF
--- a/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
@@ -13,6 +13,17 @@ const walletConnectShortcuts: ShortcutType[] = [
       },
     },
   },
+  {
+    key: 'Get App Accounts',
+    data: {
+      version: '1',
+      capabilities: {
+        getAppAccounts: {
+          chainId: 84532,
+        },
+      },
+    },
+  },
 ];
 
 export const connectionMethodShortcutsMap = {

--- a/packages/wallet-sdk/src/core/rpc/wallet_addAddress.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_addAddress.ts
@@ -11,7 +11,7 @@ export type WalletAddAddressRequest = {
   params: [
     {
       version: '1';
-      chainId: string;
+      chainId: number;
       address?: string;
       capabilities?: WalletAddAddressCapabilities;
     },

--- a/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
@@ -67,7 +67,7 @@ export type WalletConnectResponse = {
     // Capabilities granted that is associated with this account.
     capabilities?: {
       addAddress?: AddAddressCapabilityResponse | SerializedEthereumRpcError;
-      getAppAccounts?: AddAddressCapabilityResponse | SerializedEthereumRpcError;
+      getAppAccounts?: AddAddressCapabilityResponse[];
       spendPermissions?: SpendPermissionsCapabilityResponse | SerializedEthereumRpcError;
       signInWithEthereum?: SignInWithEthereumCapabilityResponse | SerializedEthereumRpcError;
     };

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -193,16 +193,11 @@ export class SCWSigner implements Signer {
         // TODO: in future PR update state to support multiple accounts
         const account = response.accounts.at(0);
         const capabilities = account?.capabilities;
-        if (capabilities?.addAddress) {
-          assertSubAccountInfo(capabilities.addAddress);
+        if (capabilities?.addAddress || capabilities?.getAppAccounts) {
+          const capabilityResponse = capabilities?.addAddress ?? capabilities?.getAppAccounts?.[0];
+          assertSubAccountInfo(capabilityResponse);
           subaccounts.setState({
-            account: capabilities.addAddress,
-          });
-        }
-        if (capabilities?.getAppAccounts) {
-          assertSubAccountInfo(capabilities.getAppAccounts[0]);
-          subaccounts.setState({
-            account: capabilities.getAppAccounts[0],
+            account: capabilityResponse,
           });
         }
         this.callback?.('accountsChanged', [

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -365,8 +365,10 @@ export class SCWSigner implements Signer {
   private shouldRequestUseSubAccountSigner(request: RequestArguments) {
     const sender = getSenderFromRequest(request);
     const state = subaccounts.getState();
-    if (!sender) return false;
-    return sender && sender !== state.account?.address;
+    if (sender) {
+      return sender === state.account?.address;
+    }
+    return false;
   }
 
   private async sendRequestToSubAccountSigner(request: RequestArguments) {

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -193,19 +193,17 @@ export class SCWSigner implements Signer {
         // TODO: in future PR update state to support multiple accounts
         const account = response.accounts.at(0);
         const capabilities = account?.capabilities;
-        if (capabilities) {
-          if (capabilities.addAddress) {
-            assertSubAccountInfo(capabilities.addAddress);
-            subaccounts.setState({
-              account: capabilities.addAddress,
-            });
-          }
-          if (capabilities.getAppAccounts) {
-            assertSubAccountInfo(capabilities.getAppAccounts[0]);
-            subaccounts.setState({
-              account: capabilities.getAppAccounts[0],
-            });
-          }
+        if (capabilities?.addAddress) {
+          assertSubAccountInfo(capabilities.addAddress);
+          subaccounts.setState({
+            account: capabilities.addAddress,
+          });
+        }
+        if (capabilities?.getAppAccounts) {
+          assertSubAccountInfo(capabilities.getAppAccounts[0]);
+          subaccounts.setState({
+            account: capabilities.getAppAccounts[0],
+          });
         }
         this.callback?.('accountsChanged', [
           subaccounts.getState().account?.address ?? this.accounts[0],


### PR DESCRIPTION
### _Summary_

This PR adds support for the getAppAccounts capability and improves sub-account handling logic.

Key changes:
* Added getAppAccounts shortcut in test app with chainId 84532
* Updated WalletConnectResponse type to handle getAppAccounts capability response as an array
* Modified SCWSigner to:
* Handle getAppAccounts capability responses
* Improve sub-account signer request routing logic
* Remove hardcoded ROOT_ACCOUNT_METHODS array

### _How did you test your changes?_

* Run the test app
* Connect wallet using WalletConnect
* Test the "Get App Accounts" shortcut
* Verify that sub-account handling works correctly when:
* Getting app accounts
* Switching between root and sub-accounts
* Making transactions from different accounts

#### Implementation Details:
* getAppAccounts capability now returns an array of AddAddressCapabilityResponse
* Sub-account signer request routing is now based purely on sender address matching
* State management updated to handle multiple accounts (groundwork for future expansion)
* Please verify the changes in:
* Test app shortcuts
* WalletConnect response types
* SCWSigner account handling logic
