### PR TITLE
feat(testapp): add COOP simulation toggle to eth_requestAccounts

### DIFF
--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -56,7 +56,7 @@ const replaceAddressInValue = async (value: any, getCurrentAddress: () => Promis
   return value;
 };
 
-export function RpcMethodCard({ format, method, params, shortcuts }) {
+export function RpcMethodCard({ format, method, params, shortcuts, children = null }) {
   const [response, setResponse] = React.useState<Response | null>(null);
   const [verifyResult, setVerifyResult] = React.useState<string | null>(null);
   const [error, setError] = React.useState<Record<string, unknown> | string | number | null>(null);
@@ -258,6 +258,7 @@ export function RpcMethodCard({ format, method, params, shortcuts }) {
             </Code>
           </VStack>
         )}
+        {children}
       </CardBody>
     </Card>
   );

--- a/examples/testapp/src/pages/index.page.tsx
+++ b/examples/testapp/src/pages/index.page.tsx
@@ -1,9 +1,11 @@
-import { Box, Container, Grid, Heading } from '@chakra-ui/react';
-import React, { useEffect } from 'react';
+import { Box, Container, Flex, Grid, GridItem, Heading, Switch, Text } from '@chakra-ui/react';
+import React, { useCallback, useEffect } from 'react';
 
 import { EventListenersCard } from '../components/EventListeners/EventListenersCard';
 import { WIDTH_2XL } from '../components/Layout';
 import { MethodsSection } from '../components/MethodsSection/MethodsSection';
+import { RpcMethodCard } from '../components/RpcMethods/RpcMethodCard';
+import { useConfig } from '../context/ConfigContextProvider';
 import { connectionMethods } from '../components/RpcMethods/method/connectionMethods';
 import { ephemeralMethods } from '../components/RpcMethods/method/ephemeralMethods';
 import { multiChainMethods } from '../components/RpcMethods/method/multiChainMethods';
@@ -23,6 +25,22 @@ import { useEIP1193Provider } from '../context/EIP1193ProviderContextProvider';
 
 export default function Home() {
   const { provider } = useEIP1193Provider();
+  const { scwUrl, setScwUrlAndSave } = useConfig();
+
+  const simulateCoop = new URL(scwUrl).searchParams.get('coop') === 'same-origin';
+
+  const handleSimulateCoopToggle = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const url = new URL(scwUrl);
+      if (e.target.checked) {
+        url.searchParams.set('coop', 'same-origin');
+      } else {
+        url.searchParams.delete('coop');
+      }
+      setScwUrlAndSave(url.toString() as Parameters<typeof setScwUrlAndSave>[0]);
+    },
+    [scwUrl, setScwUrlAndSave]
+  );
   // @ts-expect-error refactor soon
   const [connected, setConnected] = React.useState(Boolean(provider?.connected));
   const [chainId, setChainId] = React.useState<number | undefined>(undefined);
@@ -76,11 +94,40 @@ export default function Home() {
       <Box mt={4}>
         <SDKConfig />
       </Box>
-      <MethodsSection
-        title="Wallet Connection"
-        methods={connectionMethods}
-        shortcutsMap={connectionMethodShortcutsMap}
-      />
+      <Box mt={4}>
+        <Heading size="md">Wallet Connection</Heading>
+        <Grid
+          mt={2}
+          templateColumns={{ base: '100%', md: 'repeat(2, 50%)', xl: 'repeat(3, 33%)' }}
+          gap={2}
+        >
+          <GridItem w="100%" key="eth_requestAccounts">
+            <RpcMethodCard
+              method="eth_requestAccounts"
+              params={[]}
+              format={undefined}
+              shortcuts={connectionMethodShortcutsMap?.['eth_requestAccounts']}
+            >
+              <Flex align="center" justify="space-between" mt={4} pt={3} borderTopWidth={1}>
+                <Text fontSize="sm" fontWeight="medium">Simulate COOP</Text>
+                <Switch isChecked={simulateCoop} onChange={handleSimulateCoopToggle} />
+              </Flex>
+            </RpcMethodCard>
+          </GridItem>
+          {connectionMethods
+            .filter((rpc) => rpc.method !== 'eth_requestAccounts')
+            .map((rpc) => (
+              <GridItem w="100%" key={rpc.method}>
+                <RpcMethodCard
+                  method={rpc.method}
+                  params={rpc.params}
+                  format={rpc.format}
+                  shortcuts={connectionMethodShortcutsMap?.[rpc.method]}
+                />
+              </GridItem>
+            ))}
+        </Grid>
+      </Box>
       <MethodsSection
         title="Ephemeral Methods"
         methods={ephemeralMethods}

--- a/packages/wallet-sdk/src/util/web.test.ts
+++ b/packages/wallet-sdk/src/util/web.test.ts
@@ -68,13 +68,25 @@ describe('PopupManager', () => {
     url.searchParams.append('sdkVersion', VERSION);
     url.searchParams.append('origin', mockOrigin);
     url.searchParams.append('coop', 'null');
-    
+
     (window.open as Mock).mockReturnValue({ focus: vi.fn() });
 
     await openPopup(url);
 
     const paramCount = url.searchParams.toString().split('&').length;
     expect(paramCount).toBe(4);
+  });
+
+  it('should not overwrite coop=same-origin when already present in the URL', async () => {
+    const url = new URL('https://example.com');
+    url.searchParams.set('coop', 'same-origin');
+
+    (window.open as Mock).mockReturnValue({ focus: vi.fn() });
+
+    await openPopup(url);
+
+    expect(url.searchParams.get('coop')).toBe('same-origin');
+    expect(url.searchParams.getAll('coop')).toHaveLength(1);
   });
 
   it('should show snackbar with retry button when popup is blocked and retry successfully', async () => {


### PR DESCRIPTION
## Summary

Adds a **Simulate COOP** toggle to the `eth_requestAccounts` card in the testapp (BA-5119). When on, the SDK opens `localhost:3005/connect?coop=same-origin` with `smartWalletOnly` preference, bypassing any injected extension so `CoinbaseWalletProvider` handles the popup directly.

Also fixes `appendAppInfoQueryParams` to skip params already set in `keysUrl` — without this, `coop=same-origin` was being duplicated as `coop=same-origin&coop=null`.

## What was tried / considered

Considered a standalone "Simulate COOP" card in its own page section, but embedding the toggle in the `eth_requestAccounts` card makes the relationship to the connection flow clearer. Also considered setting real `COOP: same-origin` headers on the testapp via `next.config.js`, but that would affect all routes and null out `window.opener` globally — too broad for a targeted simulation.

## How was this tested?

**With local keys**

https://github.com/user-attachments/assets/5a8955b5-2c1f-4f73-8826-0b27646c0d22

- Testapp at `localhost:3002`, SCW at `localhost:3005` on `eric/simulate-blockscout` (returns `null` from `getWindowContext()` when `coop=same-origin` is in the URL)
- Toggling "Simulate COOP" on and submitting `eth_requestAccounts` opens the popup at `localhost:3005/connect?coop=same-origin` and correctly reaches the `AppCoopErrorCTA` screen
- Added a unit test to `web.test.js` verifying that `openPopup` does not duplicate a `coop` param already present in the URL

