### PR TITLE
fix: grant spend permission button on add-sub-account page

### DIFF
--- a/examples/testapp/src/pages/add-sub-account/components/GrantSpendPermission.tsx
+++ b/examples/testapp/src/pages/add-sub-account/components/GrantSpendPermission.tsx
@@ -108,7 +108,7 @@ export function GrantSpendPermission({
 
       const response = await provider?.request({
         method: 'eth_signTypedData_v4',
-        params: [accounts[0] as Address, spendPermission],
+        params: [accounts[1] as Address, spendPermission],
       });
       console.info('response', response);
       localStorage.setItem('cbwsdk.demo.spend-permission.signature', response as Hex);


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
Fixes a bug where the sub account was signing its own spend permission in the playground

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
Manual testing
