### PR TITLE
[BW-1540] Add Support for Fetching Spend Limits via Provider 

### DIFF
--- a/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
+++ b/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
@@ -1,0 +1,31 @@
+import { Address } from 'viem';
+
+export type FetchPermissionsRequest = {
+  method: 'coinbase_fetchPermissions';
+  params: [{ account: Address; chainId: `0x${string}`; spender: Address }];
+};
+
+export type EmptyFetchPermissionsRequest = Omit<FetchPermissionsRequest, 'params'> & {
+  params: undefined;
+};
+
+export type SpendLimit = {
+  createdAt: number; // UTC timestamp for when the permission was granted
+  permissionHash: string; // hex
+  signature: string; // hex
+  permission: {
+    account: string; // address
+    spender: string; // address
+    token: string; // address
+    allowance: string; // base 10 numeric string
+    period: number; // unix seconds
+    start: number; // unix seconds
+    end: number; // unix seconds
+    salt: string; // base 10 numeric string
+    extraData: string; // hex
+  };
+};
+
+export type FetchPermissionsResponse = {
+  permissions: SpendLimit[];
+};

--- a/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
+++ b/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
@@ -9,20 +9,36 @@ export type EmptyFetchPermissionsRequest = Omit<FetchPermissionsRequest, 'params
   params: undefined;
 };
 
+/**
+ * Represents a spending permission with limits
+ */
 export type SpendLimit = {
-  createdAt: number; // UTC timestamp for when the permission was granted
-  permissionHash: string; // hex
-  signature: string; // hex
+  /** UTC timestamp for when the permission was granted */
+  createdAt: number;
+  /** Hash of the permission in hex format */
+  permissionHash: string;
+  /** Cryptographic signature in hex format */
+  signature: string;
+  /** The permission details */
   permission: {
-    account: string; // address
-    spender: string; // address
-    token: string; // address
-    allowance: string; // base 10 numeric string
-    period: number; // unix seconds
-    start: number; // unix seconds
-    end: number; // unix seconds
-    salt: string; // base 10 numeric string
-    extraData: string; // hex
+    /** Wallet address of the account */
+    account: string;
+    /** Address of the contract/entity allowed to spend */
+    spender: string;
+    /** Address of the token being spent */
+    token: string;
+    /** Maximum amount allowed as base 10 numeric string */
+    allowance: string;
+    /** Time period in seconds */
+    period: number;
+    /** Start time in unix seconds */
+    start: number;
+    /** Expiration time in unix seconds */
+    end: number;
+    /** Salt as base 10 numeric string */
+    salt: string;
+    /** Additional data in hex format */
+    extraData: string;
   };
 };
 

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -227,7 +227,7 @@ describe('SCWSigner', () => {
         },
         chains: [],
         keys: {},
-        spendLimits: [],
+        spendLimits: {},
         config: {
           metadata: mockMetadata,
           preference: { keysUrl: CB_KEYS_URL, options: 'all' },
@@ -502,7 +502,7 @@ describe('SCWSigner', () => {
         },
         chains: [],
         keys: {},
-        spendLimits: [],
+        spendLimits: {},
         config: {
           metadata: mockMetadata,
           preference: { keysUrl: CB_KEYS_URL, options: 'all' },
@@ -528,7 +528,9 @@ describe('SCWSigner', () => {
 
       await signer.request(mockRequest);
 
-      expect(mockSetSpendLimits).toHaveBeenCalledWith(mockSpendLimits);
+      expect(mockSetSpendLimits).toHaveBeenCalledWith({
+        '0xa': mockSpendLimits,
+      });
     });
   });
 });

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -529,7 +529,7 @@ describe('SCWSigner', () => {
       await signer.request(mockRequest);
 
       expect(mockSetSpendLimits).toHaveBeenCalledWith({
-        '0xa': mockSpendLimits,
+        '10': mockSpendLimits,
       });
     });
   });

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -190,11 +190,15 @@ export class SCWSigner implements Signer {
         return this.addSubAccount(request);
       case 'coinbase_fetchPermissions': {
         assertFetchPermissionsRequest(request);
+        const completeRequest = fillMissingParamsForFetchPermissions(request);
         const permissions = (await fetchRPCRequest(
-          fillMissingParamsForFetchPermissions(request),
+          completeRequest,
           CB_WALLET_RPC_URL
         )) as FetchPermissionsResponse;
-        store.spendLimits.set(permissions.permissions);
+        const requestedChainIdInHex = completeRequest.params?.[0].chainId;
+        store.spendLimits.set({
+          [requestedChainIdInHex]: permissions.permissions,
+        });
         return permissions;
       }
       default:

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -1,4 +1,4 @@
-import { Hex, numberToHex } from 'viem';
+import { Hex, hexToNumber, numberToHex } from 'viem';
 
 import { Communicator } from ':core/communicator/Communicator.js';
 import { CB_WALLET_RPC_URL } from ':core/constants.js';
@@ -195,9 +195,9 @@ export class SCWSigner implements Signer {
           completeRequest,
           CB_WALLET_RPC_URL
         )) as FetchPermissionsResponse;
-        const requestedChainIdInHex = completeRequest.params?.[0].chainId;
+        const requestedChainId = hexToNumber(completeRequest.params?.[0].chainId);
         store.spendLimits.set({
-          [requestedChainIdInHex]: permissions.permissions,
+          [requestedChainId]: permissions.permissions,
         });
         return permissions;
       }

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -1,7 +1,9 @@
 import { store } from ':store/store.js';
 import {
   addSenderToRequest,
+  assertFetchPermissionsRequest,
   assertParamsChainId,
+  fillMissingParamsForFetchPermissions,
   getSenderFromRequest,
   initSubAccountConfig,
   injectRequestCapabilities,
@@ -194,5 +196,70 @@ describe('initSubAccountConfig', () => {
 
     const config = store.subAccountsConfig.get();
     expect(config?.capabilities?.addSubAccount).toBeDefined();
+  });
+});
+
+describe('assertFetchPermissionsRequest', () => {
+  it('should throw if the request is not a fetch permissions request', () => {
+    expect(() => assertFetchPermissionsRequest({ method: 'eth_sendTransaction' })).toThrow();
+  });
+
+  it('should throw if the request params are the correct shape', () => {
+    expect(() =>
+      assertFetchPermissionsRequest({
+        method: 'coinbase_fetchPermissions',
+        params: [{ account: 'non-hex-string' }],
+      })
+    ).toThrow();
+  });
+
+  it('should pass if the params is omitted completely', () => {
+    expect(() =>
+      assertFetchPermissionsRequest({ method: 'coinbase_fetchPermissions' })
+    ).not.toThrow();
+  });
+
+  it('should pass if the params is correct shape', () => {
+    expect(() =>
+      assertFetchPermissionsRequest({
+        method: 'coinbase_fetchPermissions',
+        params: [{ account: '0x123', chainId: '0x123', spender: '0x123' }],
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('fillMissingParamsForFetchPermissions', () => {
+  it('should return the request if the params are present', () => {
+    const request = {
+      method: 'coinbase_fetchPermissions',
+      params: [{ account: '0x123', chainId: '0x123', spender: '0x123' }],
+    };
+    assertFetchPermissionsRequest(request);
+    expect(fillMissingParamsForFetchPermissions(request)).toEqual(request);
+  });
+
+  it('should fill in the missing params if the params are not present', () => {
+    vi.spyOn(store, 'getState').mockImplementation(() => ({
+      account: {
+        accounts: ['0x123'],
+        chain: { id: 1 },
+      },
+      subAccount: { address: '0x456' },
+      chains: [],
+      keys: {},
+      spendLimits: [],
+      config: {
+        version: '1.0.0',
+      },
+    }));
+    const request = {
+      method: 'coinbase_fetchPermissions',
+    };
+    assertFetchPermissionsRequest(request);
+    expect(fillMissingParamsForFetchPermissions(request)).toEqual({
+      method: 'coinbase_fetchPermissions',
+      params: [{ account: '0x123', chainId: '0x1', spender: '0x456' }],
+    });
   });
 });

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -248,7 +248,7 @@ describe('fillMissingParamsForFetchPermissions', () => {
       subAccount: { address: '0x456' },
       chains: [],
       keys: {},
-      spendLimits: [],
+      spendLimits: {},
       config: {
         version: '1.0.0',
       },

--- a/packages/wallet-sdk/src/store/store.ts
+++ b/packages/wallet-sdk/src/store/store.ts
@@ -95,7 +95,7 @@ const createSubAccountConfigSlice: StateCreator<StoreState, [], [], SubAccountCo
 };
 
 type SpendLimitsSlice = {
-  spendLimits: Record<string, SpendLimit[]>;
+  spendLimits: Record<number, SpendLimit[]>;
 };
 
 const createSpendLimitsSlice: StateCreator<StoreState, [], [], SpendLimitsSlice> = () => {

--- a/packages/wallet-sdk/src/store/store.ts
+++ b/packages/wallet-sdk/src/store/store.ts
@@ -95,12 +95,12 @@ const createSubAccountConfigSlice: StateCreator<StoreState, [], [], SubAccountCo
 };
 
 type SpendLimitsSlice = {
-  spendLimits: SpendLimit[];
+  spendLimits: Record<string, SpendLimit[]>;
 };
 
 const createSpendLimitsSlice: StateCreator<StoreState, [], [], SpendLimitsSlice> = () => {
   return {
-    spendLimits: [],
+    spendLimits: {},
   };
 };
 
@@ -196,12 +196,12 @@ export const subAccounts = {
 
 export const spendLimits = {
   get: () => sdkstore.getState().spendLimits,
-  set: (spendLimits: SpendLimit[]) => {
-    sdkstore.setState({ spendLimits });
+  set: (spendLimits: Record<string, SpendLimit[]>) => {
+    sdkstore.setState((state) => ({ spendLimits: { ...state.spendLimits, ...spendLimits } }));
   },
   clear: () => {
     sdkstore.setState({
-      spendLimits: [],
+      spendLimits: {},
     });
   },
 };

--- a/packages/wallet-sdk/src/store/store.ts
+++ b/packages/wallet-sdk/src/store/store.ts
@@ -1,4 +1,5 @@
 import { AppMetadata, Preference } from ':core/provider/interface.js';
+import { SpendLimit } from ':core/rpc/coinbase_fetchSpendPermissions.js';
 import { OwnerAccount } from ':core/type/index.js';
 import { Address, Hex } from 'viem';
 import { createJSONStorage, persist } from 'zustand/middleware';
@@ -93,6 +94,16 @@ const createSubAccountConfigSlice: StateCreator<StoreState, [], [], SubAccountCo
   };
 };
 
+type SpendLimitsSlice = {
+  spendLimits: SpendLimit[];
+};
+
+const createSpendLimitsSlice: StateCreator<StoreState, [], [], SpendLimitsSlice> = () => {
+  return {
+    spendLimits: [],
+  };
+};
+
 type ConfigSlice = {
   config: Config;
 };
@@ -110,7 +121,15 @@ type MergeTypes<T extends unknown[]> = T extends [infer First, ...infer Rest]
   : Record<string, unknown>;
 
 export type StoreState = MergeTypes<
-  [ChainSlice, KeysSlice, AccountSlice, SubAccountSlice, SubAccountConfigSlice, ConfigSlice]
+  [
+    ChainSlice,
+    KeysSlice,
+    AccountSlice,
+    SubAccountSlice,
+    SubAccountConfigSlice,
+    SpendLimitsSlice,
+    ConfigSlice,
+  ]
 >;
 
 export const sdkstore = createStore(
@@ -120,6 +139,7 @@ export const sdkstore = createStore(
       ...createKeysSlice(...args),
       ...createAccountSlice(...args),
       ...createSubAccountSlice(...args),
+      ...createSpendLimitsSlice(...args),
       ...createConfigSlice(...args),
       ...createSubAccountConfigSlice(...args),
     }),
@@ -134,6 +154,7 @@ export const sdkstore = createStore(
           keys: state.keys,
           account: state.account,
           subAccount: state.subAccount,
+          spendLimits: state.spendLimits,
           config: state.config,
         } as StoreState;
       },
@@ -169,6 +190,18 @@ export const subAccounts = {
   clear: () => {
     sdkstore.setState({
       subAccount: undefined,
+    });
+  },
+};
+
+export const spendLimits = {
+  get: () => sdkstore.getState().spendLimits,
+  set: (spendLimits: SpendLimit[]) => {
+    sdkstore.setState({ spendLimits });
+  },
+  clear: () => {
+    sdkstore.setState({
+      spendLimits: [],
     });
   },
 };
@@ -221,6 +254,7 @@ export const config = {
 const actions = {
   subAccounts,
   subAccountsConfig,
+  spendLimits,
   account,
   chains,
   keys,


### PR DESCRIPTION
### _Summary_

This PR adds support for app to call `coinbase_fetchPermissions` directly with provider object.

A new shortcut added: if app is connected to user's sub account and universal account, they can omit the params field completely and have it filled by provider. 



### _How did you test your changes?_

| fetch w/o params in logged in state | fetch w params | fetch w/o params in logged out state |
| ---------- | ---------- | ---------- |
| <video src='https://github.com/user-attachments/assets/5cf81da0-3120-4dbb-b931-3ef3f54f4aae' /> | <video src='https://github.com/user-attachments/assets/b9997742-05bd-491e-b9ad-21f4857404ed' /> | <video src='https://github.com/user-attachments/assets/97f0dc7a-cdaa-4c02-aba4-4c1dc867ff72' /> |




Cache in zustand

![image](https://github.com/user-attachments/assets/b297c254-15ad-4516-aa04-ed0e8ef5aa27)




