### PR TITLE
fix: update manual sub account odering behavior

### DIFF
--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -81,6 +81,22 @@ export default function AutoSubAccount() {
     }
   };
 
+  const handleEthAccounts = async () => {
+    if (!provider) return;
+
+    try {
+      const response = await provider.request({
+        method: 'eth_accounts',
+        params: [],
+      });
+      setAccounts(response as string[]);
+      setLastResult(JSON.stringify(response, null, 2));
+    } catch (e) {
+      console.error('error', e);
+      setLastResult(JSON.stringify(e, null, 2));
+    }
+  };
+
   const handleSendTransaction = async () => {
     if (!provider || !accounts.length) return;
 
@@ -384,6 +400,9 @@ export default function AutoSubAccount() {
         </Box>
         <Button w="full" onClick={handleRequestAccounts}>
           eth_requestAccounts
+        </Button>
+        <Button w="full" onClick={handleEthAccounts}>
+          eth_accounts
         </Button>
         <Button w="full" onClick={handleSendTransaction} isDisabled={!accounts.length}>
           eth_sendTransaction

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -490,8 +490,8 @@ describe('appendWithoutDuplicates', () => {
     expect(appendWithoutDuplicates(['1', '2', '3'], '4')).toEqual(['1', '2', '3', '4']);
   });
 
-  it('should not append an item to an array if it is already present', () => {
-    expect(appendWithoutDuplicates(['1', '2', '3'], '2')).toEqual(['1', '2', '3']);
+  it('should move an existing item to the end of the array', () => {
+    expect(appendWithoutDuplicates(['1', '2', '3'], '2')).toEqual(['1', '3', '2']);
   });
 });
 

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -3,6 +3,7 @@ import { hashTypedData, hexToBigInt, numberToHex } from 'viem';
 import {
   SpendPermissionBatch,
   addSenderToRequest,
+  appendWithoutDuplicates,
   assertFetchPermissionsRequest,
   assertGetCapabilitiesParams,
   assertParamsChainId,
@@ -120,9 +121,15 @@ describe('assertGetCapabilitiesParams', () => {
     expect(() => assertGetCapabilitiesParams(['0x123'])).toThrow(); // Too short
     expect(() => assertGetCapabilitiesParams(['0x123abc'])).toThrow(); // Too short
     expect(() => assertGetCapabilitiesParams(['xyz123'])).toThrow(); // No 0x prefix
-    expect(() => assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678gg'])).toThrow(); // Invalid hex characters
-    expect(() => assertGetCapabilitiesParams(['0x123456789012345678901234567890123456789'])).toThrow(); // Too short (39 chars)
-    expect(() => assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678901'])).toThrow(); // Too long (41 chars)
+    expect(() =>
+      assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678gg'])
+    ).toThrow(); // Invalid hex characters
+    expect(() =>
+      assertGetCapabilitiesParams(['0x123456789012345678901234567890123456789'])
+    ).toThrow(); // Too short (39 chars)
+    expect(() =>
+      assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678901'])
+    ).toThrow(); // Too long (41 chars)
   });
 
   it('should not throw for valid single parameter (valid Ethereum address)', () => {
@@ -148,7 +155,9 @@ describe('assertGetCapabilitiesParams', () => {
   it('should not throw for valid parameters with filter array', () => {
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, []])).not.toThrow();
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1']])).not.toThrow();
-    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', '0x2', '0x3']])).not.toThrow();
+    expect(() =>
+      assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', '0x2', '0x3']])
+    ).not.toThrow();
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0xabcdef', '0x0']])).not.toThrow();
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_2, ['0x1', '0xa']])).not.toThrow();
   });
@@ -473,6 +482,16 @@ describe('prependWithoutDuplicates', () => {
 
   it('should not prepend an item to an array if it is already present', () => {
     expect(prependWithoutDuplicates(['1', '2', '3'], '2')).toEqual(['2', '1', '3']);
+  });
+});
+
+describe('appendWithoutDuplicates', () => {
+  it('should append an item to an array without duplicates', () => {
+    expect(appendWithoutDuplicates(['1', '2', '3'], '4')).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('should not append an item to an array if it is already present', () => {
+    expect(appendWithoutDuplicates(['1', '2', '3'], '2')).toEqual(['1', '2', '3']);
   });
 });
 

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -577,6 +577,17 @@ export function prependWithoutDuplicates<T>(array: T[], item: T): T[] {
   return [item, ...filtered];
 }
 
+/**
+ * Appends an item to an array without duplicates
+ * @param array The array to append to
+ * @param item The item to append
+ * @returns The array with the item appended
+ */
+export function appendWithoutDuplicates<T>(array: T[], item: T): T[] {
+  const filtered = array.filter((i) => i !== item);
+  return [...filtered, item];
+}
+
 export async function getCachedWalletConnectResponse(): Promise<WalletConnectResponse | null> {
   const spendPermissions = store.spendPermissions.get();
   const subAccount = store.subAccounts.get();
@@ -591,7 +602,8 @@ export async function getCachedWalletConnectResponse(): Promise<WalletConnectRes
       address: account,
       capabilities: {
         subAccounts: subAccount ? [subAccount] : undefined,
-        spendPermissions: spendPermissions.length > 0 ? { permissions: spendPermissions } : undefined,
+        spendPermissions:
+          spendPermissions.length > 0 ? { permissions: spendPermissions } : undefined,
       },
     })
   );


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
https://linear.app/coinbase/issue/BA-2376/sdk-update-default-sub-account-behavior

When `enableAutoSubAccounts` is false, we no longer automatically make the sub account the 'active' account. All requests meant for the sub accounts need to explicitly specify the sub account address.

In this mode, the sub account is always returned at index 1 when calling `eth_requestAccounts` and `eth_accounts`.

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

Unit tests, manual testing in playground
