### PR TITLE
Add support for wallet_getCapabilities v2

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -9,10 +9,10 @@ import { SpendLimit } from ':core/rpc/coinbase_fetchSpendPermissions.js';
 import { getClient } from ':store/chain-clients/utils.js';
 import { store } from ':store/store.js';
 import {
-  decryptContent,
-  encryptContent,
-  exportKeyToHexString,
-  importKeyFromHexString,
+    decryptContent,
+    encryptContent,
+    exportKeyToHexString,
+    importKeyFromHexString,
 } from ':util/cipher.js';
 import { fetchRPCRequest } from ':util/provider.js';
 import { HttpRequestError, numberToHex } from 'viem';
@@ -1067,6 +1067,223 @@ describe('SCWSigner', () => {
       expect(handleInsufficientBalanceError).toHaveBeenCalled();
 
       (createSubAccountSigner as Mock).mockRestore();
+    });
+  });
+
+  describe('wallet_getCapabilities', () => {
+    let stateSpy: MockInstance;
+
+    beforeEach(() => {
+      stateSpy = vi.spyOn(store, 'getState').mockImplementation(() => ({
+        account: {
+          accounts: [globalAccountAddress],
+          capabilities: {
+            '0x1': { 
+              atomicBatch: { supported: true },
+              paymasterService: { supported: true }
+            },
+            '0x5': {
+              atomicBatch: { supported: false }
+            },
+            '0xa': {
+              paymasterService: { supported: true }
+            }
+          },
+        },
+        chains: [],
+        keys: {},
+        spendLimits: [],
+        config: {
+          metadata: mockMetadata,
+          preference: { keysUrl: CB_KEYS_URL, options: 'all' },
+          version: '1.0.0',
+        },
+      }));
+
+      signer['accounts'] = [globalAccountAddress];
+    });
+
+    afterEach(() => {
+      stateSpy.mockRestore();
+    });
+
+    it('should return all capabilities when no filter is provided', async () => {
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: [globalAccountAddress],
+      };
+
+      const result = await signer.request(request);
+
+      expect(result).toEqual({
+        '0x1': { 
+          atomicBatch: { supported: true },
+          paymasterService: { supported: true }
+        },
+        '0x5': {
+          atomicBatch: { supported: false }
+        },
+        '0xa': {
+          paymasterService: { supported: true }
+        }
+      });
+    });
+
+    it('should return filtered capabilities when chain filter is provided', async () => {
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: [globalAccountAddress, ['0x1', '0xa']],
+      };
+
+      const result = await signer.request(request);
+
+      expect(result).toEqual({
+        '0x1': { 
+          atomicBatch: { supported: true },
+          paymasterService: { supported: true }
+        },
+        '0xa': {
+          paymasterService: { supported: true }
+        }
+      });
+    });
+
+    it('should handle different hex formatting in filters', async () => {
+      // Test that '0x01' matches '0x1' capability
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: [globalAccountAddress, ['0x01', '0x05']],
+      };
+
+      const result = await signer.request(request);
+
+      expect(result).toEqual({
+        '0x1': { 
+          atomicBatch: { supported: true },
+          paymasterService: { supported: true }
+        },
+        '0x5': {
+          atomicBatch: { supported: false }
+        }
+      });
+    });
+
+    it('should return empty object when filter matches no capabilities', async () => {
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: [globalAccountAddress, ['0x99', '0x100']],
+      };
+
+      const result = await signer.request(request);
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object when capabilities is undefined', async () => {
+      stateSpy.mockImplementation(() => ({
+        account: {
+          accounts: [globalAccountAddress],
+          capabilities: undefined,
+        },
+        chains: [],
+        keys: {},
+        spendLimits: [],
+        config: {
+          metadata: mockMetadata,
+          preference: { keysUrl: CB_KEYS_URL, options: 'all' },
+          version: '1.0.0',
+        },
+      }));
+
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: [globalAccountAddress],
+      };
+
+      const result = await signer.request(request);
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object when empty filter array is provided', async () => {
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: [globalAccountAddress, []],
+      };
+
+      const result = await signer.request(request);
+
+      expect(result).toEqual({
+        '0x1': { 
+          atomicBatch: { supported: true },
+          paymasterService: { supported: true }
+        },
+        '0x5': {
+          atomicBatch: { supported: false }
+        },
+        '0xa': {
+          paymasterService: { supported: true }
+        }
+      });
+    });
+
+    it('should handle capabilities with non-hex keys gracefully', async () => {
+      stateSpy.mockImplementation(() => ({
+        account: {
+          accounts: [globalAccountAddress],
+          capabilities: {
+            '0x1': { atomicBatch: { supported: true } },
+            'invalid-key': { someFeature: true },
+            '0x5': { paymasterService: { supported: true } }
+          },
+        },
+        chains: [],
+        keys: {},
+        spendLimits: [],
+        config: {
+          metadata: mockMetadata,
+          preference: { keysUrl: CB_KEYS_URL, options: 'all' },
+          version: '1.0.0',
+        },
+      }));
+
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: [globalAccountAddress, ['0x1']],
+      };
+
+      const result = await signer.request(request);
+
+      expect(result).toEqual({
+        '0x1': { atomicBatch: { supported: true } }
+      });
+    });
+
+    it('should throw error when account is not in accounts list', async () => {
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: [subAccountAddress],
+      };
+
+      await expect(signer.request(request)).rejects.toThrow('no active account found');
+    });
+
+    it('should throw error when account parameter is invalid', async () => {
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: ['invalid-address'],
+      };
+
+      await expect(signer.request(request)).rejects.toThrow();
+    });
+
+    it('should throw error when filter contains invalid hex strings', async () => {
+      const request = {
+        method: 'wallet_getCapabilities',
+        params: [globalAccountAddress, ['0x1', 'invalid-hex']],
+      };
+
+      await expect(signer.request(request)).rejects.toThrow();
     });
   });
 

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -1,5 +1,5 @@
 import { CB_WALLET_RPC_URL } from ':core/constants.js';
-import { Hex, hexToNumber, numberToHex } from 'viem';
+import { Hex, hexToNumber, isAddressEqual, numberToHex } from 'viem';
 
 import { Communicator } from ':core/communicator/Communicator.js';
 import { isActionableHttpRequestError, isViemError, standardErrors } from ':core/error/errors.js';
@@ -27,6 +27,7 @@ import { SCWKeyManager } from './SCWKeyManager.js';
 import {
   addSenderToRequest,
   assertFetchPermissionsRequest,
+  assertGetCapabilitiesParams,
   assertParamsChainId,
   fillMissingParamsForFetchPermissions,
   getCachedWalletConnectResponse,
@@ -170,7 +171,7 @@ export class SCWSigner implements Signer {
       case 'eth_chainId':
         return numberToHex(this.chain.id);
       case 'wallet_getCapabilities':
-        return store.getState().account.capabilities;
+        return this.handleGetCapabilitiesRequest(request);
       case 'wallet_switchEthereumChain':
         return this.handleSwitchChainRequest(request);
       case 'eth_ecRecover':
@@ -341,6 +342,47 @@ export class SCWSigner implements Signer {
       this.updateChain(chainId);
     }
     return popupResult;
+  }
+
+  private async handleGetCapabilitiesRequest(request: RequestArguments) {
+    assertGetCapabilitiesParams(request.params);
+    
+    const requestedAccount = request.params[0];
+    const filterChainIds = request.params[1]; // Optional second parameter
+
+    if (!this.accounts.some((account) => isAddressEqual(account, requestedAccount))) {
+      throw standardErrors.provider.unauthorized('no active account found');
+    }
+
+    const capabilities = store.getState().account.capabilities;
+    
+    // Return empty object if capabilities is undefined
+    if (!capabilities) {
+      return {};
+    }
+    
+    // If no filter is provided, return all capabilities
+    if (!filterChainIds || filterChainIds.length === 0) {
+      return capabilities;
+    }
+
+    // Convert filter chain IDs to numbers once for efficient lookup
+    const filterChainNumbers = new Set(filterChainIds.map(chainId => hexToNumber(chainId)));
+
+    // Filter capabilities
+    const filteredCapabilities = Object.fromEntries(
+      Object.entries(capabilities).filter(([capabilityKey]) => {
+        try {
+          const capabilityChainNumber = hexToNumber(capabilityKey as `0x${string}`);
+          return filterChainNumbers.has(capabilityChainNumber);
+        } catch {
+          // If capabilityKey is not a valid hex string, exclude it
+          return false;
+        }
+      })
+    );
+    
+    return filteredCapabilities;
   }
 
   private async sendEncryptedRequest(request: RequestArguments): Promise<RPCResponseMessage> {

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -4,6 +4,7 @@ import {
   SpendPermissionBatch,
   addSenderToRequest,
   assertFetchPermissionsRequest,
+  assertGetCapabilitiesParams,
   assertParamsChainId,
   createSpendPermissionBatchMessage,
   createWalletSendCallsRequest,
@@ -15,6 +16,11 @@ import {
   prependWithoutDuplicates,
   requestHasCapability,
 } from './utils.js';
+
+// Valid Ethereum addresses for testing
+const VALID_ADDRESS_1 = '0xe6c7D51b0d5ECC217BE74019447aeac4580Afb54';
+const VALID_ADDRESS_2 = '0x7838d2724FC686813CAf81d4429beff1110c739a';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 describe('utils', () => {
   describe('getSenderFromRequest', () => {
@@ -80,6 +86,71 @@ describe('assertParamsChainId', () => {
   it('should throw if params is null or undefined', () => {
     expect(() => assertParamsChainId(null)).toThrow();
     expect(() => assertParamsChainId(undefined)).toThrow();
+  });
+});
+
+describe('assertGetCapabilitiesParams', () => {
+  it('should throw if params is null or undefined', () => {
+    expect(() => assertGetCapabilitiesParams(null)).toThrow();
+    expect(() => assertGetCapabilitiesParams(undefined)).toThrow();
+  });
+
+  it('should throw if params is not an array', () => {
+    expect(() => assertGetCapabilitiesParams({})).toThrow();
+    expect(() => assertGetCapabilitiesParams('0x123')).toThrow();
+    expect(() => assertGetCapabilitiesParams(123)).toThrow();
+  });
+
+  it('should throw if params array is empty', () => {
+    expect(() => assertGetCapabilitiesParams([])).toThrow();
+  });
+
+  it('should throw if params array has more than 2 elements', () => {
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1'], 'extra'])).toThrow();
+  });
+
+  it('should throw if first param is not a string', () => {
+    expect(() => assertGetCapabilitiesParams([123])).toThrow();
+    expect(() => assertGetCapabilitiesParams([null])).toThrow();
+    expect(() => assertGetCapabilitiesParams([{}])).toThrow();
+  });
+
+  it('should throw if first param is not a valid Ethereum address', () => {
+    expect(() => assertGetCapabilitiesParams(['123'])).toThrow();
+    expect(() => assertGetCapabilitiesParams(['0x123'])).toThrow(); // Too short
+    expect(() => assertGetCapabilitiesParams(['0x123abc'])).toThrow(); // Too short
+    expect(() => assertGetCapabilitiesParams(['xyz123'])).toThrow(); // No 0x prefix
+    expect(() => assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678gg'])).toThrow(); // Invalid hex characters
+    expect(() => assertGetCapabilitiesParams(['0x123456789012345678901234567890123456789'])).toThrow(); // Too short (39 chars)
+    expect(() => assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678901'])).toThrow(); // Too long (41 chars)
+  });
+
+  it('should not throw for valid single parameter (valid Ethereum address)', () => {
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1])).not.toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_2])).not.toThrow();
+    expect(() => assertGetCapabilitiesParams([ZERO_ADDRESS])).not.toThrow();
+  });
+
+  it('should throw if second param is not an array when present', () => {
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, '0x1'])).toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, 123])).toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, null])).toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, {}])).toThrow();
+  });
+
+  it('should throw if second param array contains non-hex strings', () => {
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', '123']])).toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', 123]])).toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', null]])).toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['abc123']])).toThrow();
+  });
+
+  it('should not throw for valid parameters with filter array', () => {
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, []])).not.toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1']])).not.toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', '0x2', '0x3']])).not.toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0xabcdef', '0x0']])).not.toThrow();
+    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_2, ['0x1', '0xa']])).not.toThrow();
   });
 });
 

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -1,4 +1,4 @@
-import { PublicClient, WalletSendCallsParameters, hexToBigInt } from 'viem';
+import { PublicClient, WalletSendCallsParameters, hexToBigInt, isAddress } from 'viem';
 
 import { InsufficientBalanceErrorData } from ':core/error/errors.js';
 import { Hex, keccak256, numberToHex, slice, toHex } from 'viem';
@@ -73,6 +73,28 @@ export function assertParamsChainId(params: unknown): asserts params is [
   }
   if (typeof params[0].chainId !== 'string' && typeof params[0].chainId !== 'number') {
     throw standardErrors.rpc.invalidParams();
+  }
+}
+
+export function assertGetCapabilitiesParams(params: unknown): asserts params is [`0x${string}`, (`0x${string}`[])? ] {
+  if (!params || !Array.isArray(params) || (params.length !== 1 && params.length !== 2)) {
+    throw standardErrors.rpc.invalidParams();
+  }
+
+  if (typeof params[0] !== 'string' || !isAddress(params[0])) {
+    throw standardErrors.rpc.invalidParams();
+  }
+
+  if (params.length === 2) {
+    if (!Array.isArray(params[1])) {
+      throw standardErrors.rpc.invalidParams();
+    }
+
+    for (const param of params[1]) {
+      if (typeof param !== 'string' || !param.startsWith('0x')) {
+        throw standardErrors.rpc.invalidParams();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### _Summary_

**Add filtering support to `wallet_getCapabilities` method**

This PR implements optional chain ID filtering for the `wallet_getCapabilities` RPC method, allowing apps to request capabilities for specific chains only.

**Example Usage:**
```javascript
// Get all capabilities (existing behavior)
await provider.request({
  method: 'wallet_getCapabilities',
  params: ['0x123...']
});

// Get filtered capabilities (new functionality)
await provider.request({
  method: 'wallet_getCapabilities', 
  params: ['0x123...', ['0x1', '0x3']]  // Only return capabilities for chains 1 and 3
});
```

### _How did you test your changes?_

**✅ Comprehensive Test Suite Added:**
- **Parameter validation tests**: 15+ test cases covering all edge cases in `utils.test.ts`
- **Integration tests**: 10+ test cases covering the full request flow in `SCWSigner.test.ts`
- **Error handling tests**: Invalid addresses, unauthorized accounts, malformed parameters
- **Edge case coverage**: Empty filters, undefined capabilities, non-hex keys