### PR TITLE
[BW-1655] Add support for auto spend limits via config

### DIFF
--- a/examples/testapp/src/context/ConfigContextProvider.tsx
+++ b/examples/testapp/src/context/ConfigContextProvider.tsx
@@ -10,7 +10,7 @@ import {
   useEffect,
   useMemo,
   useState,
-} from 'react';
+} from "react";
 import {
   OPTIONS_KEY,
   OptionsType,
@@ -21,8 +21,8 @@ import {
   options,
   scwUrls,
   sdkVersions,
-} from '../store/config';
-import { cleanupSDKLocalStorage } from '../utils/cleanupSDKLocalStorage';
+} from "../store/config";
+import { cleanupSDKLocalStorage } from "../utils/cleanupSDKLocalStorage";
 
 type ConfigContextProviderProps = {
   children: ReactNode;
@@ -43,7 +43,9 @@ type ConfigContextType = {
 
 const ConfigContext = createContext<ConfigContextType | null>(null);
 
-export const ConfigContextProvider = ({ children }: ConfigContextProviderProps) => {
+export const ConfigContextProvider = ({
+  children,
+}: ConfigContextProviderProps) => {
   const [version, setVersion] = useState<SDKVersionType | undefined>(undefined);
   const [option, setOption] = useState<OptionsType | undefined>(undefined);
   const [scwUrl, setScwUrl] = useState<ScwUrlType | undefined>(undefined);
@@ -53,16 +55,20 @@ export const ConfigContextProvider = ({ children }: ConfigContextProviderProps) 
       auto: false,
     },
   });
-  const [subAccountsConfig, setSubAccountsConfig] = useState<SubAccountOptions | undefined>(
-    undefined
-  );
+  const [subAccountsConfig, setSAConfig] = useState<
+    SubAccountOptions | undefined
+  >(undefined);
 
   useEffect(
     function initializeSDKVersion() {
       if (version === undefined) {
-        const savedVersion = localStorage.getItem(SELECTED_SDK_KEY) as SDKVersionType;
+        const savedVersion = localStorage.getItem(
+          SELECTED_SDK_KEY
+        ) as SDKVersionType;
         setVersion(
-          sdkVersions.includes(savedVersion) ? (savedVersion as SDKVersionType) : sdkVersions[0]
+          sdkVersions.includes(savedVersion)
+            ? (savedVersion as SDKVersionType)
+            : sdkVersions[0]
         );
       }
     },
@@ -73,7 +79,7 @@ export const ConfigContextProvider = ({ children }: ConfigContextProviderProps) 
     function initializeOption() {
       if (option === undefined) {
         const option = localStorage.getItem(OPTIONS_KEY) as OptionsType;
-        setOption(options.includes(option) ? (option as OptionsType) : 'all');
+        setOption(options.includes(option) ? (option as OptionsType) : "all");
       }
     },
     [option]
@@ -82,8 +88,14 @@ export const ConfigContextProvider = ({ children }: ConfigContextProviderProps) 
   useEffect(
     function initializeScwUrl() {
       if (scwUrl === undefined) {
-        const savedScwUrl = localStorage.getItem(SELECTED_SCW_URL_KEY) as ScwUrlType;
-        setScwUrl(scwUrls.includes(savedScwUrl) ? (savedScwUrl as ScwUrlType) : scwUrls[0]);
+        const savedScwUrl = localStorage.getItem(
+          SELECTED_SCW_URL_KEY
+        ) as ScwUrlType;
+        setScwUrl(
+          scwUrls.includes(savedScwUrl)
+            ? (savedScwUrl as ScwUrlType)
+            : scwUrls[0]
+        );
       }
     },
     [scwUrl]
@@ -106,6 +118,13 @@ export const ConfigContextProvider = ({ children }: ConfigContextProviderProps) 
     localStorage.setItem(SELECTED_SCW_URL_KEY, url);
     setScwUrl(url);
   }, []);
+
+  const setSubAccountsConfig = useCallback(
+    (subAccountsConfig: SubAccountOptions) => {
+      setSAConfig((prev) => ({ ...prev, ...subAccountsConfig }));
+    },
+    []
+  );
 
   const value = useMemo(() => {
     return {
@@ -132,13 +151,15 @@ export const ConfigContextProvider = ({ children }: ConfigContextProviderProps) 
     setSubAccountsConfig,
   ]);
 
-  return <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>;
+  return (
+    <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>
+  );
 };
 
 export function useConfig() {
   const context = useContext(ConfigContext);
   if (context === undefined) {
-    throw new Error('useConfig must be used within a ConfigContextProvider');
+    throw new Error("useConfig must be used within a ConfigContextProvider");
   }
   return context;
 }

--- a/examples/testapp/src/context/ConfigContextProvider.tsx
+++ b/examples/testapp/src/context/ConfigContextProvider.tsx
@@ -10,7 +10,7 @@ import {
   useEffect,
   useMemo,
   useState,
-} from "react";
+} from 'react';
 import {
   OPTIONS_KEY,
   OptionsType,
@@ -21,8 +21,8 @@ import {
   options,
   scwUrls,
   sdkVersions,
-} from "../store/config";
-import { cleanupSDKLocalStorage } from "../utils/cleanupSDKLocalStorage";
+} from '../store/config';
+import { cleanupSDKLocalStorage } from '../utils/cleanupSDKLocalStorage';
 
 type ConfigContextProviderProps = {
   children: ReactNode;

--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -9,6 +9,7 @@ import {
   Stack,
   VStack,
 } from '@chakra-ui/react';
+import { SpendLimitConfig } from '@coinbase/wallet-sdk/dist/core/provider/interface';
 import { useState } from 'react';
 import { baseSepolia } from 'viem/chains';
 import { useConfig } from '../../context/ConfigContextProvider';
@@ -45,7 +46,7 @@ export default function AutoSubAccount() {
         params: [
           {
             from: accounts[0],
-            to: '0x000000000000000000000000000000000000dead',
+            to: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
             value: '0x0',
             data: '0x',
           },
@@ -99,6 +100,24 @@ export default function AutoSubAccount() {
     }
   };
 
+  const handleSetDefaultSpendLimits = (value: string) => {
+    const defaultSpendLimits = {
+      [baseSepolia.id]: [
+        {
+          token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+          allowance: '0x2386F26FC10000',
+          period: 86400,
+        } as SpendLimitConfig,
+      ],
+    };
+
+    if (value === 'true') {
+      setSubAccountsConfig({ defaultSpendLimits });
+    } else {
+      setSubAccountsConfig({ defaultSpendLimits: {} });
+    }
+  };
+
   return (
     <Container mb={16}>
       <VStack w="full" spacing={4}>
@@ -107,6 +126,18 @@ export default function AutoSubAccount() {
           <RadioGroup
             value={(subAccountsConfig?.enableAutoSubAccounts || false).toString()}
             onChange={(value) => setSubAccountsConfig({ enableAutoSubAccounts: value === 'true' })}
+          >
+            <Stack direction="row">
+              <Radio value="true">Enabled</Radio>
+              <Radio value="false">Disabled</Radio>
+            </Stack>
+          </RadioGroup>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Default Spend Limit</FormLabel>
+          <RadioGroup
+            value={subAccountsConfig?.defaultSpendLimits?.[baseSepolia.id] ? 'true' : 'false'}
+            onChange={handleSetDefaultSpendLimits}
           >
             <Stack direction="row">
               <Radio value="true">Enabled</Radio>

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -56,7 +56,6 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
               signerType = await this.requestSignerSelection(args);
             }
             const signer = this.initSigner(signerType);
-
             if (signerType === 'scw' && subAccountsConfig?.enableAutoSubAccounts) {
               await signer.handshake({ method: 'handshake' });
               await signer.request(args);

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -39,6 +39,8 @@ export type SpendLimitConfig = {
   token: Address;
   allowance: Hex;
   period: number;
+  salt?: Hex;
+  extraData?: Hex;
 };
 
 export interface AppMetadata {
@@ -93,7 +95,7 @@ export type SubAccountOptions = {
    * Spend limits requested on app connect if a matching existing one does not exist.
    * Only supports native chain tokens currently.
    */
-  defaultSpendLimits?: Record<Hex, SpendLimitConfig[]>;
+  defaultSpendLimits?: Record<number, SpendLimitConfig[]>;
   /**
    * Used when users have insufficient funds, the SDK will request a new spend limit (only used when auto sub accounts is enabled)
    */

--- a/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
+++ b/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
@@ -14,9 +14,9 @@ export type EmptyFetchPermissionsRequest = Omit<FetchPermissionsRequest, 'params
  */
 export type SpendLimit = {
   /** UTC timestamp for when the permission was granted */
-  createdAt: number;
+  createdAt?: number;
   /** Hash of the permission in hex format */
-  permissionHash: string;
+  permissionHash?: string;
   /** Cryptographic signature in hex format */
   signature: string;
   /** The permission details */

--- a/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
@@ -1,5 +1,7 @@
-import { AddSubAccountAccount } from './wallet_addSubAccount.js';
 import { SerializedEthereumRpcError } from ':core/error/utils.js';
+import { SpendLimitConfig } from ':core/provider/interface.js';
+import { Hex } from 'viem';
+import { AddSubAccountAccount } from './wallet_addSubAccount.js';
 
 export type SignInWithEthereumCapabilityRequest = {
   nonce: string;
@@ -21,17 +23,17 @@ export type SignInWithEthereumCapabilityResponse = {
   signature: `0x${string}`;
 };
 
-export type SpendPermissionsCapabilityRequest = {
-  token: `0x${string}`;
-  allowance: string;
-  period: number;
-  salt?: `0x${string}`;
-  extraData?: `0x${string}`;
-};
+export type SpendLimitsCapabilityRequest = Record<number, SpendLimitConfig[]>;
 
-export type SpendPermissionsCapabilityResponse = {
+type SpendLimitResult = {
+  createdAt: number;
+  message: SpendLimitConfig;
   signature: `0x${string}`;
-};
+  permissionHash: Hex;
+  isRevoked: boolean;
+}
+
+export type SpendLimitsCapabilityResponse = Record<number, SpendLimitResult[]>;
 
 export type AddSubAccountCapabilityRequest = {
   account: AddSubAccountAccount;
@@ -53,7 +55,7 @@ export type WalletConnectRequest = {
       capabilities?: {
         addSubAccount?: AddSubAccountCapabilityRequest;
         getSubAccounts?: boolean;
-        spendPermissions?: SpendPermissionsCapabilityRequest;
+        spendLimits?: SpendLimitsCapabilityRequest;
         signInWithEthereum?: SignInWithEthereumCapabilityRequest;
       };
     },
@@ -68,7 +70,7 @@ export type WalletConnectResponse = {
     capabilities?: {
       addSubAccount?: AddSubAccountCapabilityResponse | SerializedEthereumRpcError;
       getSubAccounts?: AddSubAccountCapabilityResponse[];
-      spendPermissions?: SpendPermissionsCapabilityResponse | SerializedEthereumRpcError;
+      spendLimits?: SpendLimitsCapabilityResponse | SerializedEthereumRpcError;
       signInWithEthereum?: SignInWithEthereumCapabilityResponse | SerializedEthereumRpcError;
     };
   }[];

--- a/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
@@ -1,6 +1,6 @@
 import { SerializedEthereumRpcError } from ':core/error/utils.js';
 import { SpendLimitConfig } from ':core/provider/interface.js';
-import { Hex } from 'viem';
+import { SpendLimit } from './coinbase_fetchSpendPermissions.js';
 import { AddSubAccountAccount } from './wallet_addSubAccount.js';
 
 export type SignInWithEthereumCapabilityRequest = {
@@ -25,15 +25,7 @@ export type SignInWithEthereumCapabilityResponse = {
 
 export type SpendLimitsCapabilityRequest = Record<number, SpendLimitConfig[]>;
 
-type SpendLimitResult = {
-  createdAt: number;
-  message: SpendLimitConfig;
-  signature: `0x${string}`;
-  permissionHash: Hex;
-  isRevoked: boolean;
-}
-
-export type SpendLimitsCapabilityResponse = Record<number, SpendLimitResult[]>;
+export type SpendLimitsCapabilityResponse = SpendLimit;
 
 export type AddSubAccountCapabilityRequest = {
   account: AddSubAccountAccount;
@@ -43,6 +35,12 @@ export type AddSubAccountCapabilityResponse = {
   address?: `0x${string}`;
   factory?: `0x${string}`;
   factoryData?: `0x${string}`;
+};
+
+export type GetSpendLimitsCapabilityRequest = boolean;
+
+export type GetSpendLimitsCapabilityResponse = {
+  permissions: SpendLimit[];
 };
 
 export type WalletConnectRequest = {
@@ -56,6 +54,7 @@ export type WalletConnectRequest = {
         addSubAccount?: AddSubAccountCapabilityRequest;
         getSubAccounts?: boolean;
         spendLimits?: SpendLimitsCapabilityRequest;
+        getSpendLimits?: GetSpendLimitsCapabilityRequest;
         signInWithEthereum?: SignInWithEthereumCapabilityRequest;
       };
     },
@@ -71,6 +70,7 @@ export type WalletConnectResponse = {
       addSubAccount?: AddSubAccountCapabilityResponse | SerializedEthereumRpcError;
       getSubAccounts?: AddSubAccountCapabilityResponse[];
       spendLimits?: SpendLimitsCapabilityResponse | SerializedEthereumRpcError;
+      getSpendLimits?: GetSpendLimitsCapabilityResponse | SerializedEthereumRpcError;
       signInWithEthereum?: SignInWithEthereumCapabilityResponse | SerializedEthereumRpcError;
     };
   }[];

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
@@ -55,6 +55,8 @@ export function createCoinbaseWalletSDK(params: CreateCoinbaseWalletSDKOptions) 
   store.subAccountsConfig.set({
     toOwnerAccount: params.subAccounts?.toOwnerAccount,
     enableAutoSubAccounts: params.subAccounts?.enableAutoSubAccounts,
+    defaultSpendLimits: params.subAccounts?.defaultSpendLimits, 
+    dynamicSpendLimit: params.subAccounts?.dynamicSpendLimit,
   });
 
   // set the options in the store

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -90,7 +90,7 @@ export class SCWSigner implements Signer {
   }
 
   // TODO: Properly type the return value
-  async request(request: RequestArguments): Promise<any> {
+  async request(request: RequestArguments) {
     if (this.accounts.length === 0) {
       switch (request.method) {
         case 'eth_requestAccounts': {
@@ -99,7 +99,6 @@ export class SCWSigner implements Signer {
             // Wait for the popup to be loaded before making async calls
             await this.communicator.waitForPopupLoaded?.();
             await initSubAccountConfig();
-
             // This will populate the store with the sub account
             await this.request({
               method: 'wallet_connect',
@@ -244,7 +243,6 @@ export class SCWSigner implements Signer {
           accounts,
         });
 
-        // TODO: support multiple accounts?
         const account = response.accounts.at(0);
         const capabilities = account?.capabilities;
         if (capabilities?.addSubAccount || capabilities?.getSubAccounts) {
@@ -273,6 +271,10 @@ export class SCWSigner implements Signer {
             this.accounts = accounts_;
           }
         }
+
+        // TODO: cache spend limits response
+        // Depends on coinbase_fetchPermissions PR
+        // const spendLimits = response?.accounts?.[0].capabilities?.spendLimits;
 
         this.callback?.('accountsChanged', accounts_);
         break;

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -135,6 +135,7 @@ export async function initSubAccountConfig() {
         ],
       },
     },
+    spendLimits: config?.defaultSpendLimits ?? undefined,
   };
 
   // Store the owner account and capabilities in the non-persisted config

--- a/packages/wallet-sdk/src/store/store.ts
+++ b/packages/wallet-sdk/src/store/store.ts
@@ -201,7 +201,7 @@ export const subAccounts = {
 
 export const spendLimits = {
   get: () => sdkstore.getState().spendLimits,
-  set: (spendLimits: Record<string, SpendLimit[]>) => {
+  set: (spendLimits: Record<number, SpendLimit[]>) => {
     sdkstore.setState((state) => ({ spendLimits: { ...state.spendLimits, ...spendLimits } }));
   },
   clear: () => {

--- a/packages/wallet-sdk/src/store/store.ts
+++ b/packages/wallet-sdk/src/store/store.ts
@@ -1,4 +1,4 @@
-import { AppMetadata, Preference } from ':core/provider/interface.js';
+import { AppMetadata, Preference, SpendLimitConfig } from ':core/provider/interface.js';
 import { SpendLimit } from ':core/rpc/coinbase_fetchSpendPermissions.js';
 import { OwnerAccount } from ':core/type/index.js';
 import { Address, Hex } from 'viem';
@@ -24,12 +24,17 @@ export type SubAccount = {
   address: Address;
   factory?: Address;
   factoryData?: Hex;
+  config?: {
+    capabilities: Record<string, unknown>;
+  };
 };
 
 type SubAccountConfig = {
   toOwnerAccount?: ToOwnerAccountFn;
   capabilities?: Record<string, unknown>;
   enableAutoSubAccounts?: boolean;
+  defaultSpendLimits?: Record<number, SpendLimitConfig[]>;
+  dynamicSpendLimit?: boolean;
 };
 
 type Account = {

--- a/packages/wallet-sdk/src/store/store.ts
+++ b/packages/wallet-sdk/src/store/store.ts
@@ -24,9 +24,6 @@ export type SubAccount = {
   address: Address;
   factory?: Address;
   factoryData?: Hex;
-  config?: {
-    capabilities: Record<string, unknown>;
-  };
 };
 
 type SubAccountConfig = {


### PR DESCRIPTION
# Summary

This PR adds support for spend limits in WalletConnect requests and responses. The changes include:

- Added new types `SpendLimitsCapabilityRequest` and `SpendLimitsCapabilityResponse` to handle spend limit functionality
- Added `GetSpendLimitsCapabilityRequest` and `GetSpendLimitsCapabilityResponse` for retrieving spend limits
- Updated `WalletConnectRequest` and `WalletConnectResponse` types to include spend limit capabilities
- Added proper error handling for spend limit responses using `SerializedEthereumRpcError`

# How did you test your changes?

- Verified type definitions compile correctly with TypeScript
- Tested spend limit capability integration with existing WalletConnect flow
- Ensured error handling works as expected for spend limit responses****