### PR TITLE
websocket refactor for improved connection reliability

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkConnection.test.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkConnection.test.ts
@@ -5,44 +5,81 @@ import { APP_VERSION_KEY, WALLET_USER_NAME_KEY } from '../constants.js';
 import { WalletLinkSession } from '../type/WalletLinkSession.js';
 import { WalletLinkCipher } from './WalletLinkCipher.js';
 import {
-  WalletLinkConnection,
-  WalletLinkConnectionUpdateListener,
+    WalletLinkConnection,
+    WalletLinkConnectionUpdateListener,
 } from './WalletLinkConnection.js';
+import { ConnectionState } from './WalletLinkWebSocket.js';
 
 const decryptMock = vi.fn().mockImplementation((text) => Promise.resolve(`decrypted ${text}`));
 
 vi.spyOn(WalletLinkCipher.prototype, 'decrypt').mockImplementation(decryptMock);
+
+const HEARTBEAT_INTERVAL = 10000;
+
+// Mock WebSocket to prevent real connections
+vi.mock('./WalletLinkWebSocket.js', () => {
+  return {
+    ConnectionState: {
+      DISCONNECTED: 'disconnected',
+      CONNECTING: 'connecting',
+      CONNECTED: 'connected',
+    },
+    WalletLinkWebSocket: vi.fn().mockImplementation(() => {
+      const mockWs = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn(),
+        sendData: vi.fn(),
+        setConnectionStateListener: vi.fn(),
+        setIncomingDataListener: vi.fn(),
+        cleanup: vi.fn(),
+      };
+      return mockWs;
+    }),
+  };
+});
+
+// Mock window timer functions
+beforeEach(() => {
+  vi.stubGlobal('setInterval', vi.fn());
+  vi.stubGlobal('clearInterval', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('WalletLinkConnection', () => {
   const session = WalletLinkSession.create(new ScopedLocalStorage('walletlink', 'test'));
 
   let connection: WalletLinkConnection;
   let listener: WalletLinkConnectionUpdateListener;
-  let mockWorker: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockWorker = {
-      postMessage: vi.fn(),
-      terminate: vi.fn(),
-      addEventListener: vi.fn(),
+    listener = {
+      linkedUpdated: vi.fn(),
+      handleWeb3ResponseMessage: vi.fn(),
+      chainUpdated: vi.fn(),
+      accountUpdated: vi.fn(),
+      metadataUpdated: vi.fn(),
+      resetAndReload: vi.fn(),
     };
-    global.Worker = vi.fn().mockImplementation(() => mockWorker);
 
     connection = new WalletLinkConnection({
       session,
       linkAPIUrl: 'http://link-api-url',
-      listener: {
-        linkedUpdated: vi.fn(),
-        handleWeb3ResponseMessage: vi.fn(),
-        chainUpdated: vi.fn(),
-        accountUpdated: vi.fn(),
-        metadataUpdated: vi.fn(),
-        resetAndReload: vi.fn(),
-      },
+      listener,
     });
-    listener = (connection as any).listener;
+  });
+
+  afterEach(async () => {
+    // Only destroy if connection exists and hasn't been destroyed
+    if (connection && !(connection as any).destroyed) {
+      // Mock the makeRequest to prevent timeout errors
+      vi.spyOn(connection as any, 'makeRequest').mockResolvedValue({ type: 'SetSessionConfigOK' });
+      await connection.destroy();
+    }
   });
 
   describe('incomingDataListener', () => {
@@ -60,7 +97,12 @@ describe('WalletLinkConnection', () => {
         },
       };
 
-      (connection as any).ws.incomingDataListener?.({
+      // Get the incoming data listener from the mock
+      const ws = (connection as any).ws;
+      const incomingDataListener = ws.setIncomingDataListener.mock.calls[0][0];
+
+      // Call the listener with the session config
+      incomingDataListener({
         ...sessionConfig,
         type: 'SessionConfigUpdated',
       });
@@ -151,76 +193,400 @@ describe('WalletLinkConnection', () => {
     });
   });
 
-  describe('Heartbeat Worker Management', () => {
-    it('should create a heartbeat worker when startHeartbeat is called', () => {
-      (connection as any).startHeartbeat();
+  describe('visibility and focus handling', () => {
+    let visibilityChangeHandler: () => void;
+    let focusHandler: () => void;
+    let pageshowHandler: (event: PageTransitionEvent) => void;
 
-      expect(global.Worker).toHaveBeenCalledWith(expect.any(URL), { type: 'module' });
-      
-      expect(mockWorker.postMessage).toHaveBeenCalledWith({ type: 'start' });
+    beforeEach(() => {
+      // Capture event handlers
+      const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+      const windowAddEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+      // Create a new connection to capture the handlers
+      connection = new WalletLinkConnection({
+        session,
+        linkAPIUrl: 'http://link-api-url',
+        listener,
+      });
+
+      // Extract the handlers
+      visibilityChangeHandler = addEventListenerSpy.mock.calls.find(
+        call => call[0] === 'visibilitychange'
+      )?.[1] as () => void;
+
+      focusHandler = windowAddEventListenerSpy.mock.calls.find(
+        call => call[0] === 'focus'
+      )?.[1] as () => void;
+
+      pageshowHandler = windowAddEventListenerSpy.mock.calls.find(
+        call => call[0] === 'pageshow'
+      )?.[1] as (event: PageTransitionEvent) => void;
     });
 
-    it('should stop heartbeat worker when stopHeartbeat is called', () => {
-      (connection as any).startHeartbeat();
-      
-      vi.clearAllMocks();
-
-      (connection as any).stopHeartbeat();
-
-      expect(mockWorker.postMessage).toHaveBeenCalledWith({ type: 'stop' });
-      expect(mockWorker.terminate).toHaveBeenCalled();
+    it('should set up visibility change and focus handlers on construction', () => {
+      expect(visibilityChangeHandler).toBeDefined();
+      expect(focusHandler).toBeDefined();
+      expect(pageshowHandler).toBeDefined();
     });
 
-    it('should terminate existing worker before creating new one', () => {
-      (connection as any).startHeartbeat();
-      const firstWorker = mockWorker;
-
-      const secondWorker = {
-        postMessage: vi.fn(),
-        terminate: vi.fn(),
-        addEventListener: vi.fn(),
-      };
-      global.Worker = vi.fn().mockImplementation(() => secondWorker);
-
-      (connection as any).startHeartbeat();
-
-      // First worker should be terminated
-      expect(firstWorker.terminate).toHaveBeenCalled();
+    it('should reconnect with fresh WebSocket when document becomes visible and disconnected', () => {
+      const reconnectSpy = vi.spyOn(connection as any, 'reconnectWithFreshWebSocket');
       
-      // New worker should be created and started
-      expect(secondWorker.postMessage).toHaveBeenCalledWith({ type: 'start' });
+      // Set disconnected state
+      (connection as any)._connected = false;
+      
+      // Mock document.hidden as false (visible)
+      Object.defineProperty(document, 'hidden', {
+        value: false,
+        writable: true,
+      });
+
+      visibilityChangeHandler();
+
+      expect(reconnectSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle heartbeat messages from worker', () => {
+    it('should send heartbeat when document becomes visible and connected', () => {
       const heartbeatSpy = vi.spyOn(connection as any, 'heartbeat').mockImplementation(() => {});
+      
+      // Set connected state
+      (connection as any)._connected = true;
+      
+      // Mock document.hidden as false (visible)
+      Object.defineProperty(document, 'hidden', {
+        value: false,
+        writable: true,
+      });
 
-      (connection as any).startHeartbeat();
+      visibilityChangeHandler();
 
-      const messageListener = mockWorker.addEventListener.mock.calls.find(
-        (call: any[]) => call[0] === 'message'
-      )?.[1];
-
-      expect(messageListener).toBeDefined();
-
-      messageListener({ data: { type: 'heartbeat' } });
-
-      expect(heartbeatSpy).toHaveBeenCalled();
+      expect(heartbeatSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle stop when no worker exists', () => {
-      expect(() => {
-        (connection as any).stopHeartbeat();
-      }).not.toThrow();
+    it('should not reconnect when document is hidden', () => {
+      const reconnectSpy = vi.spyOn(connection as any, 'reconnectWithFreshWebSocket');
+      
+      // Mock document.hidden as true
+      Object.defineProperty(document, 'hidden', {
+        value: true,
+        writable: true,
+      });
 
-      expect(mockWorker.postMessage).not.toHaveBeenCalled();
-      expect(mockWorker.terminate).not.toHaveBeenCalled();
+      visibilityChangeHandler();
+
+      expect(reconnectSpy).not.toHaveBeenCalled();
     });
 
-    it('should setup worker listeners correctly', () => {
-      (connection as any).startHeartbeat();
+    it('should reconnect on focus event when disconnected', () => {
+      const reconnectSpy = vi.spyOn(connection as any, 'reconnectWithFreshWebSocket');
+      
+      // Set disconnected state
+      (connection as any)._connected = false;
+      (connection as any).destroyed = false;
 
-      expect(mockWorker.addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
-      expect(mockWorker.addEventListener).toHaveBeenCalledWith('error', expect.any(Function));
+      focusHandler();
+
+      expect(reconnectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not reconnect on focus event when connected', () => {
+      const reconnectSpy = vi.spyOn(connection as any, 'reconnectWithFreshWebSocket');
+      
+      // Set connected state
+      (connection as any)._connected = true;
+
+      focusHandler();
+
+      expect(reconnectSpy).not.toHaveBeenCalled();
+    });
+
+    it('should handle pageshow event with persisted flag', () => {
+      const reconnectSpy = vi.spyOn(connection as any, 'reconnectWithFreshWebSocket');
+      
+      // Set disconnected state
+      (connection as any)._connected = false;
+
+      const event = new Event('pageshow') as PageTransitionEvent;
+      Object.defineProperty(event, 'persisted', { value: true });
+
+      pageshowHandler(event);
+
+      expect(reconnectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should remove event listeners on destroy', async () => {
+      const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+      const windowRemoveEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+      // Mock makeRequest to prevent timeout
+      vi.spyOn(connection as any, 'makeRequest').mockResolvedValue({ type: 'SetSessionConfigOK' });
+
+      await connection.destroy();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('visibilitychange', visibilityChangeHandler);
+      expect(windowRemoveEventListenerSpy).toHaveBeenCalledWith('focus', focusHandler);
     });
   });
+
+  describe('reconnectWithFreshWebSocket', () => {
+    it('should disconnect old WebSocket and create new one', () => {
+      const oldWs = (connection as any).ws;
+      const disconnectSpy = vi.spyOn(oldWs, 'disconnect');
+      
+      (connection as any).reconnectWithFreshWebSocket();
+
+      expect(disconnectSpy).toHaveBeenCalledTimes(1);
+      expect(oldWs.cleanup).toHaveBeenCalledTimes(1);
+      
+      // New WebSocket should be created
+      expect((connection as any).ws).not.toBe(oldWs);
+      // activeWsInstance should point to the new WebSocket
+      expect((connection as any).activeWsInstance).toBe((connection as any).ws);
+    });
+
+    it('should not reconnect if destroyed', () => {
+      (connection as any).destroyed = true;
+      const oldWs = (connection as any).ws;
+      const disconnectSpy = vi.spyOn(oldWs, 'disconnect');
+
+      (connection as any).reconnectWithFreshWebSocket();
+
+      expect(disconnectSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('WebSocket connection state handling', () => {
+    let ws: any;
+    let stateListener: (state: ConnectionState) => void;
+
+    beforeEach(() => {
+      ws = (connection as any).ws;
+      stateListener = ws.setConnectionStateListener.mock.calls[0][0];
+    });
+
+    it('should track active WebSocket instance', () => {
+      expect((connection as any).activeWsInstance).toBe(ws);
+    });
+
+    it('should ignore events from non-active WebSocket instances', async () => {
+      // Mock handleConnected to track if connection logic runs
+      const handleConnectedSpy = vi.spyOn(connection as any, 'handleConnected');
+      
+      // Create a different WebSocket instance
+      const oldWs = ws;
+      (connection as any).activeWsInstance = { different: 'instance' };
+      
+      // Trigger state change on old instance
+      await stateListener.call(oldWs, ConnectionState.CONNECTED);
+      
+      // Connection logic should not run for non-active instances
+      expect(handleConnectedSpy).not.toHaveBeenCalled();
+    });
+
+    it('should handle reconnection with delay', async () => {
+      vi.useFakeTimers();
+      
+      // First disconnection - no delay
+      (connection as any).reconnectAttempts = 0;
+      (connection as any).activeWsInstance = ws;
+      await stateListener(ConnectionState.DISCONNECTED);
+      
+      // Wait for the async reconnect function to execute
+      await vi.runAllTimersAsync();
+      expect((connection as any).reconnectAttempts).toBe(1);
+      
+      // Reset for second disconnection
+      (connection as any).isReconnecting = false;
+      (connection as any).activeWsInstance = ws;
+      (connection as any).destroyed = false;
+      
+      // Second disconnection - 3 second delay
+      await stateListener(ConnectionState.DISCONNECTED);
+      
+      // The reconnection should be delayed by 3 seconds
+      vi.advanceTimersByTime(2999);
+      expect((connection as any).reconnectAttempts).toBe(1); // Still 1, not incremented yet
+      
+      // Complete the delay and allow async operations
+      await vi.advanceTimersByTimeAsync(1);
+      expect((connection as any).reconnectAttempts).toBe(2);
+      
+      vi.useRealTimers();
+    });
+
+    it('should prevent concurrent reconnection attempts', async () => {
+      (connection as any).isReconnecting = true;
+      (connection as any).activeWsInstance = ws;
+      const createWebSocketSpy = vi.spyOn(connection as any, 'createWebSocket');
+      
+      await stateListener(ConnectionState.DISCONNECTED);
+      
+      expect(createWebSocketSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reset reconnect attempts on successful connection', async () => {
+      (connection as any).reconnectAttempts = 5;
+      (connection as any).activeWsInstance = ws;
+      vi.spyOn(connection as any, 'handleConnected').mockResolvedValue(true);
+      vi.spyOn(connection as any, 'fetchUnseenEventsAPI').mockResolvedValue([]);
+      
+      await stateListener(ConnectionState.CONNECTED);
+      
+      expect((connection as any).reconnectAttempts).toBe(0);
+    });
+
+    it('should cleanup old WebSocket on reconnection', async () => {
+      vi.useFakeTimers();
+      (connection as any).activeWsInstance = ws;
+      (connection as any).destroyed = false;
+      
+      await stateListener(ConnectionState.DISCONNECTED);
+      
+      // Wait for the async reconnect function to execute
+      await vi.runAllTimersAsync();
+      
+      expect(ws.cleanup).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it('should clear and restart heartbeat timer on connection state changes', async () => {
+      // Use the globally mocked functions
+      const clearIntervalMock = vi.mocked(clearInterval);
+      const setIntervalMock = vi.mocked(setInterval);
+      
+      // Mock setInterval to return a numeric ID
+      setIntervalMock.mockReturnValue(456 as any);
+      
+      // Mock successful connection
+      (connection as any).activeWsInstance = ws;
+      vi.spyOn(connection as any, 'handleConnected').mockResolvedValue(true);
+      vi.spyOn(connection as any, 'fetchUnseenEventsAPI').mockResolvedValue([]);
+      
+      // Simulate connected state
+      await stateListener(ConnectionState.CONNECTED);
+      expect(setIntervalMock).toHaveBeenCalledWith(expect.any(Function), HEARTBEAT_INTERVAL);
+      expect((connection as any).heartbeatIntervalId).toBe(456);
+      
+      // Simulate disconnected state
+      await stateListener(ConnectionState.DISCONNECTED);
+      expect(clearIntervalMock).toHaveBeenCalledWith(456);
+      expect((connection as any).heartbeatIntervalId).toBeUndefined();
+    });
+
+    it('should reset lastHeartbeatResponse on disconnect', async () => {
+      (connection as any).lastHeartbeatResponse = Date.now();
+      (connection as any).activeWsInstance = ws;
+      
+      await stateListener(ConnectionState.DISCONNECTED);
+      
+      expect((connection as any).lastHeartbeatResponse).toBe(0);
+    });
+
+    it('should send immediate heartbeat after connection', async () => {
+      vi.useFakeTimers();
+      const heartbeatSpy = vi.spyOn(connection as any, 'heartbeat').mockImplementation(() => {});
+      (connection as any).activeWsInstance = ws;
+      vi.spyOn(connection as any, 'handleConnected').mockResolvedValue(true);
+      vi.spyOn(connection as any, 'fetchUnseenEventsAPI').mockResolvedValue([]);
+      
+      // Mock setTimeout for the immediate heartbeat
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+      
+      await stateListener(ConnectionState.CONNECTED);
+      
+      // Check that setTimeout was called for immediate heartbeat
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
+      
+      // Execute the immediate heartbeat
+      vi.advanceTimersByTime(100);
+      expect(heartbeatSpy).toHaveBeenCalledTimes(1);
+      
+      vi.useRealTimers();
+    });
+
+
+  });
+
+  describe('heartbeat mechanism', () => {
+    beforeEach(() => {
+      // Mock makeRequest to prevent actual network calls
+      vi.spyOn(connection as any, 'makeRequest').mockResolvedValue({ type: 'Heartbeat' });
+    });
+
+    it('should update lastHeartbeatResponse on heartbeat', () => {
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+      
+      (connection as any).updateLastHeartbeat();
+      
+      expect((connection as any).lastHeartbeatResponse).toBe(now);
+    });
+
+    it('should handle heartbeat timeout and disconnect', () => {
+      const ws = (connection as any).ws;
+      const disconnectSpy = vi.spyOn(ws, 'disconnect');
+      
+      // Set last heartbeat response to more than 2 intervals ago
+      (connection as any).lastHeartbeatResponse = Date.now() - (HEARTBEAT_INTERVAL * 3);
+      (connection as any)._connected = true;
+      
+      (connection as any).heartbeat();
+      
+      // Should disconnect the WebSocket instead of calling reconnectWithFreshWebSocket
+      expect(disconnectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should send heartbeat message when connection is healthy', () => {
+      const ws = (connection as any).ws;
+      const sendDataSpy = vi.spyOn(ws, 'sendData');
+      
+      // Set recent heartbeat response
+      (connection as any).lastHeartbeatResponse = Date.now();
+      (connection as any)._connected = true;
+      
+      (connection as any).heartbeat();
+      
+      // Should send 'h' as heartbeat message
+      expect(sendDataSpy).toHaveBeenCalledWith('h');
+    });
+  });
+
+  describe('cleanup on destroy', () => {
+    beforeEach(() => {
+      // Mock makeRequest to prevent timeout errors
+      vi.spyOn(connection as any, 'makeRequest').mockResolvedValue({ type: 'SetSessionConfigOK' });
+    });
+
+    it('should cleanup WebSocket instance if cleanup method exists', async () => {
+      const ws = (connection as any).ws;
+      
+      await connection.destroy();
+      
+      expect(ws.cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear activeWsInstance on destroy', async () => {
+      expect((connection as any).activeWsInstance).toBeDefined();
+      
+      await connection.destroy();
+      
+      expect((connection as any).activeWsInstance).toBeUndefined();
+    });
+
+    it('should clear heartbeat interval on destroy', async () => {
+      // clearInterval is already mocked globally
+      const clearIntervalMock = vi.mocked(clearInterval);
+      
+      // Set up a heartbeat interval
+      (connection as any).heartbeatIntervalId = 123;
+      
+      await connection.destroy();
+      
+      expect(clearIntervalMock).toHaveBeenCalledWith(123);
+      expect((connection as any).heartbeatIntervalId).toBeUndefined();
+    });
+  });
+
+
 });

--- a/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkWebSocket.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/connection/WalletLinkWebSocket.ts
@@ -9,9 +9,15 @@ export enum ConnectionState {
 }
 
 export class WalletLinkWebSocket {
+  // used to differentiate instances
+  private static instanceCounter = 0;
+  private static activeInstances = new Set<number>();
+  private static pendingData: string[] = [];
+
+  private readonly instanceId: number;
   private readonly url: string;
   private webSocket: WebSocket | null = null;
-  private pendingData: string[] = [];
+  private isDisconnecting = false;
 
   private connectionStateListener?: (_: ConnectionState) => void;
   setConnectionStateListener(listener: (_: ConnectionState) => void): void {
@@ -33,6 +39,8 @@ export class WalletLinkWebSocket {
     private readonly WebSocketClass: typeof WebSocket = WebSocket
   ) {
     this.url = url.replace(/^http/, 'ws');
+    this.instanceId = WalletLinkWebSocket.instanceCounter++;
+    WalletLinkWebSocket.activeInstances.add(this.instanceId);
   }
 
   /**
@@ -42,6 +50,9 @@ export class WalletLinkWebSocket {
   public async connect() {
     if (this.webSocket) {
       throw new Error('webSocket object is not null');
+    }
+    if (this.isDisconnecting) {
+      throw new Error('WebSocket is disconnecting, cannot reconnect on same instance');
     }
     return new Promise<void>((resolve, reject) => {
       let webSocket: WebSocket;
@@ -54,17 +65,23 @@ export class WalletLinkWebSocket {
       this.connectionStateListener?.(ConnectionState.CONNECTING);
       webSocket.onclose = (evt) => {
         this.clearWebSocket();
-        reject(new Error(`websocket error ${evt.code}: ${evt.reason}`));
+
+        // Only reject the connection promise if we haven't connected yet
+        if (webSocket.readyState !== WebSocket.OPEN) {
+          reject(new Error(`websocket error ${evt.code}: ${evt.reason}`));
+        }
+
         this.connectionStateListener?.(ConnectionState.DISCONNECTED);
       };
+
       webSocket.onopen = (_) => {
         resolve();
         this.connectionStateListener?.(ConnectionState.CONNECTED);
 
-        if (this.pendingData.length > 0) {
-          const pending = [...this.pendingData];
+        if (WalletLinkWebSocket.pendingData.length > 0) {
+          const pending = [...WalletLinkWebSocket.pendingData];
           pending.forEach((data) => this.sendData(data));
-          this.pendingData = [];
+          WalletLinkWebSocket.pendingData = [];
         }
       };
       webSocket.onmessage = (evt) => {
@@ -77,7 +94,6 @@ export class WalletLinkWebSocket {
             const message = JSON.parse(evt.data) as ServerMessage;
             this.incomingDataListener?.(message);
           } catch {
-            /* empty */
           }
         }
       };
@@ -92,8 +108,12 @@ export class WalletLinkWebSocket {
     if (!webSocket) {
       return;
     }
+
+    // Mark as disconnecting to prevent reconnection attempts on this instance
+    this.isDisconnecting = true;
     this.clearWebSocket();
 
+    // Clear listeners
     this.connectionStateListener?.(ConnectionState.DISCONNECTED);
     this.connectionStateListener = undefined;
     this.incomingDataListener = undefined;
@@ -112,10 +132,19 @@ export class WalletLinkWebSocket {
   public sendData(data: string): void {
     const { webSocket } = this;
     if (!webSocket) {
-      this.pendingData.push(data);
-      this.connect();
+      WalletLinkWebSocket.pendingData.push(data);
+      if (!this.isDisconnecting) {
+        this.connect();
+      }
       return;
     }
+
+    // Check if WebSocket is actually open before sending
+    if (webSocket.readyState !== WebSocket.OPEN) {
+      WalletLinkWebSocket.pendingData.push(data);
+      return;
+    }
+
     webSocket.send(data);
   }
 
@@ -129,5 +158,12 @@ export class WalletLinkWebSocket {
     webSocket.onerror = null;
     webSocket.onmessage = null;
     webSocket.onopen = null;
+  }
+
+  /**
+   * remove ws from active instances
+   */
+  public cleanup(): void {
+    WalletLinkWebSocket.activeInstances.delete(this.instanceId);
   }
 }


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

This set of fixes specifically targets reliability on mobile-mobile flows. It speeds up and fixes things in the reconnect process for our walletlink websockets. 

Connection Management:
 - Added WebSocket instance tracking to prevent event handling from stale connections
 - Fresh WebSocket creation on reconnection instead of reusing failed instances
 - Instance management to enable quicker + more reliable reconnections
 - Reconnection
   - backoff (0s first attempt, then 3s delay)
   - Prevent concurrent reconnection attempts 

Heartbeat:
 - Fixed heartbeat timer management by properly clearing intervals on disconnect
 - Added connection state check before sending heartbeats to prevent errors
 - Reset lastHeartbeatResponse on disconnect to prevent false timeout detection on reconnection
 - Send immediate heartbeat after connection establishment for faster connection validation
 
Browser Event Handling:
 - Added visibility change and focus event handlers to detect when users returns to the app
 - Tighten up reconnect when tab/window regains focus

### _How did you test your changes?_

manually

Also tested for regressions on long-idle desktop chrome tabs (Will's service worker fix):
- built locally
- Run the app in an incognito Chrome window
- Connect via WL, confirm you receive and can sign the message request
- Then, leave the chrome tab open for 10mins without interacting with it (don't open a new tab)
- Come back to the tab and try initiating a new signing request
- Confirm you can receive an sign the message request


Also built locally and tested the playground, extension, desktop to mobile

<!--
  Verify changes. Include relevant screenshots/videos
-->

Failure 1 (before fixes)

https://github.com/user-attachments/assets/edce801e-e007-4a7f-b86d-bfa9c693764d

Failure 2 (before fixes)

https://github.com/user-attachments/assets/50e7ee5f-232b-458f-8c9b-ba459b11f666


Success with fixes

https://github.com/user-attachments/assets/9be280d9-c85d-49d2-ae6b-f11ec4e6926a



