### PR TITLE
fix: don't allow cryptokey use in iframe

### DIFF
--- a/packages/wallet-sdk/src/kms/crypto-key/index.test.ts
+++ b/packages/wallet-sdk/src/kms/crypto-key/index.test.ts
@@ -2,7 +2,13 @@ import { Hex, PublicKey } from 'ox';
 import { type LocalAccount, type OneOf } from 'viem';
 import { WebAuthnAccount } from 'viem/account-abstraction';
 
-import { generateKeyPair, getCryptoKeyAccount, getKeypair, storage } from './index.js';
+import {
+  generateKeyPair,
+  getCryptoKeyAccount,
+  getKeypair,
+  isContextAllowedToSign,
+  storage,
+} from './index.js';
 
 function assertWebAuthnAccount(
   account: OneOf<WebAuthnAccount | LocalAccount> | null
@@ -17,6 +23,22 @@ function assertWebAuthnAccount(
 }
 
 describe('crypto-key', () => {
+  const originalWindow = window;
+
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      ...originalWindow,
+      location: {
+        hostname: 'test.com',
+        origin: 'https://test.com',
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('should generate a key pair', async () => {
     const keypair = await generateKeyPair();
     expect(keypair.privateKey).toBeDefined();
@@ -124,5 +146,171 @@ describe('crypto-key', () => {
         signature: expect.any(String),
       })
     );
+  });
+
+  describe('iframe context restrictions', () => {
+    beforeEach(() => {
+      // Mock window.top and window.self to be different objects (simulating iframe)
+      const mockTop = {
+        location: {
+          hostname: 'test.com',
+          origin: 'https://test.com',
+        },
+      };
+      Object.defineProperty(window, 'top', {
+        value: mockTop,
+        writable: true,
+      });
+      Object.defineProperty(window, 'self', {
+        value: window,
+        writable: true,
+      });
+    });
+
+    it('should throw error when trying to get account in iframe', async () => {
+      const mockKeypair = await generateKeyPair();
+      vi.spyOn(storage, 'getItem').mockResolvedValue(mockKeypair);
+
+      await expect(getCryptoKeyAccount()).rejects.toThrow(
+        'Context is not allowed to sign. Ensure that the page is not in an iframe.'
+      );
+    });
+
+    it('should throw error when trying to sign message in iframe', async () => {
+      const mockKeypair = await generateKeyPair();
+      vi.spyOn(storage, 'getItem').mockResolvedValue(mockKeypair);
+
+      // Temporarily restore window to get the account
+      Object.defineProperty(window, 'top', {
+        value: window,
+        writable: true,
+      });
+      const { account } = await getCryptoKeyAccount();
+      assertWebAuthnAccount(account);
+
+      // Restore iframe context
+      const mockTop = {
+        location: {
+          hostname: 'test.com',
+          origin: 'https://test.com',
+        },
+      };
+      Object.defineProperty(window, 'top', {
+        value: mockTop,
+        writable: true,
+      });
+
+      await expect(account.signMessage({ message: 'Hello, world!' })).rejects.toThrow(
+        'Context is not allowed to sign. Ensure that the page is not in an iframe.'
+      );
+    });
+
+    it('should throw error when trying to sign typed data in iframe', async () => {
+      const mockKeypair = await generateKeyPair();
+      vi.spyOn(storage, 'getItem').mockResolvedValue(mockKeypair);
+
+      // Temporarily restore window to get the account
+      Object.defineProperty(window, 'top', {
+        value: window,
+        writable: true,
+      });
+      const { account } = await getCryptoKeyAccount();
+      assertWebAuthnAccount(account);
+
+      // Restore iframe context
+      const mockTop = {
+        location: {
+          hostname: 'test.com',
+          origin: 'https://test.com',
+        },
+      };
+      Object.defineProperty(window, 'top', {
+        value: mockTop,
+        writable: true,
+      });
+
+      await expect(
+        account.signTypedData({
+          primaryType: 'Test',
+          domain: { name: 'Test' },
+          types: { Test: [{ name: 'foo', type: 'string' }] },
+          message: { foo: 'bar' },
+        })
+      ).rejects.toThrow(
+        'Context is not allowed to sign. Ensure that the page is not in an iframe.'
+      );
+    });
+
+    it('should throw error when trying to sign hash in iframe', async () => {
+      const mockKeypair = await generateKeyPair();
+      vi.spyOn(storage, 'getItem').mockResolvedValue(mockKeypair);
+
+      // Temporarily restore window to get the account
+      Object.defineProperty(window, 'top', {
+        value: window,
+        writable: true,
+      });
+      const { account } = await getCryptoKeyAccount();
+      assertWebAuthnAccount(account);
+
+      // Restore iframe context
+      const mockTop = {
+        location: {
+          hostname: 'test.com',
+          origin: 'https://test.com',
+        },
+      };
+      Object.defineProperty(window, 'top', {
+        value: mockTop,
+        writable: true,
+      });
+
+      await expect(account.sign({ hash: '0x123' })).rejects.toThrow(
+        'Context is not allowed to sign. Ensure that the page is not in an iframe.'
+      );
+    });
+  });
+});
+
+describe('isContextAllowedToSign', () => {
+  const originalWindow = window;
+
+  beforeEach(() => {
+    vi.stubGlobal('window', { ...originalWindow });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should return true when not in an iframe', async () => {
+    // Mock window.top and window.self to be the same object
+    Object.defineProperty(window, 'top', {
+      value: window,
+      writable: true,
+    });
+    Object.defineProperty(window, 'self', {
+      value: window,
+      writable: true,
+    });
+
+    const result = await isContextAllowedToSign();
+    expect(result).toBe(true);
+  });
+
+  it('should return false when in an iframe', async () => {
+    // Mock window.top and window.self to be different objects
+    const mockTop = {};
+    Object.defineProperty(window, 'top', {
+      value: mockTop,
+      writable: true,
+    });
+    Object.defineProperty(window, 'self', {
+      value: window,
+      writable: true,
+    });
+
+    const result = await isContextAllowedToSign();
+    expect(result).toBe(false);
   });
 });

--- a/packages/wallet-sdk/src/kms/crypto-key/index.ts
+++ b/packages/wallet-sdk/src/kms/crypto-key/index.ts
@@ -69,7 +69,7 @@ async function getOrCreateKeypair(): Promise<P256KeyPair> {
 }
 
 async function getAccount(): Promise<WebAuthnAccount> {
-  if (!isContextAllowedToSign()) {
+  if (!(await isContextAllowedToSign())) {
     throw new Error('Context is not allowed to sign. Ensure that the page is not in an iframe.');
   }
 
@@ -81,7 +81,7 @@ async function getAccount(): Promise<WebAuthnAccount> {
   const publicKey = Hex.slice(PublicKey.toHex(keypair.publicKey), 1);
 
   const sign = async (payload: Hex.Hex) => {
-    if (!isContextAllowedToSign()) {
+    if (!(await isContextAllowedToSign())) {
       throw new Error('Context is not allowed to sign. Ensure that the page is not in an iframe.');
     }
 


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

Disallow the use of CryptoKey signer if the SDK detects that it is in an iframe.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
