### PR TITLE
fix: injected wallet playground webview

### DIFF
--- a/examples/testapp/src/pages/index.page.tsx
+++ b/examples/testapp/src/pages/index.page.tsx
@@ -48,6 +48,11 @@ export default function Home() {
         setChainId(Number.parseInt(chainId, 16));
       });
     }
+
+    // Injected provider does not emit a 'connect' event
+    if (provider?.isCoinbaseBrowser) {
+      setConnected(true);
+    }
   }, [connected, provider]);
 
   // There's a bug in 3.9.3 where it does not emit a 'connect' event for walletlink connections


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

Connected state was not triggered for injected wallets in mobile WebView because provider events are not being emitted. This change checks the `isCoinbaseBrowser` property on the provider and sets the connected state if it is present.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Loaded the playground in the coinbase mobile wallet browser and ensured the methods that depend on a wallet being connected were shown
