### PR TITLE
Increase popup height

### DIFF
--- a/packages/wallet-sdk/src/util/web.test.ts
+++ b/packages/wallet-sdk/src/util/web.test.ts
@@ -52,7 +52,7 @@ describe('PopupManager', () => {
       1,
       url,
       expect.stringContaining('wallet_'),
-      'width=420, height=540, left=302, top=114'
+      'width=420, height=700, left=302, top=114'
     );
     expect(popup.focus).toHaveBeenCalledTimes(1);
 

--- a/packages/wallet-sdk/src/util/web.test.ts
+++ b/packages/wallet-sdk/src/util/web.test.ts
@@ -52,7 +52,7 @@ describe('PopupManager', () => {
       1,
       url,
       expect.stringContaining('wallet_'),
-      'width=420, height=700, left=302, top=114'
+      'width=420, height=700, left=302, top=34'
     );
     expect(popup.focus).toHaveBeenCalledTimes(1);
 

--- a/packages/wallet-sdk/src/util/web.ts
+++ b/packages/wallet-sdk/src/util/web.ts
@@ -5,7 +5,7 @@ import { NAME, VERSION } from '../sdk-info.js';
 import { getCrossOriginOpenerPolicy } from './checkCrossOriginOpenerPolicy.js';
 
 const POPUP_WIDTH = 420;
-const POPUP_HEIGHT = 540;
+const POPUP_HEIGHT = 700;
 
 const RETRY_BUTTON = {
   isRed: false,


### PR DESCRIPTION
### _Summary_

- Increased the popup height to 700 to match the new expected height on keys.coinbase.com

<!--
  What changed? Link to relevant issues.
-->



### _How did you test your changes?_

- Manually and unit tests

https://github.com/user-attachments/assets/0845ec16-c0c2-44df-838f-07a24c4f06d9


<!--



  Verify changes. Include relevant screenshots/videos
-->
