### PR TITLE
ix: use dynamic chainId and inject paymaster capabilities in handleAddSubAccountOwner

### DIFF
--- a/packages/wallet-sdk/src/sign/scw/utils/handleAddSubAccountOwner.test.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/handleAddSubAccountOwner.test.ts
@@ -45,10 +45,11 @@ describe('handleAddSubAccountOwner', () => {
     (store.subAccounts.get as ReturnType<typeof vi.fn>).mockReturnValue({
       address: '0xsub',
     });
+    (store.config.get as ReturnType<typeof vi.fn>).mockReturnValue({});
     (getClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
   });
 
-  it("should throw error when client is not found", async () => {
+  it('should throw error when client is not found', async () => {
     (getClient as ReturnType<typeof vi.fn>).mockReturnValue(null);
 
     await expect(
@@ -56,22 +57,22 @@ describe('handleAddSubAccountOwner', () => {
         ownerAccount: mockOwnerAccount,
         globalAccountRequest: mockGlobalAccountRequest,
       })
-    ).rejects.toThrow(standardErrors.rpc.internal("client not found for chainId 1"));
+    ).rejects.toThrow(standardErrors.rpc.internal('client not found for chainId 1'));
   });
 
-  it("should throw error when calls fail", async () => {
-    (waitForCallsStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ status: "failed" });
+  it('should throw error when calls fail', async () => {
+    (waitForCallsStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'failed' });
 
     await expect(
       handleAddSubAccountOwner({
         ownerAccount: mockOwnerAccount,
         globalAccountRequest: mockGlobalAccountRequest,
       })
-    ).rejects.toThrow(standardErrors.rpc.internal("add owner call failed"));
+    ).rejects.toThrow(standardErrors.rpc.internal('add owner call failed'));
   });
 
   it('should successfully add owner when all conditions are met', async () => {
-    (waitForCallsStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ status: "success" });
+    (waitForCallsStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'success' });
 
     await handleAddSubAccountOwner({
       ownerAccount: mockOwnerAccount,
@@ -83,6 +84,43 @@ describe('handleAddSubAccountOwner', () => {
       params: expect.any(Array),
     });
     expect(findOwnerIndex).toHaveBeenCalled();
+  });
+
+  it('should use chain ID from store instead of hardcoded value', async () => {
+    (store.account.get as ReturnType<typeof vi.fn>).mockReturnValue({
+      accounts: ['0xglobal', '0xsub'],
+      chain: { id: 8453 },
+    });
+    (waitForCallsStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'success' });
+
+    await handleAddSubAccountOwner({
+      ownerAccount: mockOwnerAccount,
+      globalAccountRequest: mockGlobalAccountRequest,
+    });
+
+    const sendCallsParams = mockGlobalAccountRequest.mock.calls[0][0].params[0];
+    expect(sendCallsParams.chainId).toBe('0x2105');
+  });
+
+  it('should inject paymaster capabilities when paymasterUrls is configured', async () => {
+    (store.account.get as ReturnType<typeof vi.fn>).mockReturnValue({
+      accounts: ['0xglobal', '0xsub'],
+      chain: { id: 8453 },
+    });
+    (store.config.get as ReturnType<typeof vi.fn>).mockReturnValue({
+      paymasterUrls: { 8453: 'https://paymaster.example.com' },
+    });
+    (waitForCallsStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'success' });
+
+    await handleAddSubAccountOwner({
+      ownerAccount: mockOwnerAccount,
+      globalAccountRequest: mockGlobalAccountRequest,
+    });
+
+    const sendCallsParams = mockGlobalAccountRequest.mock.calls[0][0].params[0];
+    expect(sendCallsParams.capabilities).toEqual({
+      paymasterService: { url: 'https://paymaster.example.com' },
+    });
   });
 
   it('should throw error when no global account is found', async () => {

--- a/packages/wallet-sdk/src/sign/scw/utils/handleAddSubAccountOwner.ts
+++ b/packages/wallet-sdk/src/sign/scw/utils/handleAddSubAccountOwner.ts
@@ -1,19 +1,14 @@
-import { standardErrors } from ":core/error/errors.js";
-import { RequestArguments } from ":core/provider/interface.js";
-import { OwnerAccount } from ":core/type/index.js";
-import { getClient } from ":store/chain-clients/utils.js";
-import { store } from ":store/store.js";
-import { assertPresence } from ":util/assertPresence.js";
-import {
-  decodeAbiParameters,
-  encodeFunctionData,
-  numberToHex,
-  toHex,
-} from "viem";
-import { waitForCallsStatus } from "viem/experimental";
-import { abi } from "../utils/constants.js";
-import { findOwnerIndex } from "../utils/findOwnerIndex.js";
-import { presentAddOwnerDialog } from "./presentAddOwnerDialog.js";
+import { standardErrors } from ':core/error/errors.js';
+import { RequestArguments } from ':core/provider/interface.js';
+import { OwnerAccount } from ':core/type/index.js';
+import { getClient } from ':store/chain-clients/utils.js';
+import { store } from ':store/store.js';
+import { assertPresence } from ':util/assertPresence.js';
+import { decodeAbiParameters, encodeFunctionData, numberToHex, toHex } from 'viem';
+import { waitForCallsStatus } from 'viem/experimental';
+import { abi } from '../utils/constants.js';
+import { findOwnerIndex } from '../utils/findOwnerIndex.js';
+import { presentAddOwnerDialog } from './presentAddOwnerDialog.js';
 
 export async function handleAddSubAccountOwner({
   ownerAccount,
@@ -28,26 +23,17 @@ export async function handleAddSubAccountOwner({
     (account) => account.toLowerCase() !== subAccount?.address.toLowerCase()
   );
 
-  assertPresence(
-    globalAccount,
-    standardErrors.provider.unauthorized("no global account")
-  );
-  assertPresence(
-    account.chain?.id,
-    standardErrors.provider.unauthorized("no chain id")
-  );
-  assertPresence(
-    subAccount?.address,
-    standardErrors.provider.unauthorized("no sub account")
-  );
+  assertPresence(globalAccount, standardErrors.provider.unauthorized('no global account'));
+  assertPresence(account.chain?.id, standardErrors.provider.unauthorized('no chain id'));
+  assertPresence(subAccount?.address, standardErrors.provider.unauthorized('no sub account'));
 
   const calls = [];
-  if (ownerAccount.type === "local" && ownerAccount.address) {
+  if (ownerAccount.type === 'local' && ownerAccount.address) {
     calls.push({
       to: subAccount.address,
       data: encodeFunctionData({
         abi,
-        functionName: "addOwnerAddress",
+        functionName: 'addOwnerAddress',
         args: [ownerAccount.address] as const,
       }),
       value: toHex(0),
@@ -56,35 +42,44 @@ export async function handleAddSubAccountOwner({
 
   if (ownerAccount.publicKey) {
     const [x, y] = decodeAbiParameters(
-      [{ type: "bytes32" }, { type: "bytes32" }],
+      [{ type: 'bytes32' }, { type: 'bytes32' }],
       ownerAccount.publicKey
     );
     calls.push({
       to: subAccount.address,
       data: encodeFunctionData({
         abi,
-        functionName: "addOwnerPublicKey",
+        functionName: 'addOwnerPublicKey',
         args: [x, y] as const,
       }),
       value: toHex(0),
     });
   }
 
+  const chainId = account.chain.id;
+  const chainIdHex = numberToHex(chainId);
+  const paymasterUrls = store.config.get().paymasterUrls;
+  const capabilities: Record<string, unknown> = {};
+  if (paymasterUrls?.[chainId]) {
+    capabilities.paymasterService = { url: paymasterUrls[chainId] };
+  }
+
   const request: RequestArguments = {
-    method: "wallet_sendCalls",
+    method: 'wallet_sendCalls',
     params: [
       {
-        version: "1",
+        version: '1',
         calls,
-        chainId: numberToHex(84532),
+        chainId: chainIdHex,
         from: globalAccount,
+        ...(Object.keys(capabilities).length > 0 && { capabilities }),
       },
     ],
   };
 
   const selection = await presentAddOwnerDialog();
-  if (selection === "cancel") {
-    throw standardErrors.provider.unauthorized("user cancelled");
+  if (selection === 'cancel') {
+    throw standardErrors.provider.unauthorized('user cancelled');
   }
 
   const callsId = (await globalAccountRequest(request)) as string;
@@ -92,9 +87,7 @@ export async function handleAddSubAccountOwner({
   const client = getClient(account.chain.id);
   assertPresence(
     client,
-    standardErrors.rpc.internal(
-      `client not found for chainId ${account.chain.id}`
-    )
+    standardErrors.rpc.internal(`client not found for chainId ${account.chain.id}`)
   );
 
   const callsResult = await waitForCallsStatus(client, {
@@ -102,20 +95,20 @@ export async function handleAddSubAccountOwner({
   });
 
   if (callsResult.status !== 'success') {
-    throw standardErrors.rpc.internal("add owner call failed");
+    throw standardErrors.rpc.internal('add owner call failed');
   }
 
   const ownerIndex = await findOwnerIndex({
     address: subAccount.address,
     publicKey:
-      ownerAccount.type === "local" && ownerAccount.address
+      ownerAccount.type === 'local' && ownerAccount.address
         ? ownerAccount.address
         : ownerAccount.publicKey,
     client,
   });
 
   if (ownerIndex === -1) {
-    throw standardErrors.rpc.internal("failed to find owner index");
+    throw standardErrors.rpc.internal('failed to find owner index');
   }
 
   return ownerIndex;


### PR DESCRIPTION
Related to #1600

## Problem

`handleAddSubAccountOwner` has two bugs:

### 1. Hardcoded Base Sepolia chain ID

The `addOwnerAddress` / `addOwnerPublicKey` `wallet_sendCalls` request uses `numberToHex(84532)` (Base Sepolia) instead of reading the chain from the account store. This means owner-addition calls are always sent to Base Sepolia, even when the user is on Base mainnet (8453) or any other chain.

### 2. No paymaster capabilities

Unlike `createWalletSendCallsRequest` in `utils.ts`, this function never injects `paymasterService` capabilities into the `wallet_sendCalls` request. This means `addOwner` calls cannot be sponsored even when a `paymasterUrls` entry is configured for the active chain, causing users to pay gas out of pocket or the call to fail if the smart wallet has no ETH.

## Changes

### `packages/wallet-sdk/src/sign/scw/utils/handleAddSubAccountOwner.ts`
- Replaced hardcoded `numberToHex(84532)` with `numberToHex(account.chain.id)` from the store
- Added `paymasterService` capabilities injection (flat format per ERC-7677) when `paymasterUrls` config includes the active chain

### Tests (`handleAddSubAccountOwner.test.ts`)
- Added `store.config.get` mock to `beforeEach` so new code path for `paymasterUrls` lookup doesn't throw
- Added test: verifies `chainId` in `wallet_sendCalls` comes from the store (`0x2105` for Base mainnet) instead of hardcoded `0x14a34` (Base Sepolia)
- Added test: verifies `paymasterService` capabilities are injected when `paymasterUrls` is configured

All 63 tests pass (54 in `utils.test.ts` + 9 in `handleAddSubAccountOwner.test.ts`).