### PR TITLE
fix: remove dynamic spend limit configuration from sdk constructor

### DIFF
--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -324,20 +324,6 @@ export default function AutoSubAccount() {
           </RadioGroup>
         </FormControl>
         <FormControl>
-          <FormLabel>Dynamic Spend Limits</FormLabel>
-          <RadioGroup
-            value={(subAccountsConfig?.dynamicSpendLimits || false).toString()}
-            onChange={(value) =>
-              setSubAccountsConfig((prev) => ({ ...prev, dynamicSpendLimits: value === 'true' }))
-            }
-          >
-            <Stack direction="row">
-              <Radio value="true">Enabled</Radio>
-              <Radio value="false">Disabled</Radio>
-            </Stack>
-          </RadioGroup>
-        </FormControl>
-        <FormControl>
           <FormLabel>Attribution</FormLabel>
           <RadioGroup value={getAttributionMode()} onChange={handleAttributionModeChange}>
             <Stack direction="row">

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -96,10 +96,6 @@ export type SubAccountOptions = {
    * Only supports native chain tokens currently.
    */
   defaultSpendLimits?: Record<number, SpendLimitConfig[]>;
-  /**
-   * Used when users have insufficient funds, the SDK will request a new spend limit (only used when auto sub accounts is enabled)
-   */
-  dynamicSpendLimits?: boolean;
 };
 
 export interface ConstructorOptions {

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
@@ -58,7 +58,6 @@ export function createCoinbaseWalletSDK(params: CreateCoinbaseWalletSDKOptions) 
     toOwnerAccount: params.subAccounts?.toOwnerAccount,
     enableAutoSubAccounts: params.subAccounts?.enableAutoSubAccounts,
     defaultSpendLimits: params.subAccounts?.defaultSpendLimits,
-    dynamicSpendLimits: params.subAccounts?.dynamicSpendLimits,
   });
 
   // set the options in the store

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -921,11 +921,6 @@ describe('SCWSigner', () => {
     });
 
     it('should handle insufficient balance error if external funding source is present', async () => {
-      vi.spyOn(store.subAccountsConfig, 'get').mockReturnValue({
-        enableAutoSubAccounts: true,
-        dynamicSpendLimits: true,
-      });
-
       (createSubAccountSigner as Mock).mockImplementation(async () => {
         const request = vi.fn((args) => {
           throw new HttpRequestError({

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -586,14 +586,7 @@ export class SCWSigner implements Signer {
         throw error;
       }
 
-      if (
-        !(
-          isActionableHttpRequestError(errorObject) &&
-          subAccountsConfig?.dynamicSpendLimits &&
-          subAccountsConfig?.enableAutoSubAccounts &&
-          errorObject.data
-        )
-      ) {
+      if (!(isActionableHttpRequestError(errorObject) && errorObject.data)) {
         throw error;
       }
 


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

- Removes the `dynamicSpendLimit` config option and enables it by default for sub accounts
- Also removes the restriction that only enables it when auto sub accounts is enabled

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Manual testing, unit tests
