### PR TITLE
fix: missing methods vendor file

### DIFF
--- a/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.cjs
+++ b/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.cjs
@@ -15,6 +15,29 @@ function zeros (bytes) {
   return Buffer.allocUnsafe(bytes).fill(0)
 }
 
+
+/**
+ * Converts a `Number` into a hex `String` (https://github.com/ethjs/ethjs-util/blob/master/src/index.js)
+ * @param {Number} i
+ * @return {String}
+ */
+function intToHex(i) {
+  const hex = i.toString(16); // eslint-disable-line
+
+  return `0x${hex}`;
+}
+
+/**
+ * Converts an `Number` to a `Buffer` (https://github.com/ethjs/ethjs-util/blob/master/src/index.js)
+ * @param {Number} i
+ * @return {Buffer}
+ */
+function intToBuffer(i) {
+  const hex = intToHex(i);
+
+  return new Buffer(padToEven(hex.slice(2)), 'hex');
+}
+
 function bitLengthFromBigInt (num) {
   return num.toString(2).length
 }


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
Adds missing `intToBuffer` method to https://github.com/coinbase/coinbase-wallet-sdk/blob/master/packages/wallet-sdk/src/vendor-js/eth-eip712-util/util.cjs#L106

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
