### PR TITLE
refactor: rename spend limit back to spend permission

### DIFF
--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -12,7 +12,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { getCryptoKeyAccount } from '@coinbase/wallet-sdk';
-import { SpendLimitConfig } from '@coinbase/wallet-sdk/dist/core/provider/interface';
+import { SpendPermissionConfig } from '@coinbase/wallet-sdk/dist/core/provider/interface';
 import React, { useEffect, useState } from 'react';
 import { createPublicClient, http, numberToHex, parseEther } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
@@ -215,21 +215,21 @@ export default function AutoSubAccount() {
     }
   };
 
-  const handleSetDefaultSpendLimits = (value: string) => {
-    const defaultSpendLimits = {
+  const handleSetDefaultSpendPermissions = (value: string) => {
+    const defaultSpendPermissions = {
       [baseSepolia.id]: [
         {
           token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
           allowance: '0x2386F26FC10000',
           period: 86400,
-        } as SpendLimitConfig,
+        } as SpendPermissionConfig,
       ],
     };
 
     if (value === 'true') {
-      setSubAccountsConfig((prev) => ({ ...prev, defaultSpendLimits }));
+      setSubAccountsConfig((prev) => ({ ...prev, defaultSpendPermissions }));
     } else {
-      setSubAccountsConfig((prev) => ({ ...prev, defaultSpendLimits: {} }));
+      setSubAccountsConfig((prev) => ({ ...prev, defaultSpendPermissions: {} }));
     }
   };
 
@@ -327,10 +327,10 @@ export default function AutoSubAccount() {
           </RadioGroup>
         </FormControl>
         <FormControl>
-          <FormLabel>Default Spend Limit</FormLabel>
+          <FormLabel>Default Spend Permissions</FormLabel>
           <RadioGroup
-            value={subAccountsConfig?.defaultSpendLimits?.[baseSepolia.id] ? 'true' : 'false'}
-            onChange={handleSetDefaultSpendLimits}
+            value={subAccountsConfig?.defaultSpendPermissions?.[baseSepolia.id] ? 'true' : 'false'}
+            onChange={handleSetDefaultSpendPermissions}
           >
             <Stack direction="row">
               <Radio value="true">Enabled</Radio>

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -35,7 +35,7 @@ export interface ProviderInterface extends ProviderEventEmitter {
 
 export type ProviderEventCallback = ProviderInterface['emit'];
 
-export type SpendLimitConfig = {
+export type SpendPermissionConfig = {
   token: Address;
   allowance: Hex;
   period: number;
@@ -92,10 +92,10 @@ export type SubAccountOptions = {
    */
   toOwnerAccount?: ToOwnerAccountFn;
   /**
-   * Spend limits requested on app connect if a matching existing one does not exist.
+   * Spend permissions requested on app connect if a matching existing one does not exist.
    * Only supports native chain tokens currently.
    */
-  defaultSpendLimits?: Record<number, SpendLimitConfig[]>;
+  defaultSpendPermissions?: Record<number, SpendPermissionConfig[]>;
 };
 
 export interface ConstructorOptions {

--- a/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
+++ b/packages/wallet-sdk/src/core/rpc/coinbase_fetchSpendPermissions.ts
@@ -12,7 +12,7 @@ export type EmptyFetchPermissionsRequest = Omit<FetchPermissionsRequest, 'params
 /**
  * Represents a spending permission with limits
  */
-export type SpendLimit = {
+export type SpendPermission = {
   /** UTC timestamp for when the permission was granted */
   createdAt?: number;
   /** Hash of the permission in hex format */
@@ -45,5 +45,5 @@ export type SpendLimit = {
 };
 
 export type FetchPermissionsResponse = {
-  permissions: SpendLimit[];
+  permissions: SpendPermission[];
 };

--- a/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
+++ b/packages/wallet-sdk/src/core/rpc/wallet_connect.ts
@@ -1,6 +1,6 @@
 import { SerializedEthereumRpcError } from ':core/error/utils.js';
-import { SpendLimitConfig } from ':core/provider/interface.js';
-import { SpendLimit } from './coinbase_fetchSpendPermissions.js';
+import { SpendPermissionConfig } from ':core/provider/interface.js';
+import { SpendPermission } from './coinbase_fetchSpendPermissions.js';
 import { AddSubAccountAccount } from './wallet_addSubAccount.js';
 
 export type SignInWithEthereumCapabilityRequest = {
@@ -23,7 +23,7 @@ export type SignInWithEthereumCapabilityResponse = {
   signature: `0x${string}`;
 };
 
-export type SpendLimitsCapabilityRequest = Record<number, SpendLimitConfig[]>;
+export type SpendPermissionsCapabilityRequest = Record<number, SpendPermissionConfig[]>;
 
 export type AddSubAccountCapabilityRequest = {
   account: AddSubAccountAccount;
@@ -35,8 +35,8 @@ export type AddSubAccountCapabilityResponse = {
   factoryData?: `0x${string}`;
 };
 
-export type SpendLimitsCapabilityResponse = {
-  permissions: SpendLimit[];
+export type SpendPermissionsCapabilityResponse = {
+  permissions: SpendPermission[];
 };
 
 export type WalletConnectRequest = {
@@ -48,7 +48,7 @@ export type WalletConnectRequest = {
       // Optional capabilities to request (e.g. Sign In With Ethereum).
       capabilities?: {
         addSubAccount?: AddSubAccountCapabilityRequest;
-        spendLimits?: SpendLimitsCapabilityRequest;
+        spendPermissions?: SpendPermissionsCapabilityRequest;
         signInWithEthereum?: SignInWithEthereumCapabilityRequest;
       };
     },
@@ -62,7 +62,7 @@ export type WalletConnectResponse = {
     // Capabilities granted that is associated with this account.
     capabilities?: {
       subAccounts?: AddSubAccountCapabilityResponse[] | SerializedEthereumRpcError;
-      spendLimits?: SpendLimitsCapabilityResponse | SerializedEthereumRpcError;
+      spendPermissions?: SpendPermissionsCapabilityResponse | SerializedEthereumRpcError;
       signInWithEthereum?: SignInWithEthereumCapabilityResponse | SerializedEthereumRpcError;
     };
   }[];

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
@@ -57,7 +57,7 @@ export function createCoinbaseWalletSDK(params: CreateCoinbaseWalletSDKOptions) 
   store.subAccountsConfig.set({
     toOwnerAccount: params.subAccounts?.toOwnerAccount,
     enableAutoSubAccounts: params.subAccounts?.enableAutoSubAccounts,
-    defaultSpendLimits: params.subAccounts?.defaultSpendLimits,
+    defaultSpendPermissions: params.subAccounts?.defaultSpendPermissions,
   });
 
   // set the options in the store

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.test.ts
@@ -5,7 +5,7 @@ import { CB_KEYS_URL } from ':core/constants.js';
 import { standardErrors } from ':core/error/errors.js';
 import { EncryptedData, RPCResponseMessage } from ':core/message/RPCMessage.js';
 import { AppMetadata, ProviderEventCallback, RequestArguments } from ':core/provider/interface.js';
-import { SpendLimit } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
 import { getClient } from ':store/chain-clients/utils.js';
 import { store } from ':store/store.js';
 import {
@@ -268,7 +268,7 @@ describe('SCWSigner', () => {
         },
         chains: [],
         keys: {},
-        spendLimits: [],
+        spendPermissions: [],
         config: {
           metadata: mockMetadata,
           preference: { keysUrl: CB_KEYS_URL, options: 'all' },
@@ -682,7 +682,7 @@ describe('SCWSigner', () => {
         params: [],
       };
 
-      const mockSpendLimits = [
+      const mockSpendPermissions = [
         {
           permissionHash: '0xPermissionHash',
           signature: '0xSignature',
@@ -708,8 +708,8 @@ describe('SCWSigner', () => {
                       factoryData: '0x',
                     },
                   ],
-                  spendLimits: {
-                    permissions: mockSpendLimits,
+                  spendPermissions: {
+                    permissions: mockSpendPermissions,
                   },
                 },
               },
@@ -743,8 +743,8 @@ describe('SCWSigner', () => {
                   factoryData: '0x',
                 },
               ],
-              spendLimits: {
-                permissions: mockSpendLimits,
+              spendPermissions: {
+                permissions: mockSpendPermissions,
               },
             },
           },
@@ -1121,7 +1121,7 @@ describe('SCWSigner', () => {
         },
         chains: [],
         keys: {},
-        spendLimits: [],
+        spendPermissions: [],
         config: {
           metadata: mockMetadata,
           preference: { keysUrl: CB_KEYS_URL, options: 'all' },
@@ -1216,7 +1216,7 @@ describe('SCWSigner', () => {
         },
         chains: [],
         keys: {},
-        spendLimits: [],
+        spendPermissions: [],
         config: {
           metadata: mockMetadata,
           preference: { keysUrl: CB_KEYS_URL, options: 'all' },
@@ -1268,7 +1268,7 @@ describe('SCWSigner', () => {
         },
         chains: [],
         keys: {},
-        spendLimits: [],
+        spendPermissions: [],
         config: {
           metadata: mockMetadata,
           preference: { keysUrl: CB_KEYS_URL, options: 'all' },
@@ -1317,7 +1317,7 @@ describe('SCWSigner', () => {
   });
 
   describe('coinbase_fetchPermissions', () => {
-    const mockSpendLimits = [
+    const mockSpendPermissions = [
       {
         permissionHash: '0xPermissionHash',
         signature: '0xSignature',
@@ -1327,7 +1327,7 @@ describe('SCWSigner', () => {
         },
         chainId: 10,
       },
-    ] as [SpendLimit];
+    ] as [SpendPermission];
 
     beforeEach(() => {
       vi.spyOn(store, 'getState').mockImplementation(() => ({
@@ -1340,7 +1340,7 @@ describe('SCWSigner', () => {
         },
         chains: [],
         keys: {},
-        spendLimits: [],
+        spendPermissions: [],
         config: {
           metadata: mockMetadata,
           preference: { keysUrl: CB_KEYS_URL, options: 'all' },
@@ -1349,7 +1349,7 @@ describe('SCWSigner', () => {
       }));
 
       (fetchRPCRequest as Mock).mockResolvedValue({
-        permissions: mockSpendLimits,
+        permissions: mockSpendPermissions,
       });
     });
 
@@ -1362,11 +1362,11 @@ describe('SCWSigner', () => {
 
       signer['accounts'] = ['0xAddress']; // mock the logged in state
 
-      const mockSetSpendLimits = vi.spyOn(store.spendLimits, 'set');
+      const mockSetSpendPermissions = vi.spyOn(store.spendPermissions, 'set');
 
       await signer.request(mockRequest);
 
-      expect(mockSetSpendLimits).toHaveBeenCalledWith(mockSpendLimits);
+      expect(mockSetSpendPermissions).toHaveBeenCalledWith(mockSpendPermissions);
     });
   });
 });

--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -218,7 +218,7 @@ export class SCWSigner implements Signer {
           CB_WALLET_RPC_URL
         )) as FetchPermissionsResponse;
         const requestedChainId = hexToNumber(completeRequest.params?.[0].chainId);
-        store.spendLimits.set(
+        store.spendPermissions.set(
           permissions.permissions.map((permission) => ({
             ...permission,
             chainId: requestedChainId,
@@ -296,10 +296,10 @@ export class SCWSigner implements Signer {
           this.accounts = prependWithoutDuplicates(this.accounts, subAccount.address);
         }
 
-        const spendLimits = response?.accounts?.[0].capabilities?.spendLimits;
+        const spendPermissions = response?.accounts?.[0].capabilities?.spendPermissions;
 
-        if (spendLimits && 'permissions' in spendLimits) {
-          store.spendLimits.set(spendLimits?.permissions);
+        if (spendPermissions && 'permissions' in spendPermissions) {
+          store.spendPermissions.set(spendPermissions?.permissions);
         }
 
         this.callback?.('accountsChanged', accounts_);

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -326,7 +326,7 @@ describe('fillMissingParamsForFetchPermissions', () => {
       subAccount: { address: '0x456' },
       chains: [],
       keys: {},
-      spendLimits: [],
+      spendPermissions: [],
       config: {
         version: '1.0.0',
       },
@@ -478,7 +478,7 @@ describe('prependWithoutDuplicates', () => {
 
 describe('getCachedWalletConnectResponse', () => {
   beforeEach(() => {
-    vi.spyOn(store.spendLimits, 'get').mockReturnValue([]);
+    vi.spyOn(store.spendPermissions, 'get').mockReturnValue([]);
     vi.spyOn(store.subAccounts, 'get').mockReturnValue(undefined);
     vi.spyOn(store.account, 'get').mockReturnValue({ accounts: undefined });
   });
@@ -488,7 +488,7 @@ describe('getCachedWalletConnectResponse', () => {
     expect(result).toBeNull();
   });
 
-  it('should return accounts with no capabilities if no spend limits or sub accounts', async () => {
+  it('should return accounts with no capabilities if no spend permissions or sub accounts', async () => {
     vi.spyOn(store.account, 'get').mockReturnValue({ accounts: ['0x123', '0x456'] });
 
     const result = await getCachedWalletConnectResponse();
@@ -498,14 +498,14 @@ describe('getCachedWalletConnectResponse', () => {
           address: '0x123',
           capabilities: {
             subAccounts: undefined,
-            spendLimits: undefined,
+            spendPermissions: undefined,
           },
         },
         {
           address: '0x456',
           capabilities: {
             subAccounts: undefined,
-            spendLimits: undefined,
+            spendPermissions: undefined,
           },
         },
       ],
@@ -533,16 +533,16 @@ describe('getCachedWalletConnectResponse', () => {
                 factoryData: '0xdata',
               },
             ],
-            spendLimits: undefined,
+            spendPermissions: undefined,
           },
         },
       ],
     });
   });
 
-  it('should include spend limits capability if spend limits exist', async () => {
+  it('should include spend permissions capability if spend permissions exist', async () => {
     vi.spyOn(store.account, 'get').mockReturnValue({ accounts: ['0x123'] });
-    vi.spyOn(store.spendLimits, 'get').mockReturnValue([
+    vi.spyOn(store.spendPermissions, 'get').mockReturnValue([
       {
         signature: '0xsig1',
         chainId: 1,
@@ -582,7 +582,7 @@ describe('getCachedWalletConnectResponse', () => {
           address: '0x123',
           capabilities: {
             subAccounts: undefined,
-            spendLimits: {
+            spendPermissions: {
               permissions: [
                 {
                   signature: '0xsig1',
@@ -622,14 +622,14 @@ describe('getCachedWalletConnectResponse', () => {
     });
   });
 
-  it('should include both sub account and spend limits capabilities if both exist', async () => {
+  it('should include both sub account and spend permissions capabilities if both exist', async () => {
     vi.spyOn(store.account, 'get').mockReturnValue({ accounts: ['0x123'] });
     vi.spyOn(store.subAccounts, 'get').mockReturnValue({
       address: '0xsub',
       factory: '0xfactory',
       factoryData: '0xdata',
     });
-    vi.spyOn(store.spendLimits, 'get').mockReturnValue([
+    vi.spyOn(store.spendPermissions, 'get').mockReturnValue([
       {
         signature: '0xsig1',
         chainId: 1,
@@ -660,7 +660,7 @@ describe('getCachedWalletConnectResponse', () => {
                 factoryData: '0xdata',
               },
             ],
-            spendLimits: {
+            spendPermissions: {
               permissions: [
                 {
                   signature: '0xsig1',

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -164,8 +164,8 @@ export async function initSubAccountConfig() {
     };
   }
 
-  if (config.defaultSpendLimits) {
-    capabilities.spendLimits = config.defaultSpendLimits;
+  if (config.defaultSpendPermissions) {
+    capabilities.spendPermissions = config.defaultSpendPermissions;
   }
 
   // Store the owner account and capabilities in the non-persisted config
@@ -562,7 +562,7 @@ export function prependWithoutDuplicates<T>(array: T[], item: T): T[] {
 }
 
 export async function getCachedWalletConnectResponse(): Promise<WalletConnectResponse | null> {
-  const spendLimits = store.spendLimits.get();
+  const spendPermissions = store.spendPermissions.get();
   const subAccount = store.subAccounts.get();
   const accounts = store.account.get().accounts;
 
@@ -575,7 +575,7 @@ export async function getCachedWalletConnectResponse(): Promise<WalletConnectRes
       address: account,
       capabilities: {
         subAccounts: subAccount ? [subAccount] : undefined,
-        spendLimits: spendLimits.length > 0 ? { permissions: spendLimits } : undefined,
+        spendPermissions: spendPermissions.length > 0 ? { permissions: spendPermissions } : undefined,
       },
     })
   );

--- a/packages/wallet-sdk/src/store/store.ts
+++ b/packages/wallet-sdk/src/store/store.ts
@@ -1,5 +1,5 @@
 import { AppMetadata, Preference, SubAccountOptions } from ':core/provider/interface.js';
-import { SpendLimit } from ':core/rpc/coinbase_fetchSpendPermissions.js';
+import { SpendPermission } from ':core/rpc/coinbase_fetchSpendPermissions.js';
 import { OwnerAccount } from ':core/type/index.js';
 import { Address, Hex } from 'viem';
 import { createJSONStorage, persist } from 'zustand/middleware';
@@ -93,13 +93,13 @@ const createSubAccountConfigSlice: StateCreator<StoreState, [], [], SubAccountCo
   };
 };
 
-type SpendLimitsSlice = {
-  spendLimits: SpendLimit[];
+type SpendPermissionsSlice = {
+  spendPermissions: SpendPermission[];
 };
 
-const createSpendLimitsSlice: StateCreator<StoreState, [], [], SpendLimitsSlice> = () => {
+const createSpendPermissionsSlice: StateCreator<StoreState, [], [], SpendPermissionsSlice> = () => {
   return {
-    spendLimits: [],
+    spendPermissions: [],
   };
 };
 
@@ -126,7 +126,7 @@ export type StoreState = MergeTypes<
     AccountSlice,
     SubAccountSlice,
     SubAccountConfigSlice,
-    SpendLimitsSlice,
+    SpendPermissionsSlice,
     ConfigSlice,
   ]
 >;
@@ -138,7 +138,7 @@ export const sdkstore = createStore(
       ...createKeysSlice(...args),
       ...createAccountSlice(...args),
       ...createSubAccountSlice(...args),
-      ...createSpendLimitsSlice(...args),
+      ...createSpendPermissionsSlice(...args),
       ...createConfigSlice(...args),
       ...createSubAccountConfigSlice(...args),
     }),
@@ -153,7 +153,7 @@ export const sdkstore = createStore(
           keys: state.keys,
           account: state.account,
           subAccount: state.subAccount,
-          spendLimits: state.spendLimits,
+          spendPermissions: state.spendPermissions,
           config: state.config,
         } as StoreState;
       },
@@ -193,14 +193,14 @@ export const subAccounts = {
   },
 };
 
-export const spendLimits = {
-  get: () => sdkstore.getState().spendLimits,
-  set: (spendLimits: SpendLimit[]) => {
-    sdkstore.setState({ spendLimits });
+export const spendPermissions = {
+  get: () => sdkstore.getState().spendPermissions,
+  set: (spendPermissions: SpendPermission[]) => {
+    sdkstore.setState({ spendPermissions });
   },
   clear: () => {
     sdkstore.setState({
-      spendLimits: [],
+      spendPermissions: [],
     });
   },
 };
@@ -253,7 +253,7 @@ export const config = {
 const actions = {
   subAccounts,
   subAccountsConfig,
-  spendLimits,
+  spendPermissions,
   account,
   chains,
   keys,


### PR DESCRIPTION
### _Summary_

renaming spend limits back to spend permissions

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

Unit tests, playground with updated CBSW wallet

