### PR TITLE
refactor: remove Heartbeat type from ServerMessage types

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/relay/type/ServerMessage.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/type/ServerMessage.ts
@@ -9,9 +9,6 @@ type Type = _ServerMessage['type'];
 
 type _ServerMessage =
   | {
-      type: 'Heartbeat'; // TODO: remove. it's client side only virtual message.
-    }
-  | {
       type: 'OK';
       id: IntNumber;
       sessionId: string;


### PR DESCRIPTION
### _Summary_

This commit removes the Heartbeat type from the ServerMessage types as it was
only used as a client-side virtual message and doesn't belong in the server
message type definitions. This change improves type safety by ensuring that
the server message types accurately reflect only messages that can come from
the server.
