### PR TITLE
fix: playground bug due to switching of default sub account index in …

### DIFF
--- a/examples/testapp/src/pages/add-sub-account/components/GrantSpendPermission.tsx
+++ b/examples/testapp/src/pages/add-sub-account/components/GrantSpendPermission.tsx
@@ -91,9 +91,10 @@ export function GrantSpendPermission({
         ],
       })) as string[];
 
+      const universalAddress = accounts[0] as Address;
       const data = {
         chainId: baseSepolia.id,
-        account: accounts[1] as Address,
+        account: universalAddress,
         spender: subAccountAddress as Address,
         token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
         allowance: '0x5AF3107A4000',
@@ -108,7 +109,7 @@ export function GrantSpendPermission({
 
       const response = await provider?.request({
         method: 'eth_signTypedData_v4',
-        params: [accounts[1] as Address, spendPermission],
+        params: [universalAddress, spendPermission],
       });
       console.info('response', response);
       localStorage.setItem('cbwsdk.demo.spend-permission.signature', response as Hex);


### PR DESCRIPTION
…accounts array

### _Summary_

GrantSpendPermission was being called with the sub account address as the `account` param, which was resulting in the sub account granting the spend permission. This was a side effect of the re-ordering change https://github.com/coinbase/coinbase-wallet-sdk/pull/1681

### _How did you test your changes?_

verified in playground