### PR TITLE
chore: update sub accounts rpcs to match updated spec

### DIFF
--- a/examples/testapp/src/components/Layout.tsx
+++ b/examples/testapp/src/components/Layout.tsx
@@ -28,7 +28,7 @@ type LayoutProps = {
 
 export const WIDTH_2XL = '1536px';
 
-const PAGES = ['/', '/add-sub-account', '/import-sub-account'];
+const PAGES = ['/', '/add-sub-account', '/import-sub-account', '/auto-sub-account'];
 
 export function Layout({ children }: LayoutProps) {
   const { option, setPreference, version, setSDKVersion, scwUrl, setScwUrlAndSave } = useConfig();

--- a/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
+++ b/examples/testapp/src/components/RpcMethods/shortcut/connectionMethodShortcuts.ts
@@ -13,17 +13,6 @@ const walletConnectShortcuts: ShortcutType[] = [
       },
     },
   },
-  {
-    key: 'Get App Accounts',
-    data: {
-      version: '1',
-      capabilities: {
-        getSubAccounts: {
-          chainId: 84532,
-        },
-      },
-    },
-  },
 ];
 
 export const connectionMethodShortcutsMap = {

--- a/examples/testapp/src/context/ConfigContextProvider.tsx
+++ b/examples/testapp/src/context/ConfigContextProvider.tsx
@@ -43,9 +43,7 @@ type ConfigContextType = {
 
 const ConfigContext = createContext<ConfigContextType | null>(null);
 
-export const ConfigContextProvider = ({
-  children,
-}: ConfigContextProviderProps) => {
+export const ConfigContextProvider = ({ children }: ConfigContextProviderProps) => {
   const [version, setVersion] = useState<SDKVersionType | undefined>(undefined);
   const [option, setOption] = useState<OptionsType | undefined>(undefined);
   const [scwUrl, setScwUrl] = useState<ScwUrlType | undefined>(undefined);
@@ -55,20 +53,14 @@ export const ConfigContextProvider = ({
       auto: false,
     },
   });
-  const [subAccountsConfig, setSAConfig] = useState<
-    SubAccountOptions | undefined
-  >(undefined);
+  const [subAccountsConfig, setSAConfig] = useState<SubAccountOptions | undefined>(undefined);
 
   useEffect(
     function initializeSDKVersion() {
       if (version === undefined) {
-        const savedVersion = localStorage.getItem(
-          SELECTED_SDK_KEY
-        ) as SDKVersionType;
+        const savedVersion = localStorage.getItem(SELECTED_SDK_KEY) as SDKVersionType;
         setVersion(
-          sdkVersions.includes(savedVersion)
-            ? (savedVersion as SDKVersionType)
-            : sdkVersions[0]
+          sdkVersions.includes(savedVersion) ? (savedVersion as SDKVersionType) : sdkVersions[0]
         );
       }
     },
@@ -79,7 +71,7 @@ export const ConfigContextProvider = ({
     function initializeOption() {
       if (option === undefined) {
         const option = localStorage.getItem(OPTIONS_KEY) as OptionsType;
-        setOption(options.includes(option) ? (option as OptionsType) : "all");
+        setOption(options.includes(option) ? (option as OptionsType) : 'all');
       }
     },
     [option]
@@ -88,14 +80,8 @@ export const ConfigContextProvider = ({
   useEffect(
     function initializeScwUrl() {
       if (scwUrl === undefined) {
-        const savedScwUrl = localStorage.getItem(
-          SELECTED_SCW_URL_KEY
-        ) as ScwUrlType;
-        setScwUrl(
-          scwUrls.includes(savedScwUrl)
-            ? (savedScwUrl as ScwUrlType)
-            : scwUrls[0]
-        );
+        const savedScwUrl = localStorage.getItem(SELECTED_SCW_URL_KEY) as ScwUrlType;
+        setScwUrl(scwUrls.includes(savedScwUrl) ? (savedScwUrl as ScwUrlType) : scwUrls[0]);
       }
     },
     [scwUrl]
@@ -120,8 +106,8 @@ export const ConfigContextProvider = ({
   }, []);
 
   const setSubAccountsConfig = useCallback(
-    (subAccountsConfig: SubAccountOptions) => {
-      setSAConfig((prev) => ({ ...prev, ...subAccountsConfig }));
+    (...args: Parameters<Dispatch<SetStateAction<SubAccountOptions>>>) => {
+      setSAConfig(...args);
     },
     []
   );
@@ -151,15 +137,13 @@ export const ConfigContextProvider = ({
     setSubAccountsConfig,
   ]);
 
-  return (
-    <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>
-  );
+  return <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>;
 };
 
 export function useConfig() {
   const context = useContext(ConfigContext);
   if (context === undefined) {
-    throw new Error("useConfig must be used within a ConfigContextProvider");
+    throw new Error('useConfig must be used within a ConfigContextProvider');
   }
   return context;
 }

--- a/examples/testapp/src/pages/add-sub-account/components/AddSubAccount.tsx
+++ b/examples/testapp/src/pages/add-sub-account/components/AddSubAccount.tsx
@@ -41,13 +41,13 @@ export function AddSubAccount({ sdk, onAddSubAccount, signerFn }: AddSubAccountP
                 ? [
                     {
                       type: 'webauthn-p256',
-                      key: account.publicKey,
+                      publicKey: account.publicKey,
                     },
                   ]
                 : [
                     {
                       type: 'address',
-                      key: account.address,
+                      publicKey: account.address,
                     },
                   ],
           },

--- a/examples/testapp/src/pages/add-sub-account/components/GrantSpendPermission.tsx
+++ b/examples/testapp/src/pages/add-sub-account/components/GrantSpendPermission.tsx
@@ -93,20 +93,7 @@ export function GrantSpendPermission({
 
       const data = {
         chainId: baseSepolia.id,
-        account: accounts[0],
-        spender: subAccountAddress,
-        token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-        allowance: '0x2386F26FC10000',
-        period: 86400,
-        start: 1724264802,
-        end: 17242884802,
-        salt: '0x1',
-        extraData: '0x',
-      };
-
-      const spendPermission = makeSpendPermissionTypedData({
-        chainId: baseSepolia.id,
-        account: accounts[0] as Address,
+        account: accounts[1] as Address,
         spender: subAccountAddress as Address,
         token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
         allowance: '0x2386F26FC10000',
@@ -115,7 +102,9 @@ export function GrantSpendPermission({
         end: 17242884802,
         salt: '0x1',
         extraData: '0x',
-      });
+      } as const;
+
+      const spendPermission = makeSpendPermissionTypedData(data);
 
       const response = await provider?.request({
         method: 'eth_signTypedData_v4',

--- a/examples/testapp/src/pages/add-sub-account/components/GrantSpendPermission.tsx
+++ b/examples/testapp/src/pages/add-sub-account/components/GrantSpendPermission.tsx
@@ -86,9 +86,7 @@ export function GrantSpendPermission({
         params: [
           {
             version: '1',
-            capabilities: {
-              getSubAccounts: true,
-            },
+            capabilities: {},
           },
         ],
       })) as string[];

--- a/examples/testapp/src/pages/add-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/add-sub-account/index.page.tsx
@@ -7,10 +7,12 @@ import {
   Stack,
   VStack,
 } from '@chakra-ui/react';
-import { createCoinbaseWalletSDK, getCryptoKeyAccount } from '@coinbase/wallet-sdk';
+import { getCryptoKeyAccount } from '@coinbase/wallet-sdk';
 import { useEffect, useState } from 'react';
 import { privateKeyToAccount } from 'viem/accounts';
 
+import { useConfig } from '../../context/ConfigContextProvider';
+import { useEIP1193Provider } from '../../context/EIP1193ProviderContextProvider';
 import { unsafe_generateOrLoadPrivateKey } from '../../utils/unsafe_generateOrLoadPrivateKey';
 import { AddOwner } from './components/AddOwner';
 import { AddSubAccount } from './components/AddSubAccount';
@@ -24,7 +26,8 @@ import { SpendPermissions } from './components/SpendPermissions';
 type SignerType = 'cryptokey' | 'secp256k1';
 
 export default function SubAccounts() {
-  const [sdk, setSDK] = useState<ReturnType<typeof createCoinbaseWalletSDK>>();
+  const { sdk } = useEIP1193Provider();
+  const { setSubAccountsConfig } = useConfig();
   const [subAccountAddress, setSubAccountAddress] = useState<string>();
   const [signerType, setSignerType] = useState<SignerType>('cryptokey');
   const [getSubAccountSigner, setGetSubAccountSigner] = useState<typeof getCryptoKeyAccount>(
@@ -56,27 +59,8 @@ export default function SubAccounts() {
           };
 
     setGetSubAccountSigner(() => getSigner);
-  }, [signerType]);
-
-  useEffect(() => {
-    const sdk = createCoinbaseWalletSDK({
-      appName: 'CryptoPlayground',
-      preference: {
-        keysUrl: 'https://keys-dev.coinbase.com/connect',
-        options: 'smartWalletOnly',
-      },
-      subAccounts: {
-        toOwnerAccount: getSubAccountSigner,
-      },
-    });
-
-    setSDK(sdk);
-    const provider = sdk.getProvider();
-
-    provider.on('accountsChanged', (accounts) => {
-      console.info('accountsChanged', accounts);
-    });
-  }, [getSubAccountSigner]);
+    setSubAccountsConfig({ toOwnerAccount: getSigner });
+  }, [signerType, setSubAccountsConfig]);
 
   return (
     <Container mb={16}>

--- a/packages/wallet-sdk/src/core/rpc/wallet_addSubAccount.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_addSubAccount.ts
@@ -4,7 +4,7 @@ type AccountCreate = {
   type: 'create';
   keys: {
     type: 'address' | 'p256' | 'webcrypto-p256' | 'webauthn-p256';
-    key: `0x${string}`;
+    publicKey: `0x${string}`;
   }[];
 };
 

--- a/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
@@ -52,9 +52,7 @@ export type WalletConnectRequest = {
       // Optional capabilities to request (e.g. Sign In With Ethereum).
       capabilities?: {
         addSubAccount?: AddSubAccountCapabilityRequest;
-        getSubAccounts?: boolean;
         spendLimits?: SpendLimitsCapabilityRequest;
-        getSpendLimits?: GetSpendLimitsCapabilityRequest;
         signInWithEthereum?: SignInWithEthereumCapabilityRequest;
       };
     },
@@ -67,10 +65,8 @@ export type WalletConnectResponse = {
     address: `0x${string}`;
     // Capabilities granted that is associated with this account.
     capabilities?: {
-      addSubAccount?: AddSubAccountCapabilityResponse | SerializedEthereumRpcError;
-      getSubAccounts?: AddSubAccountCapabilityResponse[];
-      spendLimits?: SpendLimitsCapabilityResponse | SerializedEthereumRpcError;
-      getSpendLimits?: GetSpendLimitsCapabilityResponse | SerializedEthereumRpcError;
+      subAccounts?: AddSubAccountCapabilityResponse[] | SerializedEthereumRpcError;
+      spendLimits?: GetSpendLimitsCapabilityResponse | SerializedEthereumRpcError;
       signInWithEthereum?: SignInWithEthereumCapabilityResponse | SerializedEthereumRpcError;
     };
   }[];

--- a/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
@@ -25,8 +25,6 @@ export type SignInWithEthereumCapabilityResponse = {
 
 export type SpendLimitsCapabilityRequest = Record<number, SpendLimitConfig[]>;
 
-export type SpendLimitsCapabilityResponse = SpendLimit;
-
 export type AddSubAccountCapabilityRequest = {
   account: AddSubAccountAccount;
 };
@@ -37,9 +35,7 @@ export type AddSubAccountCapabilityResponse = {
   factoryData?: `0x${string}`;
 };
 
-export type GetSpendLimitsCapabilityRequest = boolean;
-
-export type GetSpendLimitsCapabilityResponse = {
+export type SpendLimitsCapabilityResponse = {
   permissions: SpendLimit[];
 };
 
@@ -66,7 +62,7 @@ export type WalletConnectResponse = {
     // Capabilities granted that is associated with this account.
     capabilities?: {
       subAccounts?: AddSubAccountCapabilityResponse[] | SerializedEthereumRpcError;
-      spendLimits?: GetSpendLimitsCapabilityResponse | SerializedEthereumRpcError;
+      spendLimits?: SpendLimitsCapabilityResponse | SerializedEthereumRpcError;
       signInWithEthereum?: SignInWithEthereumCapabilityResponse | SerializedEthereumRpcError;
     };
   }[];

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.test.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.test.ts
@@ -86,7 +86,7 @@ describe('createCoinbaseWalletSDK', () => {
           type: 'create',
           keys: [
             {
-              key: '0x123',
+              publicKey: '0x123',
               type: 'p256',
             },
           ],
@@ -112,7 +112,7 @@ describe('createCoinbaseWalletSDK', () => {
         type: 'create',
         keys: [
           {
-            key: '0x123',
+            publicKey: '0x123',
             type: 'p256',
           },
         ],
@@ -126,7 +126,7 @@ describe('createCoinbaseWalletSDK', () => {
               type: 'create',
               keys: [
                 {
-                  key: '0x123',
+                  publicKey: '0x123',
                   type: 'p256',
                 },
               ],
@@ -161,17 +161,12 @@ describe('createCoinbaseWalletSDK', () => {
       vi.spyOn(sdk, 'getProvider').mockImplementation(() => ({ request: mockRequest }) as any);
 
       await sdk.subAccount.get();
-      expect(mockRequest).toHaveBeenCalledWith({
-        method: 'wallet_connect',
-        params: [
-          {
-            version: 1,
-            capabilities: {
-              getSubAccounts: true,
-            },
-          },
-        ],
-      });
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'wallet_connect',
+        })
+      );
     });
   });
 

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
@@ -99,8 +99,9 @@ export function createCoinbaseWalletSDK(params: CreateCoinbaseWalletSDKOptions) 
           ],
         })) as SubAccount;
       },
-      async get(): Promise<SubAccount> {
+      async get(): Promise<SubAccount | null> {
         const subAccount = store.subAccounts.get();
+
         if (subAccount?.address) {
           return subAccount;
         }
@@ -110,13 +111,17 @@ export function createCoinbaseWalletSDK(params: CreateCoinbaseWalletSDKOptions) 
           params: [
             {
               version: 1,
-              capabilities: {
-                getSubAccounts: true,
-              },
+              capabilities: {},
             },
           ],
         })) as WalletConnectResponse;
-        return response.accounts[0].capabilities?.getSubAccounts?.[0] as SubAccount;
+
+        const subAccounts = response.accounts[0].capabilities?.subAccounts;
+        if (!Array.isArray(subAccounts)) {
+          return null;
+        }
+
+        return subAccounts[0] as SubAccount;
       },
       async addOwner({ address, publicKey, chainId }: SubAccountAddOwnerParams): Promise<string> {
         const subAccount = store.subAccounts.get();

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -162,7 +162,7 @@ describe('SCWSigner', () => {
       ]);
       expect(mockSetAccount).toHaveBeenNthCalledWith(1, {
         chain: {
-          id: 1,  
+          id: 1,
           rpcUrl: 'https://eth-rpc.example.com/1',
         },
       });
@@ -450,11 +450,13 @@ describe('SCWSigner', () => {
               {
                 address: globalAccountAddress,
                 capabilities: {
-                  addSubAccount: {
-                    address: subAccountAddress,
-                    factory: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
-                    factoryData: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
-                  },
+                  subAccounts: [
+                    {
+                      address: subAccountAddress,
+                      factory: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
+                      factoryData: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
+                    },
+                  ],
                 },
               },
             ],
@@ -529,7 +531,7 @@ describe('SCWSigner', () => {
               type: 'create',
               keys: [
                 {
-                  key: '0x123',
+                  publicKey: '0x123',
                   type: 'p256',
                 },
               ],
@@ -577,11 +579,13 @@ describe('SCWSigner', () => {
               {
                 address: globalAccountAddress,
                 capabilities: {
-                  addSubAccount: {
-                    address: subAccountAddress,
-                    factory: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
-                    factoryData: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
-                  },
+                  subAccounts: [
+                    {
+                      address: subAccountAddress,
+                      factory: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
+                      factoryData: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
+                    },
+                  ],
                 },
               },
             ],
@@ -617,7 +621,10 @@ describe('SCWSigner', () => {
       await signer.handshake({ method: 'handshake' });
       expect(signer['accounts']).toEqual([]);
 
-      signer['accounts'] = ['0x7838d2724FC686813CAf81d4429beff1110c739a', '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54'];
+      signer['accounts'] = [
+        '0x7838d2724FC686813CAf81d4429beff1110c739a',
+        '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
+      ];
 
       const mockRequest: RequestArguments = {
         method: 'wallet_sendCalls',
@@ -638,11 +645,13 @@ describe('SCWSigner', () => {
               {
                 address: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
                 capabilities: {
-                  addSubAccount: {
-                    address: '0x7838d2724FC686813CAf81d4429beff1110c739a',
-                    factory: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
-                    factoryData: '0x',
-                  },
+                  subAccounts: [
+                    {
+                      address: '0x7838d2724FC686813CAf81d4429beff1110c739a',
+                      factory: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
+                      factoryData: '0x',
+                    },
+                  ],
                 },
               },
             ],

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -425,23 +425,25 @@ describe('SCWSigner', () => {
   });
 
   describe('wallet_connect', () => {
-    it('should update internal state for successful wallet_connect', async () => {
+    beforeEach(async () => {
       await signer.cleanup();
-
-      const mockRequest: RequestArguments = {
-        method: 'wallet_connect',
-        params: [],
-      };
-
       (decryptContent as Mock).mockResolvedValueOnce({
         result: {
           value: null,
         },
       });
-      const mockSetAccount = vi.spyOn(store.account, 'set');
-
       await signer.handshake({ method: 'handshake' });
+    });
+
+    it('should handle wallet_connect with no capabilities', async () => {
       expect(signer['accounts']).toEqual([]);
+      const mockRequest: RequestArguments = {
+        method: 'wallet_connect',
+        params: [],
+      };
+
+      const mockSetAccount = vi.spyOn(store.account, 'set');
+      const mockSetSubAccounts = vi.spyOn(store.subAccounts, 'set');
 
       (decryptContent as Mock).mockResolvedValueOnce({
         result: {
@@ -453,8 +455,8 @@ describe('SCWSigner', () => {
                   subAccounts: [
                     {
                       address: subAccountAddress,
-                      factory: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
-                      factoryData: '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
+                      factory: globalAccountAddress,
+                      factoryData: '0x',
                     },
                   ],
                 },
@@ -466,15 +468,211 @@ describe('SCWSigner', () => {
 
       await signer.request(mockRequest);
 
+      // Should only persist global account to accounts store
       expect(mockSetAccount).toHaveBeenCalledWith({
-        accounts: ['0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54'],
+        accounts: [globalAccountAddress],
       });
-      expect(mockCallback).toHaveBeenCalledWith('accountsChanged', [
-        '0x7838d2724FC686813CAf81d4429beff1110c739a',
-        '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54',
-      ]);
 
-      await signer.cleanup();
+      // Should persist sub account to subAccounts store
+      expect(mockSetSubAccounts).toHaveBeenCalledWith({
+        address: subAccountAddress,
+        factory: globalAccountAddress,
+        factoryData: '0x',
+      });
+
+      // eth_accounts should return only global account
+      const accounts = await signer.request({ method: 'eth_accounts' });
+      expect(accounts).toEqual([globalAccountAddress]);
+    });
+
+    it('should handle wallet_connect with addSubAccount capability', async () => {
+      expect(signer['accounts']).toEqual([]);
+      const mockRequest: RequestArguments = {
+        method: 'wallet_connect',
+        params: [
+          {
+            capabilities: {
+              addSubAccount: {
+                account: {
+                  type: 'create',
+                  keys: [{ type: 'p256', publicKey: '0x123' }],
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      const mockSetAccount = vi.spyOn(store.account, 'set');
+      const mockSetSubAccounts = vi.spyOn(store.subAccounts, 'set');
+
+      (decryptContent as Mock).mockResolvedValueOnce({
+        result: {
+          value: {
+            accounts: [
+              {
+                address: globalAccountAddress,
+                capabilities: {
+                  subAccounts: [
+                    {
+                      address: subAccountAddress,
+                      factory: globalAccountAddress,
+                      factoryData: '0x',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      await signer.request(mockRequest);
+
+      // Should persist global account to accounts store
+      expect(mockSetAccount).toHaveBeenCalledWith({
+        accounts: [globalAccountAddress],
+      });
+
+      // Should persist sub account to subAccounts store
+      expect(mockSetSubAccounts).toHaveBeenCalledWith({
+        address: subAccountAddress,
+        factory: globalAccountAddress,
+        factoryData: '0x',
+      });
+
+      // eth_accounts should return [subAccount, globalAccount]
+      const accounts = await signer.request({ method: 'eth_accounts' });
+
+      expect(accounts).toEqual([subAccountAddress, globalAccountAddress]);
+    });
+
+    it('should handle wallet_addSubAccount creating new sub account', async () => {
+      expect(signer['accounts']).toEqual([]);
+
+      (decryptContent as Mock).mockResolvedValueOnce({
+        result: {
+          value: {
+            accounts: [
+              {
+                address: globalAccountAddress,
+                capabilities: {},
+              },
+            ],
+          },
+        },
+      });
+
+      // First connect without sub account
+      await signer.request({
+        method: 'wallet_connect',
+        params: [],
+      });
+
+      const mockSetSubAccounts = vi.spyOn(store.subAccounts, 'set');
+
+      // Then add sub account
+      (decryptContent as Mock).mockResolvedValueOnce({
+        result: {
+          value: {
+            address: subAccountAddress,
+            factory: globalAccountAddress,
+            factoryData: '0x',
+          },
+        },
+      });
+
+      await signer.request({
+        method: 'wallet_addSubAccount',
+        params: [
+          {
+            version: '1',
+            account: {
+              type: 'create',
+              keys: [
+                {
+                  publicKey: '0x123',
+                  type: 'p256',
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      // Should persist sub account to subAccounts store
+      expect(mockSetSubAccounts).toHaveBeenCalledWith({
+        address: subAccountAddress,
+        factory: globalAccountAddress,
+        factoryData: '0x',
+      });
+
+      // eth_accounts should return [subAccount, globalAccount]
+      const accounts = await signer.request({ method: 'eth_accounts' });
+      expect(accounts).toEqual([subAccountAddress, globalAccountAddress]);
+    });
+
+    it('should handle eth_requestAccounts with auto sub accounts enabled', async () => {
+      expect(signer['accounts']).toEqual([]);
+      vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
+        enableAutoSubAccounts: true,
+        capabilities: {
+          addSubAccount: {
+            account: {
+              type: 'create',
+              keys: [{ type: 'p256', publicKey: '0x123' }],
+            },
+          },
+        },
+      });
+
+      const mockSetAccount = vi.spyOn(store.account, 'set');
+      const mockSetSubAccounts = vi.spyOn(store.subAccounts, 'set');
+
+      (decryptContent as Mock).mockResolvedValueOnce({
+        result: {
+          value: {
+            accounts: [
+              {
+                address: globalAccountAddress,
+                capabilities: {
+                  subAccounts: [
+                    {
+                      address: subAccountAddress,
+                      factory: globalAccountAddress,
+                      factoryData: '0x',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const accounts = await signer.request({
+        method: 'eth_requestAccounts',
+        params: [],
+      });
+
+      // Should persist global account to accounts store
+      expect(mockSetAccount).toHaveBeenCalledWith({
+        accounts: [globalAccountAddress],
+      });
+
+      // Should persist sub account to subAccounts store
+      expect(mockSetSubAccounts).toHaveBeenCalledWith({
+        address: subAccountAddress,
+        factory: globalAccountAddress,
+        factoryData: '0x',
+      });
+
+      // Should return [subAccount, globalAccount]
+      expect(accounts).toEqual([subAccountAddress, globalAccountAddress]);
+
+      // eth_accounts should also return [subAccount, globalAccount]
+      const ethAccounts = await signer.request({ method: 'eth_accounts' });
+      expect(ethAccounts).toEqual([subAccountAddress, globalAccountAddress]);
     });
   });
 
@@ -544,7 +742,7 @@ describe('SCWSigner', () => {
       expect(accounts).toEqual([subAccountAddress, globalAccountAddress]);
 
       expect(mockSetAccount).toHaveBeenCalledWith({
-        accounts: [subAccountAddress, globalAccountAddress],
+        accounts: [globalAccountAddress],
       });
     });
   });

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -444,7 +444,12 @@ export class SCWSigner implements Signer {
     // Wait for the popup to be loaded before sending the request
     await this.communicator.waitForPopupLoaded?.();
 
-    if (Array.isArray(request.params) && request.params.length > 0 && request.params[0].account) {
+    if (
+      Array.isArray(request.params) &&
+      request.params.length > 0 &&
+      request.params[0].account &&
+      request.params[0].type === 'create'
+    ) {
       let keys: { type: string; publicKey: string }[];
       if (request.params[0].account.keys && request.params[0].account.keys.length > 0) {
         keys = request.params[0].account.keys;
@@ -457,7 +462,7 @@ export class SCWSigner implements Signer {
 
         keys = [
           {
-            type: 'webauthn-p256',
+            type: 'webcrypto-p256',
             publicKey: ownerAccount.publicKey,
           },
         ];

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -11,7 +11,7 @@ import { WalletConnectRequest, WalletConnectResponse } from ':core/rpc/wallet_co
 import { Address } from ':core/type/index.js';
 import { ensureIntNumber, hexStringFromNumber } from ':core/type/util.js';
 import { SDKChain, createClients, getClient } from ':store/chain-clients/utils.js';
-import { store, subAccountsConfig } from ':store/store.js';
+import { store } from ':store/store.js';
 import { assertArrayPresence, assertPresence } from ':util/assertPresence.js';
 import { assertSubAccount } from ':util/assertSubAccount.js';
 import {
@@ -133,7 +133,7 @@ export class SCWSigner implements Signer {
           // Check if addSubAccount capability is present and if so, inject the the sub account capabilities
           let capabilitiesToInject: Record<string, unknown> = {};
           if (requestHasCapability(request, 'addSubAccount')) {
-            capabilitiesToInject = subAccountsConfig.get()?.capabilities ?? {};
+            capabilitiesToInject = store.subAccountsConfig.get()?.capabilities ?? {};
           }
           const modifiedRequest = injectRequestCapabilities(request, capabilitiesToInject);
           return this.sendRequestToPopup(modifiedRequest);

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -450,7 +450,10 @@ export class SCWSigner implements Signer {
       if (request.params[0].account.keys && request.params[0].account.keys.length > 0) {
         keys = request.params[0].account.keys;
       } else {
-        const { account: ownerAccount } = await getCryptoKeyAccount();
+        const config = store.subAccountsConfig.get() ?? {};
+        const { account: ownerAccount } = config.toOwnerAccount
+          ? await config.toOwnerAccount()
+          : await getCryptoKeyAccount();
 
         if (!ownerAccount) {
           throw standardErrors.provider.unauthorized('could not get subaccount owner account');
@@ -458,8 +461,8 @@ export class SCWSigner implements Signer {
 
         keys = [
           {
-            type: 'webcrypto-p256',
-            publicKey: ownerAccount.publicKey,
+            type: ownerAccount.address ? 'address' : 'webauthn-p256',
+            publicKey: ownerAccount.address || ownerAccount.publicKey,
           },
         ];
       }

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -11,6 +11,7 @@ import {
   getSenderFromRequest,
   initSubAccountConfig,
   injectRequestCapabilities,
+  requestHasCapability,
 } from './utils.js';
 
 describe('utils', () => {
@@ -350,6 +351,44 @@ describe('createWalletSendCallsRequest', () => {
           },
         }),
       ],
+    });
+  });
+});
+
+describe('requestCapabilities', () => {
+  describe('requestHasCapability', () => {
+    it('returns false for requests without params', () => {
+      expect(requestHasCapability({} as any, 'test')).toBe(false);
+      expect(requestHasCapability({ params: null } as any, 'test')).toBe(false);
+    });
+
+    it('returns false for requests without capabilities', () => {
+      expect(requestHasCapability({ params: [] } as any, 'test')).toBe(false);
+      expect(requestHasCapability({ params: [{}] } as any, 'test')).toBe(false);
+    });
+
+    it('returns false when capabilities is not an object', () => {
+      expect(
+        requestHasCapability({ params: [{ capabilities: 'not-an-object' }] } as any, 'test')
+      ).toBe(false);
+    });
+
+    it('returns true when capability exists', () => {
+      expect(
+        requestHasCapability(
+          { params: [{ capabilities: { testCapability: true } }] } as any,
+          'testCapability'
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when capability does not exist', () => {
+      expect(
+        requestHasCapability(
+          { params: [{ capabilities: { otherCapability: true } }] } as any,
+          'testCapability'
+        )
+      ).toBe(false);
     });
   });
 });

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -11,6 +11,7 @@ import {
   getSenderFromRequest,
   initSubAccountConfig,
   injectRequestCapabilities,
+  prependWithoutDuplicates,
   requestHasCapability,
 } from './utils.js';
 
@@ -390,5 +391,15 @@ describe('requestCapabilities', () => {
         )
       ).toBe(false);
     });
+  });
+});
+
+describe('prependWithoutDuplicates', () => {
+  it('should prepend an item to an array without duplicates', () => {
+    expect(prependWithoutDuplicates(['1', '2', '3'], '4')).toEqual(['4', '1', '2', '3']);
+  });
+
+  it('should not prepend an item to an array if it is already present', () => {
+    expect(prependWithoutDuplicates(['1', '2', '3'], '2')).toEqual(['2', '1', '3']);
   });
 });

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -88,7 +88,7 @@ describe('injectRequestCapabilities', () => {
         keys: [
           {
             type: 'address',
-            key: '0x123',
+            publicKey: '0x123',
           },
         ],
       },

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -9,7 +9,7 @@ import {
   EmptyFetchPermissionsRequest,
   FetchPermissionsRequest,
 } from ':core/rpc/coinbase_fetchSpendPermissions.js';
-import { AddSubAccountCapabilityRequest } from ':core/rpc/wallet_connect.js';
+import { WalletConnectRequest } from ':core/rpc/wallet_connect.js';
 import { Address } from ':core/type/index.js';
 import { config, store } from ':store/store.js';
 import { get } from ':util/get.js';
@@ -117,22 +117,19 @@ export function injectRequestCapabilities<T extends RequestArguments>(
 export async function initSubAccountConfig() {
   const config = store.subAccountsConfig.get() ?? {};
 
-  if (!config?.enableAutoSubAccounts) {
-    return;
-  }
+  const capabilities: WalletConnectRequest['params'][0]['capabilities'] = {};
 
-  // Get the owner account
-  const { account: owner } = config.toOwnerAccount
-    ? await config.toOwnerAccount()
-    : await getCryptoKeyAccount();
+  if (config.enableAutoSubAccounts) {
+    // Get the owner account
+    const { account: owner } = config.toOwnerAccount
+      ? await config.toOwnerAccount()
+      : await getCryptoKeyAccount();
 
-  if (!owner) {
-    throw standardErrors.provider.unauthorized('No owner account found');
-  }
+    if (!owner) {
+      throw standardErrors.provider.unauthorized('No owner account found');
+    }
 
-  // Set the capabilities for the sub account
-  const capabilities = {
-    addSubAccount: {
+    capabilities.addSubAccount = {
       account: {
         type: 'create',
         keys: [
@@ -142,9 +139,12 @@ export async function initSubAccountConfig() {
           },
         ],
       },
-    } satisfies AddSubAccountCapabilityRequest,
-    spendLimits: config?.defaultSpendLimits ?? undefined,
-  };
+    };
+  }
+
+  if (config.defaultSpendLimits) {
+    capabilities.spendLimits = config.defaultSpendLimits;
+  }
 
   // Store the owner account and capabilities in the non-persisted config
   store.subAccountsConfig.set({
@@ -513,4 +513,17 @@ export function makeDataSuffix({
   }
 
   return;
+}
+
+/**
+ * Checks if a specific capability is present in a request's params
+ * @param request The request object to check
+ * @param capabilityName The name of the capability to check for
+ * @returns boolean indicating if the capability is present
+ */
+export function requestHasCapability(request: RequestArguments, capabilityName: string): boolean {
+  if (!Array.isArray(request?.params)) return false;
+  const capabilities = request.params[0]?.capabilities;
+  if (!capabilities || typeof capabilities !== 'object') return false;
+  return capabilityName in capabilities;
 }

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -527,3 +527,14 @@ export function requestHasCapability(request: RequestArguments, capabilityName: 
   if (!capabilities || typeof capabilities !== 'object') return false;
   return capabilityName in capabilities;
 }
+
+/**
+ * Prepends an item to an array without duplicates
+ * @param array The array to prepend to
+ * @param item The item to prepend
+ * @returns The array with the item prepended
+ */
+export function prependWithoutDuplicates<T>(array: T[], item: T): T[] {
+  const filtered = array.filter((i) => i !== item);
+  return [item, ...filtered];
+}

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -9,6 +9,7 @@ import {
   EmptyFetchPermissionsRequest,
   FetchPermissionsRequest,
 } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import { AddSubAccountCapabilityRequest } from ':core/rpc/wallet_connect.js';
 import { Address } from ':core/type/index.js';
 import { config, store } from ':store/store.js';
 import { get } from ':util/get.js';
@@ -137,11 +138,11 @@ export async function initSubAccountConfig() {
         keys: [
           {
             type: owner.address ? 'address' : 'webauthn-p256',
-            key: owner.address || owner.publicKey,
+            publicKey: owner.address || owner.publicKey,
           },
         ],
       },
-    },
+    } satisfies AddSubAccountCapabilityRequest,
     spendLimits: config?.defaultSpendLimits ?? undefined,
   };
 


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
- Updates SDK to conform to updates to ERC PR https://github.com/jakeFeldman/ERCs/pull/1
- Fixes default spend limits to be injected on `wallet_connect` if `addSubAccount` is present
- Makes keys param in `wallet_addSubAccount` optional


### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

- Updated tests
- Manual testing on playground
