### PR TITLE
feat: sub accounts data suffix support

### DIFF
--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -5,6 +5,7 @@ import {
   FormControl,
   FormLabel,
   HStack,
+  Input,
   Radio,
   RadioGroup,
   Stack,
@@ -12,7 +13,7 @@ import {
 } from '@chakra-ui/react';
 import { getCryptoKeyAccount } from '@coinbase/wallet-sdk';
 import { SpendLimitConfig } from '@coinbase/wallet-sdk/dist/core/provider/interface';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { numberToHex, parseEther } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { baseSepolia } from 'viem/chains';
@@ -27,7 +28,7 @@ export default function AutoSubAccount() {
   const [lastResult, setLastResult] = useState<string>();
   const [sendingAmounts, setSendingAmounts] = useState<Record<number, boolean>>({});
   const [signerType, setSignerType] = useState<SignerType>('cryptokey');
-  const { subAccountsConfig, setSubAccountsConfig } = useConfig();
+  const { subAccountsConfig, setSubAccountsConfig, config, setConfig } = useConfig();
   const { provider } = useEIP1193Provider();
 
   useEffect(() => {
@@ -185,6 +186,42 @@ export default function AutoSubAccount() {
     }
   };
 
+  const handleAttributionDataSuffixChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value) {
+      setConfig({
+        ...config,
+        attribution: { dataSuffix: value as `0x${string}` },
+      });
+    } else {
+      const { attribution, ...rest } = config;
+      setConfig(rest);
+    }
+  };
+
+  const handleAttributionModeChange = (value: string) => {
+    if (value === 'auto') {
+      setConfig({
+        ...config,
+        attribution: { auto: true },
+      });
+    } else if (value === 'manual') {
+      setConfig({
+        ...config,
+        attribution: { dataSuffix: '0x' as `0x${string}` },
+      });
+    } else {
+      const { attribution, ...restConfig } = config;
+      setConfig(restConfig);
+    }
+  };
+
+  const getAttributionMode = () => {
+    if (!config.attribution) return 'none';
+    if (config.attribution.auto) return 'auto';
+    return 'manual';
+  };
+
   return (
     <Container mb={16}>
       <VStack w="full" spacing={4}>
@@ -238,6 +275,26 @@ export default function AutoSubAccount() {
             </Stack>
           </RadioGroup>
         </FormControl>
+        <FormControl>
+          <FormLabel>Attribution</FormLabel>
+          <RadioGroup value={getAttributionMode()} onChange={handleAttributionModeChange}>
+            <Stack direction="row">
+              <Radio value="none">None</Radio>
+              <Radio value="auto">Auto</Radio>
+              <Radio value="manual">Manual</Radio>
+            </Stack>
+          </RadioGroup>
+        </FormControl>
+        {getAttributionMode() === 'manual' && (
+          <FormControl>
+            <FormLabel>Attribution Data Suffix (hex)</FormLabel>
+            <Input
+              placeholder="0x..."
+              value={config.attribution?.dataSuffix || ''}
+              onChange={handleAttributionDataSuffixChange}
+            />
+          </FormControl>
+        )}
         <Button w="full" onClick={handleRequestAccounts}>
           eth_requestAccounts
         </Button>

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -1,7 +1,10 @@
-import { Hex, PublicClient, WalletSendCallsParameters, hexToBigInt, numberToHex } from 'viem';
+import { PublicClient, WalletSendCallsParameters, hexToBigInt } from 'viem';
 
-import { InsufficientBalanceErrorData, standardErrors } from ':core/error/errors.js';
-import { RequestArguments } from ':core/provider/interface.js';
+import { InsufficientBalanceErrorData } from ':core/error/errors.js';
+import { Hex, keccak256, numberToHex, slice, toHex } from 'viem';
+
+import { standardErrors } from ':core/error/errors.js';
+import { Attribution, RequestArguments } from ':core/provider/interface.js';
 import {
   EmptyFetchPermissionsRequest,
   FetchPermissionsRequest,
@@ -487,4 +490,26 @@ export function isEthSendTransactionParams(params: unknown): params is [
     params[0] !== null &&
     'to' in params[0]
   );
+}
+export function compute16ByteHash(input: string): Hex {
+  return slice(keccak256(toHex(input)), 0, 16);
+}
+
+export function makeDataSuffix({
+  attribution,
+  dappOrigin,
+}: { attribution?: Attribution; dappOrigin: string }): Hex | undefined {
+  if (!attribution) {
+    return;
+  }
+
+  if ('auto' in attribution && attribution.auto && dappOrigin) {
+    return compute16ByteHash(dappOrigin);
+  }
+
+  if ('dataSuffix' in attribution) {
+    return attribution.dataSuffix;
+  }
+
+  return;
 }

--- a/packages/wallet-sdk/src/sign/scw/utils/createSubAccountSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/createSubAccountSigner.test.ts
@@ -423,6 +423,9 @@ describe('createSubAccountSigner', () => {
     (getClient as any).mockReturnValue({
       request,
       getChainId: vi.fn().mockResolvedValue(84532),
+      chain: {
+        id: 84532,
+      },
     });
 
     const signer = await createSubAccountSigner({

--- a/packages/wallet-sdk/src/sign/scw/utils/createSubAccountSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/createSubAccountSigner.ts
@@ -168,7 +168,7 @@ export async function createSubAccountSigner({
                 from: subAccount.address,
                 capabilities:
                   'capabilities' in args.params[0]
-                    ? (args.params[0].capabilities as Record<string, any>)
+                    ? (args.params[0].capabilities as Record<string, unknown>)
                     : {},
               },
             ],

--- a/packages/wallet-sdk/src/sign/scw/utils/createSubAccountSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/createSubAccountSigner.ts
@@ -34,6 +34,7 @@ export async function createSubAccountSigner({
   factory,
   factoryData,
   parentAddress,
+  attribution,
 }: {
   address: Address;
   owner: OwnerAccount;
@@ -41,6 +42,13 @@ export async function createSubAccountSigner({
   parentAddress?: Address;
   factoryData?: Hex;
   factory?: Address;
+  attribution?:
+    | {
+        suffix: Hex;
+      }
+    | {
+        appOrigin: string;
+      };
 }) {
   const code = await getCode(client, {
     address,
@@ -271,6 +279,16 @@ export async function createSubAccountSigner({
 
           if (!get(args.params[0], 'calls')) {
             throw standardErrors.rpc.invalidParams('calls are required');
+          }
+
+          const prepareCallsParams = args.params[0] as PrepareCallsSchema['Parameters'][0];
+
+          if (
+            attribution &&
+            prepareCallsParams.capabilities &&
+            !('attribution' in prepareCallsParams.capabilities)
+          ) {
+            prepareCallsParams.capabilities.attribution = attribution;
           }
 
           const prepareCallsResponse = await client.request<PrepareCallsSchema>({


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

- Adds data suffix support via `wallet_prepareCalls` to createSubAccountSigner

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
- Manual testing
- Unit tests
