### PR TITLE
Try using npm directly to publish

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -39,14 +39,13 @@ jobs:
         run: yarn workspace @coinbase/wallet-sdk build
 
       # Publish to npm
-      - name: Setup NPM authentication
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Set deployment token
+        run: npm config set '//registry.npmjs.org/:_authToken' "${{ secrets.NPM_TOKEN }}"
 
       - name: Publish to npm
-        run: yarn workspace @coinbase/wallet-sdk npm publish --tag canary
+        run: |
+          cd packages/wallet-sdk
+          npm publish --tag canary
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
  


### PR DESCRIPTION
### _Summary_

Seeing this error when trying to publish
```
➤ YN0033: No authentication configured for request
➤ YN0000: Failed with errors in 0s 275ms
```
This PR updates the publish action to use npm  directly vs proxying through yarn

### _How did you test your changes?_

n/a