### PR TITLE
fix typo in getSubAccounts

### DIFF
--- a/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
@@ -18,7 +18,7 @@ const walletConnectShortcuts: ShortcutType[] = [
     data: {
       version: '1',
       capabilities: {
-        getAppAccounts: {
+        getSubAccounts: {
           chainId: 84532,
         },
       },

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.test.ts
@@ -167,7 +167,7 @@ describe('createCoinbaseWalletSDK', () => {
           {
             version: 1,
             capabilities: {
-              getAppAccounts: true,
+              getSubAccounts: true,
             },
           },
         ],

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
@@ -111,7 +111,7 @@ export function createCoinbaseWalletSDK(params: CreateCoinbaseWalletSDKOptions) 
             {
               version: 1,
               capabilities: {
-                getAppAccounts: true,
+                getSubAccounts: true,
               },
             },
           ],


### PR DESCRIPTION
### _Summary_

Fixes a typo in the SDK helper utility method for fetching sub accounts.

### _How did you test your changes?_

Manually