### PR TITLE
chore: refactor localstorage private key in example

### DIFF
--- a/examples/testapp/src/pages/add-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/add-sub-account/index.page.tsx
@@ -9,7 +9,9 @@ import {
 } from '@chakra-ui/react';
 import { createCoinbaseWalletSDK, getCryptoKeyAccount } from '@coinbase/wallet-sdk';
 import { useEffect, useState } from 'react';
-import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { unsafe_generateOrLoadPrivateKey } from '../../utils/unsafe_generateOrLoadPrivateKey';
 import { AddOwner } from './components/AddOwner';
 import { AddSubAccount } from './components/AddSubAccount';
 import { Connect } from './components/Connect';
@@ -45,11 +47,9 @@ export default function SubAccounts() {
       signerType === 'cryptokey'
         ? getCryptoKeyAccount
         : async () => {
-            let privateKey = localStorage.getItem('cbwsdk.demo.add-sub-account.pk') as `0x${string}` | null;
-            if (!privateKey) {
-              privateKey = generatePrivateKey();
-              localStorage.setItem('cbwsdk.demo.add-sub-account.pk', privateKey);
-            }
+            // THIS IS NOT SAFE, THIS IS ONLY FOR TESTING
+            // IN A REAL APP YOU SHOULD NOT STORE/EXPOSE A PRIVATE KEY
+            const privateKey = unsafe_generateOrLoadPrivateKey();
             return {
               account: privateKeyToAccount(privateKey),
             };

--- a/examples/testapp/src/pages/import-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/import-sub-account/index.page.tsx
@@ -3,9 +3,10 @@ import { createCoinbaseWalletSDK } from '@coinbase/wallet-sdk';
 import { useEffect, useState } from 'react';
 import { Client, Hex, createPublicClient, http } from 'viem';
 import { SmartAccount, toCoinbaseSmartAccount } from 'viem/account-abstraction';
-import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { privateKeyToAccount } from 'viem/accounts';
 import { baseSepolia } from 'viem/chains';
 
+import { unsafe_generateOrLoadPrivateKey } from '../../utils/unsafe_generateOrLoadPrivateKey';
 import { AddGlobalOwner } from './components/AddGlobalOwner';
 import { AddSubAccountDeployed } from './components/AddSubAccountDeployed';
 import { AddSubAccountUndeployed } from './components/AddSubAccountUndeployed';
@@ -35,13 +36,9 @@ export default function SubAccounts() {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: no dep
   useEffect(() => {
-    let pk = localStorage.getItem('cbwsdk.demo.add-sub-account.pk') as Hex | null;
-    if (!pk) {
-      pk = generatePrivateKey();
-      // THIS IS NOT SAFE, THIS IS ONLY FOR TESTING
-      // IN A REAL APP YOU SHOULD NOT STORE/EXPOSE A PRIVATE KEY
-      localStorage.setItem('cbwsdk.demo.add-sub-account.pk', pk);
-    }
+    // THIS IS NOT SAFE, THIS IS ONLY FOR TESTING
+    // IN A REAL APP YOU SHOULD NOT STORE/EXPOSE A PRIVATE KEY
+    const pk = unsafe_generateOrLoadPrivateKey();
     const account = privateKeyToAccount(pk);
 
     const sdk = createCoinbaseWalletSDK({

--- a/examples/testapp/src/utils/unsafe_generateOrLoadPrivateKey.ts
+++ b/examples/testapp/src/utils/unsafe_generateOrLoadPrivateKey.ts
@@ -1,0 +1,18 @@
+import { generatePrivateKey } from 'viem/accounts';
+
+/**
+ * Generate a private key if it doesn't exist in local storage
+ * or load the private key from local storage
+ *
+ * This is not safe, this is only for testing
+ * In a real app you should not store/expose a private key
+ * @returns a private key
+ */
+export function unsafe_generateOrLoadPrivateKey() {
+  let privateKey = localStorage.getItem('cbwsdk.demo.add-sub-account.pk') as `0x${string}` | null;
+  if (!privateKey) {
+    privateKey = generatePrivateKey();
+    localStorage.setItem('cbwsdk.demo.add-sub-account.pk', privateKey);
+  }
+  return privateKey;
+}


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
Refactors private key generation and retrieval used in example app pages into a single function

https://github.com/coinbase/coinbase-wallet-sdk/pull/1554#discussion_r2010902683


### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Tested the add account and send calls flow in the sub accounts page in playground
