### PR TITLE
fix: incorrect return type for cached sub account

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -1,4 +1,4 @@
-import { numberToHex } from 'viem';
+import { Hex, numberToHex } from 'viem';
 
 import { Signer } from '../interface.js';
 import { SCWKeyManager } from './SCWKeyManager.js';
@@ -328,12 +328,16 @@ export class SCWSigner implements Signer {
     return true;
   }
 
-  private async addSubAccount(request: RequestArguments) {
+  private async addSubAccount(request: RequestArguments): Promise<{
+    address: Address;
+    factory?: Address;
+    factoryData?: Hex;
+  }> {
     const state = store.getState();
     const subAccount = state.subAccount;
     if (subAccount?.address) {
       this.callback?.('accountsChanged', [this.accounts[0], subAccount.address]);
-      return subAccount.address;
+      return subAccount;
     }
 
     await this.communicator.waitForPopupLoaded?.();


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
The expected response for `wallet_addSubAccount` is `{address: string, factory?: string, factoryData?: string}`. However, after initially adding the wallet_addSubAccount and persisting it locally, the function only returns the address `string`. 

This PR updates the function to return the full subAccount object in the cache branch as expected.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Playground