### PR TITLE
WalletLink: Move heartbeat interval to a webworker

### DIFF
--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -46,6 +46,7 @@
     "@testing-library/preact": "^3.2.4",
     "@types/node": "^14.18.54",
     "@vitest/coverage-v8": "2.1.2",
+    "@vitest/web-worker": "3.2.1",
     "fake-indexeddb": "^6.0.0",
     "glob": "^11.0.0",
     "jest-websocket-mock": "^2.4.0",

--- a/packages/wallet-sdk/src/sign/walletlink/relay/connection/HeartbeatWorker.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/connection/HeartbeatWorker.test.ts
@@ -1,0 +1,234 @@
+import '@vitest/web-worker';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('HeartbeatWorker', () => {
+  let worker: Worker;
+
+  beforeEach(async () => {
+    // Create a new worker instance for each test
+    worker = new Worker(new URL('./HeartbeatWorker.ts', import.meta.url));
+  });
+
+  afterEach(() => {
+    if (worker) {
+      worker.terminate();
+    }
+  });
+
+  describe('Message Handling', () => {
+    it('should start heartbeat and send confirmation', async () => {
+      const messagePromise = new Promise<MessageEvent>((resolve) => {
+        worker.addEventListener('message', resolve, { once: true });
+      });
+
+      worker.postMessage({ type: 'start' });
+
+      const event = await messagePromise;
+      expect(event.data).toEqual({ type: 'started' });
+    });
+
+    it('should send heartbeat messages at regular intervals', async () => {
+      worker.postMessage({ type: 'start' });
+
+      await new Promise<void>((resolve) => {
+        worker.addEventListener('message', (event) => {
+          if (event.data.type === 'started') {
+            resolve();
+          }
+        }, { once: true });
+      });
+
+      const heartbeats: MessageEvent[] = [];
+      const heartbeatPromise = new Promise<void>((resolve) => {
+        let count = 0;
+        worker.addEventListener('message', (event) => {
+          if (event.data.type === 'heartbeat') {
+            heartbeats.push(event);
+            count++;
+            if (count >= 2) {
+              resolve();
+            }
+          }
+        });
+      });
+
+      // Wait for at least 2 heartbeat messages (this will take ~20 seconds in real time)
+      // For testing, we'll use a shorter timeout and verify the structure
+      await Promise.race([
+        heartbeatPromise,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout waiting for heartbeats')), 25000))
+      ]);
+
+      expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+      heartbeats.forEach(event => {
+        expect(event.data).toEqual({ type: 'heartbeat' });
+      });
+    }, 30000); // 30 second timeout for this test
+
+    it('should stop heartbeat and send confirmation', async () => {
+      worker.postMessage({ type: 'start' });
+      
+      await new Promise<void>((resolve) => {
+        worker.addEventListener('message', (event) => {
+          if (event.data.type === 'started') {
+            resolve();
+          }
+        }, { once: true });
+      });
+
+      const stopPromise = new Promise<MessageEvent>((resolve) => {
+        worker.addEventListener('message', (event) => {
+          if (event.data.type === 'stopped') {
+            resolve(event);
+          }
+        }, { once: true });
+      });
+
+      worker.postMessage({ type: 'stop' });
+
+      const event = await stopPromise;
+      expect(event.data).toEqual({ type: 'stopped' });
+    });
+
+    it('should handle unknown message types gracefully', async () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      worker.postMessage({ type: 'unknown' });
+
+      // Give the worker time to process the message
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Note: We can't directly verify console.warn was called in the worker context
+      // but we can verify the worker doesn't crash or send unexpected messages
+      
+      const messagePromise = new Promise<MessageEvent>((resolve) => {
+        worker.addEventListener('message', resolve, { once: true });
+      });
+
+      worker.postMessage({ type: 'start' });
+      const event = await messagePromise;
+      expect(event.data).toEqual({ type: 'started' });
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Heartbeat Interval Management', () => {
+    it('should handle restart without issues', async () => {
+      worker.postMessage({ type: 'start' });
+      
+      await new Promise<void>((resolve) => {
+        worker.addEventListener('message', (event) => {
+          if (event.data.type === 'started') {
+            resolve();
+          }
+        }, { once: true });
+      });
+
+      // Start again (should clear previous interval)
+      const secondStartPromise = new Promise<MessageEvent>((resolve) => {
+        worker.addEventListener('message', (event) => {
+          if (event.data.type === 'started') {
+            resolve(event);
+          }
+        }, { once: true });
+      });
+
+      worker.postMessage({ type: 'start' });
+      const event = await secondStartPromise;
+      expect(event.data).toEqual({ type: 'started' });
+    });
+
+    it('should stop cleanly even when no heartbeat is running', async () => {
+      const stopPromise = new Promise<MessageEvent>((resolve) => {
+        worker.addEventListener('message', resolve, { once: true });
+      });
+
+      // Stop without starting first
+      worker.postMessage({ type: 'stop' });
+
+      const event = await stopPromise;
+      expect(event.data).toEqual({ type: 'stopped' });
+    });
+  });
+
+  describe('Message Flow', () => {
+    it('should handle complete start-heartbeat-stop cycle', async () => {
+      const messages: any[] = [];
+      
+      worker.addEventListener('message', (event) => {
+        messages.push(event.data);
+      });
+
+      worker.postMessage({ type: 'start' });
+      
+      await new Promise<void>((resolve) => {
+        const checkMessages = () => {
+          if (messages.some(msg => msg.type === 'started')) {
+            resolve();
+          } else {
+            setTimeout(checkMessages, 10);
+          }
+        };
+        checkMessages();
+      });
+
+      await new Promise<void>((resolve) => {
+        const checkMessages = () => {
+          if (messages.some(msg => msg.type === 'heartbeat')) {
+            resolve();
+          } else {
+            setTimeout(checkMessages, 100);
+          }
+        };
+        checkMessages();
+      });
+
+      worker.postMessage({ type: 'stop' });
+      
+      await new Promise<void>((resolve) => {
+        const checkMessages = () => {
+          if (messages.some(msg => msg.type === 'stopped')) {
+            resolve();
+          } else {
+            setTimeout(checkMessages, 10);
+          }
+        };
+        checkMessages();
+      });
+
+      // Verify we got all expected message types
+      expect(messages.some(msg => msg.type === 'started')).toBe(true);
+      expect(messages.some(msg => msg.type === 'heartbeat')).toBe(true);
+      expect(messages.some(msg => msg.type === 'stopped')).toBe(true);
+    }, 15000); // 15 second timeout
+
+    it('should use correct heartbeat interval timing', async () => {
+      const heartbeatTimes: number[] = [];
+      
+      worker.addEventListener('message', (event) => {
+        if (event.data.type === 'heartbeat') {
+          heartbeatTimes.push(Date.now());
+        }
+      });
+
+      worker.postMessage({ type: 'start' });
+
+      await new Promise<void>((resolve) => {
+        const checkHeartbeats = () => {
+          if (heartbeatTimes.length >= 2) {
+            resolve();
+          } else {
+            setTimeout(checkHeartbeats, 100);
+          }
+        };
+        checkHeartbeats();
+      });
+
+      // Verify the interval is approximately 10 seconds (allow some tolerance)
+      const interval = heartbeatTimes[1] - heartbeatTimes[0];
+      expect(interval).toBeGreaterThan(9500); // 9.5 seconds minimum
+      expect(interval).toBeLessThan(10500);   // 10.5 seconds maximum
+    }, 25000); // 25 second timeout
+  });
+}); 

--- a/packages/wallet-sdk/src/sign/walletlink/relay/connection/HeartbeatWorker.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/connection/HeartbeatWorker.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2018-2025 Coinbase, Inc. <https://www.coinbase.com/>
+
+
+/**
+ * This worker is used to send heartbeat messages to the main thread.
+ * It is used to keep the websocket connection alive when the webpage is backgrounded.
+ * 
+ */
+
+const HEARTBEAT_INTERVAL = 10000; // 10 seconds
+
+type WorkerMessage = {
+  type: 'start' | 'stop';
+}
+
+export type WorkerResponse = {
+  type: 'heartbeat' | 'started' | 'stopped';
+}
+
+let heartbeatInterval: NodeJS.Timeout | undefined;
+
+// Listen for messages from the main thread
+self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
+  const { type } = event.data;
+
+  switch (type) {
+    case 'start':
+      startHeartbeat();
+      break;
+    case 'stop':
+      stopHeartbeat();
+      break;
+    default:
+      console.warn('Unknown message type received by HeartbeatWorker:', type);
+  }
+});
+
+function startHeartbeat(): void {
+  // Clear any existing interval
+  if (heartbeatInterval) {
+    clearInterval(heartbeatInterval);
+  }
+
+  // Start the heartbeat interval
+  heartbeatInterval = setInterval(() => {
+    // Send heartbeat message to main thread
+    const response: WorkerResponse = { type: 'heartbeat' };
+    self.postMessage(response);
+  }, HEARTBEAT_INTERVAL);
+
+  // Send confirmation that heartbeat started
+  const response: WorkerResponse = { type: 'started' };
+  self.postMessage(response);
+}
+
+function stopHeartbeat(): void {
+  if (heartbeatInterval) {
+    clearInterval(heartbeatInterval);
+    heartbeatInterval = undefined;
+  }
+
+  // Send confirmation that heartbeat stopped
+  const response: WorkerResponse = { type: 'stopped' };
+  self.postMessage(response);
+}
+
+// Handle worker termination
+self.addEventListener('beforeunload', () => {
+  stopHeartbeat();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,6 +1503,7 @@ __metadata:
     "@testing-library/preact": "npm:^3.2.4"
     "@types/node": "npm:^14.18.54"
     "@vitest/coverage-v8": "npm:2.1.2"
+    "@vitest/web-worker": "npm:3.2.1"
     clsx: "npm:1.2.1"
     eventemitter3: "npm:5.0.1"
     fake-indexeddb: "npm:^6.0.0"
@@ -3149,6 +3150,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/web-worker@npm:3.2.1":
+  version: 3.2.1
+  resolution: "@vitest/web-worker@npm:3.2.1"
+  dependencies:
+    debug: "npm:^4.4.1"
+  peerDependencies:
+    vitest: 3.2.1
+  checksum: 10/a27a41fb588975b38d2fd592a8be60a11d363ec94c183a4cc1ad44b9fc768c0d4df46be3aa97d231bd8d54b1694f346d3cdb935f97462c714b7b44c06c2fe867
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ast@npm:1.12.1, @webassemblyjs/ast@npm:^1.12.1":
   version: 1.12.1
   resolution: "@webassemblyjs/ast@npm:1.12.1"
@@ -4140,6 +4152,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10/1847944c2e3c2c732514b93d11886575625686056cd765336212dc15de2d2b29612b6cd80e1afba767bb8e1803b778caf9973e98169ef1a24a7a7009e1820367
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "debug@npm:4.4.1"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10/8e2709b2144f03c7950f8804d01ccb3786373df01e406a0f66928e47001cf2d336cbed9ee137261d4f90d68d8679468c755e3548ed83ddacdc82b194d2468afe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### _Summary_

This PR moves the WalletLink heartbeat interval management from the main thread to a WebWorker to avoid Chrome's timer throttling.

The issue was:
- When Chrome tabs are inactive for more than 5 minutes, Chrome throttles JavaScript timers to fire only once per minute. - This caused issues with the WebSocket heartbeat mechanism in WalletLinkConnection:
- The heartbeat setInterval would be throttled, causing delayed heartbeat checks
- When heartbeat responses were delayed beyond the 20-second threshold, the WebSocket would disconnect
- Upon tab reactivation, users would find their wallet connection broken
- The automatic reconnection logic was also affected by the same timer throttling

WebWorkers are not throttled the way the main thread is, so having the interval run there resolves the issue.


<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

To test:
- Connect to an app using WalletLink, confirm you can initiate requests and they are received on your mobile device.
- Leave the app's tab idle for 5+ minutes (do not navigate away or refresh)
- After 5 minutes, initiate a new request
- => Confirm the request is sent and received as expected

<!--
  Verify changes. Include relevant screenshots/videos
-->
