### PR TITLE
fix: update message in dynamic spend limits insufficient balance toast

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -397,7 +397,7 @@ export async function presentSubAccountFundingDialog() {
     (resolve) => {
       snackbar.presentItem({
         autoExpand: true,
-        message: 'Insufficient spend permission. Choose how to proceed:',
+        message: 'Insufficient spend limit. Choose how to proceed:',
         menuItems: [
           {
             isRed: false,


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

Updates the message in the insufficient balance toast for dynamic spend limits to refer to spend limits instead of spend pemissions.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
