### PR TITLE
Spencer/fix

### DIFF
--- a/packages/wallet-sdk/src/util/provider.ts
+++ b/packages/wallet-sdk/src/util/provider.ts
@@ -46,7 +46,7 @@ function getCoinbaseInjectedLegacyProvider(): CBInjectedProvider | undefined {
 function getInjectedEthereum(): CBInjectedProvider | undefined {
   try {
     const window = globalThis as CBWindow;
-    return window.ethereum ?? window.top?.ethereum;
+    return window.top?.ethereum ?? window.ethereum;
   } catch {
     return undefined;
   }

--- a/packages/wallet-sdk/src/util/provider.ts
+++ b/packages/wallet-sdk/src/util/provider.ts
@@ -31,8 +31,6 @@ export interface CBWindow {
   top: CBWindow;
   ethereum?: CBInjectedProvider;
   coinbaseWalletExtension?: CBInjectedProvider;
-  ReactNativeWebView?: unknown;
-  __CIPHER_BRIDGE__?: unknown;
 }
 
 export interface CBInjectedProvider extends ProviderInterface {
@@ -43,18 +41,6 @@ export interface CBInjectedProvider extends ProviderInterface {
 function getCoinbaseInjectedLegacyProvider(): CBInjectedProvider | undefined {
   const window = globalThis as CBWindow;
   return window.coinbaseWalletExtension;
-}
-
-function alignIframeWithParentIfNeeded() {
-  const window = globalThis as CBWindow;
-  if (window !== window.top && window.top.ethereum?.isCoinbaseBrowser) {
-    if (window.top?.ReactNativeWebView) {
-      window.ReactNativeWebView = window.top.ReactNativeWebView;
-    }
-    if (window.top?.__CIPHER_BRIDGE__) {
-      window.__CIPHER_BRIDGE__ = window.top.__CIPHER_BRIDGE__;
-    }
-  }
 }
 
 function getInjectedEthereum(): CBInjectedProvider | undefined {
@@ -82,7 +68,6 @@ export function getCoinbaseInjectedProvider({
 
   const ethereum = getInjectedEthereum();
   if (ethereum?.isCoinbaseBrowser) {
-    alignIframeWithParentIfNeeded();
     ethereum.setAppInfo?.(appName, appLogoUrl, appChainIds, preference);
     return ethereum;
   }


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

What was happening:
the RN app was trying to inject custom js code into all frames
    

each frame got its own instance of the injected provider and associated dependencies
except for the ReactNativeWebView dependency which does not get injected into all frames
The end result was a non-functional provider being injected into iframes

For Android though - this injection failed (potentially relevant issue here: https://github.com/react-native-webview/react-native-webview/issues/2259)

Since SDK logic return window.ethereum ?? window.top?.ethereum; 
on iOS: grabbed the non-functional iframe-injected provider
on Android: grabbed the window.top provider

When we injected the ReactNativeWebView it patched the issue somewhat, but there is still a mismatch somewhere between the distinct instances of all the dependencies in the iframe and what the RN app is providing as a response

The actual solution is to ignore the non functional provider and ensure iOS uses the window.top?.provider  - it already has access to its own dependencies since it is a shared reference and not a unique instance.

### _How did you test your changes?_

Using the Stripe minimal test app provided by Fan


https://github.com/user-attachments/assets/c561eb95-afde-494c-898c-ccd0eb30a522



<!--
  Verify changes. Include relevant screenshots/videos
-->
