### PR TITLE
docs: update chrome web store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 1. Coinbase Wallet mobile for [Android](https://play.google.com/store/apps/details?id=org.toshi&referrer=utm_source%3DWallet_LP) and [iOS](https://apps.apple.com/app/apple-store/id1278383455?pt=118788940&ct=Wallet_LP&mt=8)
    - Desktop: Users can connect to your dapp by scanning a QR code
    - Mobile: Users can connect to your mobile dapp through a deeplink to the dapp browser
-1. Coinbase Wallet extension for [Chrome](https://chrome.google.com/webstore/detail/coinbase-wallet-extension/hnfanknocfeofbddgcijnmhnfnkdnaad?hl=en) and [Brave](https://chromewebstore.google.com/detail/coinbase-wallet-extension/hnfanknocfeofbddgcijnmhnfnkdnaad?hl=en)
+1. Coinbase Wallet extension for [Chrome](https://chromewebstore.google.com/detail/coinbase-wallet-extension/hnfanknocfeofbddgcijnmhnfnkdnaad?hl=en) and [Brave](https://chromewebstore.google.com/detail/coinbase-wallet-extension/hnfanknocfeofbddgcijnmhnfnkdnaad?hl=en)
    - Desktop: Users can connect by clicking the connect with an extension option.
 
 ### Installing Wallet SDK


### PR DESCRIPTION
## Summary
- update the README Chrome extension link to use the current Chrome Web Store domain
- keep the Chrome and Brave extension links aligned on the same canonical store URL

## Testing
- not run (README link-only change)

## Why
The README currently links Brave to `chromewebstore.google.com`, but the adjacent Chrome link still points to the older `chrome.google.com/webstore` domain. The old domain now redirects to the new Chrome Web Store URL, so this keeps the README self-consistent and avoids relying on the legacy redirect.