### PR TITLE
chore: remove default spend limits

### DIFF
--- a/examples/testapp/src/pages/auto-sub-account/index.page.tsx
+++ b/examples/testapp/src/pages/auto-sub-account/index.page.tsx
@@ -12,7 +12,6 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { getCryptoKeyAccount } from '@coinbase/wallet-sdk';
-import { SpendPermissionConfig } from '@coinbase/wallet-sdk/dist/core/provider/interface';
 import React, { useEffect, useState } from 'react';
 import { createPublicClient, http, numberToHex, parseEther } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
@@ -215,24 +214,6 @@ export default function AutoSubAccount() {
     }
   };
 
-  const handleSetDefaultSpendPermissions = (value: string) => {
-    const defaultSpendPermissions = {
-      [baseSepolia.id]: [
-        {
-          token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-          allowance: '0x2386F26FC10000',
-          period: 86400,
-        } as SpendPermissionConfig,
-      ],
-    };
-
-    if (value === 'true') {
-      setSubAccountsConfig((prev) => ({ ...prev, defaultSpendPermissions }));
-    } else {
-      setSubAccountsConfig((prev) => ({ ...prev, defaultSpendPermissions: {} }));
-    }
-  };
-
   const handleEthSend = async (amount: string) => {
     if (!provider || !accounts.length) return;
 
@@ -319,18 +300,6 @@ export default function AutoSubAccount() {
             onChange={(value) =>
               setSubAccountsConfig((prev) => ({ ...prev, enableAutoSubAccounts: value === 'true' }))
             }
-          >
-            <Stack direction="row">
-              <Radio value="true">Enabled</Radio>
-              <Radio value="false">Disabled</Radio>
-            </Stack>
-          </RadioGroup>
-        </FormControl>
-        <FormControl>
-          <FormLabel>Default Spend Permissions</FormLabel>
-          <RadioGroup
-            value={subAccountsConfig?.defaultSpendPermissions?.[baseSepolia.id] ? 'true' : 'false'}
-            onChange={handleSetDefaultSpendPermissions}
           >
             <Stack direction="row">
               <Radio value="true">Enabled</Radio>

--- a/packages/wallet-sdk/src/core/provider/interface.ts
+++ b/packages/wallet-sdk/src/core/provider/interface.ts
@@ -96,11 +96,6 @@ export type SubAccountOptions = {
    * @returns The owner account that will be used to sign the subaccount transactions.
    */
   toOwnerAccount?: ToOwnerAccountFn;
-  /**
-   * Spend permissions requested on app connect if a matching existing one does not exist.
-   * Only supports native chain tokens currently.
-   */
-  defaultSpendPermissions?: Record<number, SpendPermissionConfig[]>;
 };
 
 export interface ConstructorOptions {

--- a/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
+++ b/packages/wallet-sdk/src/createCoinbaseWalletSDK.ts
@@ -58,7 +58,6 @@ export function createCoinbaseWalletSDK(params: CreateCoinbaseWalletSDKOptions) 
   store.subAccountsConfig.set({
     toOwnerAccount: params.subAccounts?.toOwnerAccount,
     enableAutoSubAccounts: params.subAccounts?.enableAutoSubAccounts,
-    defaultSpendPermissions: params.subAccounts?.defaultSpendPermissions,
   });
 
   // set the options in the store

--- a/packages/wallet-sdk/src/sign/scw/utils.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.test.ts
@@ -120,9 +120,15 @@ describe('assertGetCapabilitiesParams', () => {
     expect(() => assertGetCapabilitiesParams(['0x123'])).toThrow(); // Too short
     expect(() => assertGetCapabilitiesParams(['0x123abc'])).toThrow(); // Too short
     expect(() => assertGetCapabilitiesParams(['xyz123'])).toThrow(); // No 0x prefix
-    expect(() => assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678gg'])).toThrow(); // Invalid hex characters
-    expect(() => assertGetCapabilitiesParams(['0x123456789012345678901234567890123456789'])).toThrow(); // Too short (39 chars)
-    expect(() => assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678901'])).toThrow(); // Too long (41 chars)
+    expect(() =>
+      assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678gg'])
+    ).toThrow(); // Invalid hex characters
+    expect(() =>
+      assertGetCapabilitiesParams(['0x123456789012345678901234567890123456789'])
+    ).toThrow(); // Too short (39 chars)
+    expect(() =>
+      assertGetCapabilitiesParams(['0x12345678901234567890123456789012345678901'])
+    ).toThrow(); // Too long (41 chars)
   });
 
   it('should not throw for valid single parameter (valid Ethereum address)', () => {
@@ -148,7 +154,9 @@ describe('assertGetCapabilitiesParams', () => {
   it('should not throw for valid parameters with filter array', () => {
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, []])).not.toThrow();
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1']])).not.toThrow();
-    expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', '0x2', '0x3']])).not.toThrow();
+    expect(() =>
+      assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0x1', '0x2', '0x3']])
+    ).not.toThrow();
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_1, ['0xabcdef', '0x0']])).not.toThrow();
     expect(() => assertGetCapabilitiesParams([VALID_ADDRESS_2, ['0x1', '0xa']])).not.toThrow();
   });

--- a/packages/wallet-sdk/src/sign/scw/utils.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils.ts
@@ -167,10 +167,6 @@ export async function initSubAccountConfig() {
     };
   }
 
-  if (config.defaultSpendPermissions) {
-    capabilities.spendPermissions = config.defaultSpendPermissions;
-  }
-
   // Store the owner account and capabilities in the non-persisted config
   store.subAccountsConfig.set({
     capabilities,
@@ -591,7 +587,8 @@ export async function getCachedWalletConnectResponse(): Promise<WalletConnectRes
       address: account,
       capabilities: {
         subAccounts: subAccount ? [subAccount] : undefined,
-        spendPermissions: spendPermissions.length > 0 ? { permissions: spendPermissions } : undefined,
+        spendPermissions:
+          spendPermissions.length > 0 ? { permissions: spendPermissions } : undefined,
       },
     })
   );


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->
Removes sub account `defaultSpendPermission` config option

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
Ensured all unit tests pass
