### PR TITLE
fix: usage of stale sub account config

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -100,8 +100,7 @@ export class SCWSigner implements Signer {
     if (this.accounts.length === 0) {
       switch (request.method) {
         case 'eth_requestAccounts': {
-          const subAccountsConfig = store.subAccountsConfig.get();
-          if (subAccountsConfig?.enableAutoSubAccounts) {
+          if (store.subAccountsConfig.get()?.enableAutoSubAccounts) {
             // Wait for the popup to be loaded before making async calls
             await this.communicator.waitForPopupLoaded?.();
             await initSubAccountConfig();
@@ -112,7 +111,7 @@ export class SCWSigner implements Signer {
                 {
                   version: "1",
                   capabilities: {
-                    ...(subAccountsConfig?.capabilities ?? {}),
+                    ...(store.subAccountsConfig.get()?.capabilities ?? {}),
                   },
                 },
               ],


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
`wallet_connect` params are empty on `eth_requestAccounts` when `enableAutoSubAccounts` is true. This is because we were using a stale sub account config after calling `initSubAccountConfig`. The bug is resolved by calling the sub account config from the store after calling `initSubAccountConfig`.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Manual testing
