### PR TITLE
feat: cache wallet_connect response

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -232,6 +232,7 @@ describe('SCWSigner', () => {
           version: '1.0.0',
         },
         subAccountConfig: undefined,
+        walletConnectResponse: undefined,
       }));
     });
 
@@ -367,12 +368,21 @@ describe('SCWSigner', () => {
     it('should disconnect successfully', async () => {
       const mockClear = vi.spyOn(store.account, 'clear');
 
+      store.walletConnect.set({
+        accounts: [
+          {
+            address: '0x7838d2724FC686813CAf81d4429beff1110c739a',
+          },
+        ],
+      });
+
       await signer.cleanup();
 
       expect(mockClear).toHaveBeenCalled();
       expect(mockKeyManager.clear).toHaveBeenCalled();
       expect(signer['accounts']).toEqual([]);
       expect(signer['chain']).toEqual({ id: 1 });
+      expect(store.walletConnect.get()).toBeUndefined();
     });
   });
 
@@ -423,6 +433,27 @@ describe('SCWSigner', () => {
         '0x7838d2724FC686813CAf81d4429beff1110c739a',
         '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
       ]);
+
+      await signer.cleanup();
+    });
+
+    it('should return cached wallet connect response if available', async () => {
+      store.walletConnect.set({
+        accounts: [
+          {
+            address: '0x7838d2724FC686813CAf81d4429beff1110c739a',
+          },
+        ],
+      });
+
+      const mockRequest: RequestArguments = {
+        method: 'wallet_connect',
+        params: [],
+      };
+
+      const result = await signer.request(mockRequest);
+
+      expect(result).toEqual(store.walletConnect.get());
 
       await signer.cleanup();
     });

--- a/packages/wallet-sdk/src/store/store.ts
+++ b/packages/wallet-sdk/src/store/store.ts
@@ -1,4 +1,5 @@
 import { AppMetadata, Preference } from ':core/provider/interface.js';
+import { WalletConnectResponse } from ':core/rpc/wallet_connect.js';
 import { OwnerAccount } from ':core/type/index.js';
 import { Address, Hex } from 'viem';
 import { createJSONStorage, persist } from 'zustand/middleware';
@@ -105,12 +106,30 @@ const createConfigSlice: StateCreator<StoreState, [], [], ConfigSlice> = () => {
   };
 };
 
+type WalletConnectSlice = {
+  walletConnectResponse: WalletConnectResponse | undefined;
+};
+
+const createWalletConnectSlice: StateCreator<StoreState, [], [], WalletConnectSlice> = () => {
+  return {
+    walletConnectResponse: undefined,
+  };
+};
+
 type MergeTypes<T extends unknown[]> = T extends [infer First, ...infer Rest]
   ? First & (Rest extends unknown[] ? MergeTypes<Rest> : Record<string, unknown>)
   : Record<string, unknown>;
 
 export type StoreState = MergeTypes<
-  [ChainSlice, KeysSlice, AccountSlice, SubAccountSlice, SubAccountConfigSlice, ConfigSlice]
+  [
+    ChainSlice,
+    KeysSlice,
+    AccountSlice,
+    SubAccountSlice,
+    SubAccountConfigSlice,
+    ConfigSlice,
+    WalletConnectSlice,
+  ]
 >;
 
 export const sdkstore = createStore(
@@ -122,6 +141,7 @@ export const sdkstore = createStore(
       ...createSubAccountSlice(...args),
       ...createConfigSlice(...args),
       ...createSubAccountConfigSlice(...args),
+      ...createWalletConnectSlice(...args),
     }),
     {
       name: 'cbwsdk.store',
@@ -135,6 +155,7 @@ export const sdkstore = createStore(
           account: state.account,
           subAccount: state.subAccount,
           config: state.config,
+          walletConnectResponse: state.walletConnectResponse,
         } as StoreState;
       },
     }
@@ -218,6 +239,16 @@ export const config = {
   },
 };
 
+export const walletConnect = {
+  get: () => sdkstore.getState().walletConnectResponse,
+  set: (response: WalletConnectResponse | undefined) => {
+    sdkstore.setState({ walletConnectResponse: response });
+  },
+  clear: () => {
+    sdkstore.setState({ walletConnectResponse: undefined });
+  },
+};
+
 const actions = {
   subAccounts,
   subAccountsConfig,
@@ -225,6 +256,7 @@ const actions = {
   chains,
   keys,
   config,
+  walletConnect,
 };
 
 export const store = {


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

Caches the wallet_connect response to be returned on subsequent `wallet_connect` calls. This cache is cleared on disconnect.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Added unit tests and tested manually.
