### PR TITLE
Add MYRX-MAINNET (Chain ID 8472)

### DIFF
--- a/docs/networks/myrx-mainnet.md
+++ b/docs/networks/myrx-mainnet.md
@@ -1,0 +1,12 @@
+# MYRX-MAINNET (Chain ID 8472)
+
+| Field | Value |
+|-------|-------|
+| Chain ID | 8472 (0x2118) |
+| Network name | MYRX-MAINNET |
+| RPC URL | https://rpc.myrxwallet.io |
+| Block explorer | https://explorer.myrxwallet.io |
+| Native currency | MRT (MyRx Token, 18 decimals) |
+
+Operator: MyRxWallet North America Corporation
+Contact: developer@myrxwallet.io


### PR DESCRIPTION
## MYRX-MAINNET — Chain ID 8472

Sovereign EVM blockchain operated by MyRxWallet North America Corporation. Mainnet live since 2026-05-07.

**Changes:** Add `docs/networks/myrx-mainnet.md` with MYRX-MAINNET network documentation and wallet configuration.

### Verification
```
cast chain-id --rpc-url https://rpc.myrxwallet.io
# Returns: 8472
```
- Repository: https://github.com/MyRxWallet/mainnet
- Explorer: https://explorer.myrxwallet.io (EIP-3091)
- Treasury multisig: 0x7636345d9d3c375ac9af0d98eb2eed588d7a61d7

### Use case
Healthcare data and payments infrastructure. HIPAA-aligned data flows, provider settlement, patient-controlled data licensing.

### Contact
developer@myrxwallet.io | https://myrxwallet.io