### PR TITLE
fix: wallet_addSubAccount keys population if not provided

### DIFF
--- a/examples/testapp/src/pages/add-sub-account/components/AddSubAccountWithoutKeys.tsx
+++ b/examples/testapp/src/pages/add-sub-account/components/AddSubAccountWithoutKeys.tsx
@@ -1,0 +1,73 @@
+import { Box, Button } from '@chakra-ui/react';
+import { createCoinbaseWalletSDK, getCryptoKeyAccount } from '@coinbase/wallet-sdk';
+import { useCallback, useState } from 'react';
+import { numberToHex } from 'viem';
+
+type AddSubAccountWithoutKeysProps = {
+  sdk: ReturnType<typeof createCoinbaseWalletSDK>;
+  onAddSubAccount: (address: string) => void;
+  signerFn: typeof getCryptoKeyAccount;
+};
+
+export function AddSubAccountWithoutKeys({
+  sdk,
+  onAddSubAccount,
+  signerFn,
+}: AddSubAccountWithoutKeysProps) {
+  const [subAccount, setSubAccount] = useState<string>();
+
+  const handleAddSubAccount = useCallback(async () => {
+    if (!sdk) {
+      return;
+    }
+
+    const { account } = await signerFn();
+
+    if (!account) {
+      throw new Error('Could not get owner account');
+    }
+
+    const provider = sdk.getProvider();
+    await provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: numberToHex(84532) }],
+    });
+
+    const response = (await provider.request({
+      method: 'wallet_addSubAccount',
+      params: [
+        {
+          version: '1',
+          account: {
+            type: 'create',
+          },
+        },
+      ],
+    })) as { address: string };
+
+    console.info('response', response);
+    setSubAccount(response.address);
+    onAddSubAccount(response.address);
+  }, [sdk, onAddSubAccount, signerFn]);
+
+  return (
+    <>
+      <Button w="full" onClick={handleAddSubAccount}>
+        Add Address (Without Keys)
+      </Button>
+      {subAccount && (
+        <Box
+          as="pre"
+          w="full"
+          p={2}
+          bg="gray.900"
+          borderRadius="md"
+          border="1px solid"
+          borderColor="gray.700"
+        >
+          {JSON.stringify(subAccount, null, 2)}
+        </Box>
+      )}
+    </>
+  );
+}

--- a/examples/testapp/src/pages/add-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/add-sub-account/index.page.tsx
@@ -16,6 +16,7 @@ import { useEIP1193Provider } from '../../context/EIP1193ProviderContextProvider
 import { unsafe_generateOrLoadPrivateKey } from '../../utils/unsafe_generateOrLoadPrivateKey';
 import { AddOwner } from './components/AddOwner';
 import { AddSubAccount } from './components/AddSubAccount';
+import { AddSubAccountWithoutKeys } from './components/AddSubAccountWithoutKeys';
 import { Connect } from './components/Connect';
 import { GenerateNewSigner } from './components/GenerateNewSigner';
 import { GrantSpendPermission } from './components/GrantSpendPermission';
@@ -76,6 +77,11 @@ export default function SubAccounts() {
         </FormControl>
         <Connect sdk={sdk} />
         <AddSubAccount
+          sdk={sdk}
+          onAddSubAccount={setSubAccountAddress}
+          signerFn={getSubAccountSigner}
+        />
+        <AddSubAccountWithoutKeys
           sdk={sdk}
           onAddSubAccount={setSubAccountAddress}
           signerFn={getSubAccountSigner}

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -496,7 +496,7 @@ export class SCWSigner implements Signer {
       Array.isArray(request.params) &&
       request.params.length > 0 &&
       request.params[0].account &&
-      request.params[0].type === 'create'
+      request.params[0].account.type === 'create'
     ) {
       let keys: { type: string; publicKey: string }[];
       if (request.params[0].account.keys && request.params[0].account.keys.length > 0) {


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
Fixed the population of the `account.keys` field if not present in `wallet_addSubAccount` params

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
Manual testing – updated playground
Fixed tests to be more comprehensive
