### PR TITLE
fix: new owner invalid signature

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -595,17 +595,17 @@ export class SCWSigner implements Signer {
         ? ownerAccount.account.address
         : ownerAccount.account.publicKey;
 
-    const ownerIndex = await findOwnerIndex({
+    let ownerIndex = await findOwnerIndex({
       address: subAccount.address,
-      publicKey,
-      client,
       factory: subAccount.factory,
       factoryData: subAccount.factoryData,
+      publicKey,
+      client,
     });
 
     if (ownerIndex === -1) {
       try {
-        await handleAddSubAccountOwner({
+        ownerIndex = await handleAddSubAccountOwner({
           ownerAccount: ownerAccount.account,
           globalAccountRequest: this.sendRequestToPopup.bind(this),
         });
@@ -622,6 +622,7 @@ export class SCWSigner implements Signer {
       factoryData: subAccount.factoryData,
       parentAddress: globalAccountAddress,
       attribution: dataSuffix ? { suffix: dataSuffix } : undefined,
+      ownerIndex,
     });
 
     try {

--- a/packages/wallet-sdk/src/sign/scw/utils/handleAddSubAccountOwner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/handleAddSubAccountOwner.test.ts
@@ -67,7 +67,7 @@ describe('handleAddSubAccountOwner', () => {
         ownerAccount: mockOwnerAccount,
         globalAccountRequest: mockGlobalAccountRequest,
       })
-    ).rejects.toThrow(standardErrors.rpc.internal("failed to add owner to sub account"));
+    ).rejects.toThrow(standardErrors.rpc.internal("add owner call failed"));
   });
 
   it('should successfully add owner when all conditions are met', async () => {

--- a/packages/wallet-sdk/src/sign/scw/utils/handleAddSubAccountOwner.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/handleAddSubAccountOwner.ts
@@ -101,19 +101,22 @@ export async function handleAddSubAccountOwner({
     id: callsId,
   });
 
-  if (callsResult.status === "success") {
-    const ownerIndex = await findOwnerIndex({
-      address: subAccount.address,
-      publicKey:
-        ownerAccount.type === "local" && ownerAccount.address
-          ? ownerAccount.address
-          : ownerAccount.publicKey,
-      client,
-    });
-    if (ownerIndex !== -1) {
-      return;
-    }
-  } else {
-    throw standardErrors.rpc.internal("failed to add owner to sub account");
+  if (callsResult.status !== 'success') {
+    throw standardErrors.rpc.internal("add owner call failed");
   }
+
+  const ownerIndex = await findOwnerIndex({
+    address: subAccount.address,
+    publicKey:
+      ownerAccount.type === "local" && ownerAccount.address
+        ? ownerAccount.address
+        : ownerAccount.publicKey,
+    client,
+  });
+
+  if (ownerIndex === -1) {
+    throw standardErrors.rpc.internal("failed to find owner index");
+  }
+
+  return ownerIndex;
 }


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
The local sub account owner index was not being passed to the sub account request handler, so all signatures would be encoded with index 1, resulting in invalid signatures for owners not at index 1. 

- This has been fixed by updating `SCWSigner` to always pass the calculated owner index to the sub account request handler. 
- The `handleAddSubAccountOwner` function was also updated to return the new owner index which is also passed into the sub account request handler

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
Manual testing
