### PR TITLE
fix: query params getting duplicated on each popup open

### DIFF
--- a/packages/wallet-sdk/src/util/web.test.ts
+++ b/packages/wallet-sdk/src/util/web.test.ts
@@ -62,6 +62,21 @@ describe('PopupManager', () => {
     expect(url.searchParams.get('coop')).toBe('null');
   });
 
+  it('should not duplicate parameters when opening a popup with existing params', async () => {
+    const url = new URL('https://example.com');
+    url.searchParams.append('sdkName', NAME);
+    url.searchParams.append('sdkVersion', VERSION);
+    url.searchParams.append('origin', mockOrigin);
+    url.searchParams.append('coop', 'null');
+    
+    (window.open as Mock).mockReturnValue({ focus: vi.fn() });
+
+    await openPopup(url);
+
+    const paramCount = url.searchParams.toString().split('&').length;
+    expect(paramCount).toBe(4);
+  });
+
   it('should show snackbar with retry button when popup is blocked and retry successfully', async () => {
     const url = new URL('https://example.com');
     const mockPopup = { focus: vi.fn() };

--- a/packages/wallet-sdk/src/util/web.ts
+++ b/packages/wallet-sdk/src/util/web.ts
@@ -1,8 +1,8 @@
+import { NAME, VERSION } from '../sdk-info.js';
+import { getCrossOriginOpenerPolicy } from './checkCrossOriginOpenerPolicy.js';
 import { standardErrors } from ':core/error/errors.js';
 import { Snackbar } from ':sign/walletlink/relay/ui/components/Snackbar/Snackbar.js';
 import { RETRY_SVG_PATH } from ':sign/walletlink/relay/ui/WalletLinkRelayUI.js';
-import { NAME, VERSION } from '../sdk-info.js';
-import { getCrossOriginOpenerPolicy } from './checkCrossOriginOpenerPolicy.js';
 
 const POPUP_WIDTH = 420;
 const POPUP_HEIGHT = 540;

--- a/packages/wallet-sdk/src/util/web.ts
+++ b/packages/wallet-sdk/src/util/web.ts
@@ -1,8 +1,8 @@
-import { NAME, VERSION } from '../sdk-info.js';
-import { getCrossOriginOpenerPolicy } from './checkCrossOriginOpenerPolicy.js';
 import { standardErrors } from ':core/error/errors.js';
 import { Snackbar } from ':sign/walletlink/relay/ui/components/Snackbar/Snackbar.js';
 import { RETRY_SVG_PATH } from ':sign/walletlink/relay/ui/WalletLinkRelayUI.js';
+import { NAME, VERSION } from '../sdk-info.js';
+import { getCrossOriginOpenerPolicy } from './checkCrossOriginOpenerPolicy.js';
 
 const POPUP_WIDTH = 420;
 const POPUP_HEIGHT = 540;
@@ -88,7 +88,9 @@ function appendAppInfoQueryParams(url: URL) {
   };
 
   for (const [key, value] of Object.entries(params)) {
-    url.searchParams.append(key, value.toString());
+    if (!url.searchParams.has(key)) {
+      url.searchParams.append(key, value.toString());
+    }
   }
 }
 


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

- When opening the popup, we append some necessary query params to the URL. Since the URL object is re-used, the query params were getting appended again on each popup open.
  - This was fixed by adding a simple check for if the query param already exists

### _How did you test your changes?_

- Manually and unit tests

<!--
  Verify changes. Include relevant screenshots/videos
-->



### Before:
https://github.com/user-attachments/assets/b8d8313f-1bc3-462f-ab69-5f270047ae2b


### After:

https://github.com/user-attachments/assets/e612034b-0009-40b0-ae76-6b76e9874f1b



