### PR TITLE
fix: sub account personal_sign message encoding

### DIFF
--- a/examples/testapp/src/pages/add-sub-account/components/PersonalSign.tsx
+++ b/examples/testapp/src/pages/add-sub-account/components/PersonalSign.tsx
@@ -1,7 +1,8 @@
 import { Box, Button } from '@chakra-ui/react';
 import { createCoinbaseWalletSDK } from '@coinbase/wallet-sdk';
 import { useCallback, useState } from 'react';
-import { toHex } from 'viem';
+import { createPublicClient, http, toHex } from 'viem';
+import { baseSepolia } from 'viem/chains';
 
 export function PersonalSign({
   sdk,
@@ -22,8 +23,20 @@ export function PersonalSign({
         method: 'personal_sign',
         params: [toHex('Hello, world!'), subAccountAddress],
       });
+
+      const publicClient = createPublicClient({
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const isValid = await publicClient.verifyMessage({
+        address: subAccountAddress as `0x${string}`,
+        message: 'Hello, world!',
+        signature: response as `0x${string}`,
+      });
+
       console.info('response', response);
-      setState(response as string);
+      setState(`isValid: ${isValid ? 'true' : 'false'} ${response as string} `);
     } catch (e) {
       console.error('error', e);
     }

--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -14,7 +14,7 @@ import {
 import { getCryptoKeyAccount } from '@coinbase/wallet-sdk';
 import { SpendLimitConfig } from '@coinbase/wallet-sdk/dist/core/provider/interface';
 import React, { useEffect, useState } from 'react';
-import { numberToHex, parseEther } from 'viem';
+import { createPublicClient, http, numberToHex, parseEther } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { baseSepolia } from 'viem/chains';
 import { useConfig } from '../../context/ConfigContextProvider';
@@ -125,7 +125,7 @@ export default function AutoSubAccount() {
           name: 'Test Domain',
           version: '1',
           chainId: baseSepolia.id,
-          verifyingContract: '0x0000000000000000000000000000000000000000',
+          verifyingContract: '0x0000000000000000000000000000000000000000' as `0x${string}`,
         },
         message: {
           name: 'Test User',
@@ -137,7 +137,22 @@ export default function AutoSubAccount() {
         method: 'eth_signTypedData_v4',
         params: [accounts[0], JSON.stringify(typedData)],
       });
-      setLastResult(JSON.stringify(response, null, 2));
+
+      const publicClient = createPublicClient({
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const isValid = await publicClient.verifyTypedData({
+        address: accounts[0] as `0x${string}`,
+        domain: typedData.domain,
+        types: typedData.types,
+        primaryType: typedData.primaryType,
+        message: typedData.message,
+        signature: response as `0x${string}`,
+      });
+
+      setLastResult(`isValid: ${isValid}\n${response}`);
     } catch (e) {
       console.error('error', e);
       setLastResult(JSON.stringify(e, null, 2));

--- a/packages/wallet-sdk/src/sign/scw/utils/createSubAccountSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/createSubAccountSigner.ts
@@ -12,7 +12,6 @@ import {
   Address,
   Hex,
   PublicClient,
-  SignableMessage,
   TypedDataDefinition,
   hexToString,
   isHex,
@@ -283,9 +282,13 @@ export async function createSubAccountSigner({
         }
         case 'personal_sign': {
           assertArrayPresence(args.params);
-          return account.signMessage({ message: args.params[0] } as {
-            message: SignableMessage;
-          });
+          // Param is expected to be a hex encoded string
+          if (!isHex(args.params[0])) {
+            throw standardErrors.rpc.invalidParams('message must be a hex encoded string');
+          }
+          // signMessage expects the unencoded message
+          const message = hexToString(args.params[0] as `0x${string}`);
+          return account.signMessage({ message });
         }
         case 'eth_signTypedData_v4': {
           assertArrayPresence(args.params);


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
Sub account was incorrectly passing hex-encoded data to `signMessage`. This was fixed by decoding the message param first before passing to be signed by the account.

Tests were added to check for this and playground now shows signature validation result.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
Unit tests, manual testing