### PR TITLE
refactor: remove error module dependency on walletlink

### DIFF
--- a/packages/wallet-sdk/src/core/error/serialize.ts
+++ b/packages/wallet-sdk/src/core/error/serialize.ts
@@ -1,8 +1,22 @@
-// TODO: error should not depend on walletlink. revisit this.
 import { VERSION } from '../../sdk-info.js';
-import { isErrorResponse, Web3Response } from '../../sign/walletlink/relay/type/Web3Response.js';
 import { standardErrorCodes } from './constants.js';
 import { serialize } from './utils.js';
+
+/**
+ * Interface for error responses
+ */
+export interface ErrorResponse {
+  method: unknown;
+  errorCode?: number;
+  errorMessage: string;
+}
+
+/**
+ * Checks if a response is an error response
+ */
+export function isErrorResponse(response: unknown): response is ErrorResponse {
+  return (response as ErrorResponse).errorMessage !== undefined;
+}
 
 /**
  * Serializes an error to a format that is compatible with the Ethereum JSON RPC error format.
@@ -28,7 +42,7 @@ export function serializeError(error: unknown) {
 /**
  * Converts an error to a serializable object.
  */
-function getErrorObject(error: string | Web3Response | unknown) {
+function getErrorObject(error: string | ErrorResponse | unknown) {
   if (typeof error === 'string') {
     return {
       message: error,

--- a/packages/wallet-sdk/src/core/error/utils.test.ts
+++ b/packages/wallet-sdk/src/core/error/utils.test.ts
@@ -1,6 +1,7 @@
-import { isErrorResponse, Web3Response } from '../../sign/walletlink/relay/type/Web3Response.js';
+import { Web3Response } from '../../sign/walletlink/relay/type/Web3Response.js';
 import { standardErrorCodes } from './constants.js';
 import { standardErrors } from './errors.js';
+import { isErrorResponse, ErrorResponse } from './serialize.js';
 import { getErrorCode, getMessageFromCode } from './utils.js';
 
 describe('errors', () => {
@@ -23,7 +24,7 @@ describe('errors', () => {
     expect(getErrorCode(null)).toEqual(undefined);
     expect(getErrorCode(undefined)).toEqual(undefined);
 
-    const errorResponse: Web3Response = {
+    const errorResponse: ErrorResponse = {
       method: 'generic',
       errorMessage: 'test error message',
       errorCode: 4137,


### PR DESCRIPTION
This commit removes the dependency of the error module on walletlink by:
- Moving the ErrorResponse interface and isErrorResponse function from Web3Response to the error module
- Making these types exportable from the error module
- Updating tests to use the new exported types
- Removing the TODO comment as the issue is now resolved

This change improves the modularity of the codebase by ensuring that the core error handling functionality does not depend on the walletlink module.