### PR TITLE
chore: do not handle insufficent balance error if error data is not a…

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
+++ b/packages/wallet-sdk/src/sign/scw/SCWSigner.ts
@@ -743,6 +743,10 @@ export class SCWSigner implements Signer {
         throw error;
       }
 
+      if (!errorObject.data) {
+        throw error;
+      }
+
       const correlationId = correlationIds.get(request);
       logInsufficientBalanceErrorHandlingStarted({ method: request.method, correlationId });
       try {

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -424,11 +424,11 @@ export async function presentSubAccountFundingDialog() {
       logSnackbarShown({ snackbarContext: 'sub_account_insufficient_balance' });
       snackbar.presentItem({
         autoExpand: true,
-        message: 'Insufficient spend limit. Choose how to proceed:',
+        message: 'Insufficient spend permission. Choose how to proceed:',
         menuItems: [
           {
             isRed: false,
-            info: 'Create new Spend Limit',
+            info: 'Create new Spend Permission',
             svgWidth: '10',
             svgHeight: '11',
             path: '',


### PR DESCRIPTION
…vailable

### _Summary_

1. Do not provide custom error handling on insufficient balance errors for sub account if error data is not available. This is the case if wallet_sendCalls is invoked without the funding capability.
2. renamed spend limits -> spend permissions in a place that was missed during the renaming refactor

### _How did you test your changes?_

unit test coverage
