### PR TITLE
fix owner index lookup

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/utils/getOwnerIndex.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/getOwnerIndex.test.ts
@@ -18,9 +18,9 @@ describe('getOwnerIndex', () => {
     const mockReadContract = vi
       .fn()
       .mockResolvedValueOnce(BigInt(3)) // ownerCount
-      .mockResolvedValueOnce('0x46440ECd6746f7612809eFED388347d476369f6D') // owner at index 2
-      .mockResolvedValueOnce('0xd9Ec1a8603125732c1ee35147619BbFA769A062b') // owner at index 1
-      .mockResolvedValueOnce('0x7838d2724FC686813CAf81d4429beff1110c739a'); // owner at index 0
+      .mockResolvedValueOnce('0x00000000000000000000000046440ECd6746f7612809eFED388347d476369f6D') // owner at index 2
+      .mockResolvedValueOnce('0x000000000000000000000000d9Ec1a8603125732c1ee35147619BbFA769A062b') // owner at index 1
+      .mockResolvedValueOnce('0x0000000000000000000000007838d2724FC686813CAf81d4429beff1110c739a'); // owner at index 0
 
     (readContract as Mock).mockImplementation(mockReadContract);
 
@@ -38,9 +38,9 @@ describe('getOwnerIndex', () => {
     const mockReadContract = vi
       .fn()
       .mockResolvedValueOnce(BigInt(3)) // ownerCount
-      .mockResolvedValueOnce('0x46440ECd6746f7612809eFED388347d476369f6D') // owner at index 2
-      .mockResolvedValueOnce('0xd9Ec1a8603125732c1ee35147619BbFA769A062b') // owner at index 1
-      .mockResolvedValueOnce('0x7838d2724FC686813CAf81d4429beff1110c739a'); // owner at index 0
+      .mockResolvedValueOnce('0x00000000000000000000000046440ECd6746f7612809eFED388347d476369f6D') // owner at index 2
+      .mockResolvedValueOnce('0x000000000000000000000000d9Ec1a8603125732c1ee35147619BbFA769A062b') // owner at index 1
+      .mockResolvedValueOnce('0x0000000000000000000000007838d2724FC686813CAf81d4429beff1110c739a'); // owner at index 0
 
     (readContract as Mock).mockImplementation(mockReadContract);
 
@@ -51,6 +51,28 @@ describe('getOwnerIndex', () => {
     });
 
     expect(result).toBe(2);
+    expect(mockReadContract).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles 64 byte public keys', async () => {
+    const mockReadContract = vi
+      .fn()
+      .mockResolvedValueOnce(BigInt(2)) // ownerCount
+      .mockResolvedValueOnce(
+        '0xe7575170745fe55d7a26190c6d5504743496c49498b129d2b3660da3697e81d4daebb2496f89aa4a05f1705e1d5d316153211c198f80d3100b51489bf4963f47'
+      ) // owner at index 1
+      .mockResolvedValueOnce('0x0000000000000000000000007838d2724FC686813CAf81d4429beff1110c739a'); // owner at index 0
+
+    (readContract as Mock).mockImplementation(mockReadContract);
+
+    const result = await getOwnerIndex({
+      address: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
+      client,
+      publicKey:
+        '0xe7575170745fe55d7a26190c6d5504743496c49498b129d2b3660da3697e81d4daebb2496f89aa4a05f1705e1d5d316153211c198f80d3100b51489bf4963f47',
+    });
+
+    expect(result).toBe(1);
     expect(mockReadContract).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/wallet-sdk/src/sign/scw/utils/getOwnerIndex.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/getOwnerIndex.ts
@@ -1,4 +1,4 @@
-import { Client, Hex } from 'viem';
+import { Client, Hex, isAddress, pad } from 'viem';
 import { readContract } from 'viem/actions';
 
 import { abi } from './constants.js';
@@ -28,10 +28,23 @@ export async function getOwnerIndex({
       args: [BigInt(i)],
     });
 
-    if (owner.toLowerCase() === publicKey.toLowerCase()) {
+    const formatted = formatPublicKey(publicKey);
+    if (owner.toLowerCase() === formatted.toLowerCase()) {
       return i;
     }
   }
 
   throw standardErrors.rpc.internal('account owner not found');
+}
+
+/**
+ * Formats 20 byte addresses to 32 byte public keys. Contract uses 32 byte keys for owners.
+ * @param publicKey - The public key to format
+ * @returns The formatted public key
+ */
+export function formatPublicKey(publicKey: Hex): Hex {
+  if (isAddress(publicKey)) {
+    return pad(publicKey);
+  }
+  return publicKey;
 }


### PR DESCRIPTION
### _Summary_

We were not padding 20 byte addresses when checking against the owner addresses. This fixes that

### _How did you test your changes?_

Manually and unit tests