### PR TITLE
Prioritize deeplink navigation before event publishing

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/WalletLinkRelay.ts
@@ -6,8 +6,8 @@ import { ScopedLocalStorage } from ':core/storage/ScopedLocalStorage.js';
 import { Address } from ':core/type/index.js';
 import { bigIntStringFromBigInt, hexStringFromBuffer, randomBytesHex } from ':core/type/util.js';
 import {
-  WalletLinkConnection,
-  WalletLinkConnectionUpdateListener,
+    WalletLinkConnection,
+    WalletLinkConnectionUpdateListener,
 } from './connection/WalletLinkConnection.js';
 import { LOCAL_STORAGE_ADDRESSES_KEY } from './constants.js';
 import { RelayEventManager } from './RelayEventManager.js';
@@ -260,6 +260,13 @@ export class WalletLinkRelay implements WalletLinkConnectionUpdateListener {
 
   private publishWeb3RequestEvent(id: string, request: Web3Request): void {
     const message: WalletLinkEventData = { type: 'WEB3_REQUEST', id, request };
+    
+    // Fire deeplink immediately for mobile web to avoid Safari popup blocking
+    if (this.isMobileWeb) {
+      this.openCoinbaseWalletDeeplink(request.method);
+    }
+    
+    // Then publish the event asynchronously
     this.publishEvent('Web3Request', message, true)
       .then((_) => {})
       .catch((err) => {
@@ -268,10 +275,6 @@ export class WalletLinkRelay implements WalletLinkConnectionUpdateListener {
           errorMessage: err.message,
         });
       });
-
-    if (this.isMobileWeb) {
-      this.openCoinbaseWalletDeeplink(request.method);
-    }
   }
 
   // copied from MobileRelay


### PR DESCRIPTION
## [ENG-0003: Code Reviews Guidelines](https://confluence.coinbase-corp.com/display/ENG/ENG-0003%3A+Code+Reviews)

## What changed? Why?

Reordered deeplink navigation to execute before publishing web3 request events on mobile web. This change addresses Safari's popup blocking behavior by ensuring the deeplink opens within the user interaction context.

The key change:
- Moved `openCoinbaseWalletDeeplink` call to execute immediately when a web3 request is initiated on mobile web
- The event publishing now happens asynchronously after the deeplink navigation

## How was this tested?

Manual testing on mobile Safari to verify deeplinks open without being blocked by the popup blocker.

## How can reviewers manually test these changes?

1. Open the test app on mobile Safari
2. Connect wallet and trigger any web3 request (e.g., sign message, send transaction)
3. Verify the Coinbase Wallet deeplink opens immediately without Safari's popup warning
4. Confirm the web3 request is still processed correctly after navigation

## Demo/screenshots



automerge=false
