### PR TITLE
fix: return cached wallet_connect response

### DIFF
--- a/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
+++ b/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
@@ -19,6 +19,8 @@ export type SpendLimit = {
   permissionHash?: string;
   /** Cryptographic signature in hex format */
   signature: string;
+  /** Chain ID */
+  chainId: number;
   /** The permission details */
   permission: {
     /** Wallet address of the account */

--- a/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
+++ b/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
@@ -20,7 +20,7 @@ export type SpendLimit = {
   /** Cryptographic signature in hex format */
   signature: string;
   /** Chain ID */
-  chainId: number;
+  chainId?: number;
   /** The permission details */
   permission: {
     /** Wallet address of the account */

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -674,6 +674,83 @@ describe('SCWSigner', () => {
       const ethAccounts = await signer.request({ method: 'eth_accounts' });
       expect(ethAccounts).toEqual([subAccountAddress, globalAccountAddress]);
     });
+
+    it('should use cached response for subsequent wallet_connect calls', async () => {
+      // First wallet_connect call
+      const mockRequest: RequestArguments = {
+        method: 'wallet_connect',
+        params: [],
+      };
+
+      const mockSpendLimits = [
+        {
+          permissionHash: '0xPermissionHash',
+          signature: '0xSignature',
+          chainId: 1,
+          permission: {
+            account: globalAccountAddress,
+            spender: subAccountAddress,
+          },
+        },
+      ];
+
+      (decryptContent as Mock).mockResolvedValueOnce({
+        result: {
+          value: {
+            accounts: [
+              {
+                address: globalAccountAddress,
+                capabilities: {
+                  subAccounts: [
+                    {
+                      address: subAccountAddress,
+                      factory: globalAccountAddress,
+                      factoryData: '0x',
+                    },
+                  ],
+                  spendLimits: {
+                    permissions: mockSpendLimits,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      // First wallet_connect call
+      await signer.request(mockRequest);
+
+      // Reset decryptContent mock to verify it's not called again
+      (decryptContent as Mock).mockReset();
+
+      // Second wallet_connect call
+      const cachedResponse = await signer.request(mockRequest);
+
+      // Verify decryptContent was not called for the second request
+      expect(decryptContent).not.toHaveBeenCalled();
+
+      // Verify cached response matches expected format
+      expect(cachedResponse).toEqual({
+        accounts: [
+          {
+            address: globalAccountAddress,
+            capabilities: {
+              subAccounts: [
+                {
+                  address: subAccountAddress,
+                  factory: globalAccountAddress,
+                  factoryData: '0x',
+                },
+              ],
+              spendLimits: {
+                permissions: mockSpendLimits,
+              },
+            },
+          },
+        ],
+      });
+    });
   });
 
   describe('wallet_addSubAccount', () => {
@@ -1007,6 +1084,7 @@ describe('SCWSigner', () => {
           account: '0xAddress',
           spender: '0xSubAccount',
         },
+        chainId: 10,
       },
     ] as [SpendLimit];
 

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -268,7 +268,7 @@ describe('SCWSigner', () => {
         },
         chains: [],
         keys: {},
-        spendLimits: {},
+        spendLimits: [],
         config: {
           metadata: mockMetadata,
           preference: { keysUrl: CB_KEYS_URL, options: 'all' },
@@ -1099,7 +1099,7 @@ describe('SCWSigner', () => {
         },
         chains: [],
         keys: {},
-        spendLimits: {},
+        spendLimits: [],
         config: {
           metadata: mockMetadata,
           preference: { keysUrl: CB_KEYS_URL, options: 'all' },
@@ -1125,9 +1125,7 @@ describe('SCWSigner', () => {
 
       await signer.request(mockRequest);
 
-      expect(mockSetSpendLimits).toHaveBeenCalledWith({
-        '10': mockSpendLimits,
-      });
+      expect(mockSetSpendLimits).toHaveBeenCalledWith(mockSpendLimits);
     });
   });
 });

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -9,7 +9,7 @@ import {
   EmptyFetchPermissionsRequest,
   FetchPermissionsRequest,
 } from ':core/rpc/coinbase_fetchSpendPermissions.js';
-import { WalletConnectRequest } from ':core/rpc/wallet_connect.js';
+import { WalletConnectRequest, WalletConnectResponse } from ':core/rpc/wallet_connect.js';
 import { Address } from ':core/type/index.js';
 import { config, store } from ':store/store.js';
 import { get } from ':util/get.js';
@@ -537,4 +537,28 @@ export function requestHasCapability(request: RequestArguments, capabilityName: 
 export function prependWithoutDuplicates<T>(array: T[], item: T): T[] {
   const filtered = array.filter((i) => i !== item);
   return [item, ...filtered];
+}
+
+export async function getCachedWalletConnectResponse(): Promise<WalletConnectResponse | null> {
+  const spendLimits = store.spendLimits.get();
+  const subAccount = store.subAccounts.get();
+  const accounts = store.account.get().accounts;
+
+  if (!accounts) {
+    return null;
+  }
+
+  const walletConnectAccounts = accounts?.map<WalletConnectResponse['accounts'][number]>(
+    (account) => ({
+      address: account,
+      capabilities: {
+        subAccounts: subAccount ? [subAccount] : undefined,
+        spendLimits: spendLimits.length > 0 ? { permissions: spendLimits } : undefined,
+      },
+    })
+  );
+
+  return {
+    accounts: walletConnectAccounts,
+  };
 }

--- a/packages/wallet-sdk/src/store/store.ts
+++ b/packages/wallet-sdk/src/store/store.ts
@@ -94,12 +94,12 @@ const createSubAccountConfigSlice: StateCreator<StoreState, [], [], SubAccountCo
 };
 
 type SpendLimitsSlice = {
-  spendLimits: Record<number, SpendLimit[]>;
+  spendLimits: SpendLimit[];
 };
 
 const createSpendLimitsSlice: StateCreator<StoreState, [], [], SpendLimitsSlice> = () => {
   return {
-    spendLimits: {},
+    spendLimits: [],
   };
 };
 
@@ -195,12 +195,12 @@ export const subAccounts = {
 
 export const spendLimits = {
   get: () => sdkstore.getState().spendLimits,
-  set: (spendLimits: Record<number, SpendLimit[]>) => {
-    sdkstore.setState((state) => ({ spendLimits: { ...state.spendLimits, ...spendLimits } }));
+  set: (spendLimits: SpendLimit[]) => {
+    sdkstore.setState({ spendLimits });
   },
   clear: () => {
     sdkstore.setState({
-      spendLimits: {},
+      spendLimits: [],
     });
   },
 };


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

Caches the wallet_connect response to be returned on subsequent wallet_connect calls. This cache is cleared on disconnect.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Unit tests and manual testing
