### PR TITLE
refactor(testapp): improve playground layout with tabs and copy shortcuts

### DIFF
--- a/examples/testapp/src/components/MethodsSection/MethodsSection.tsx
+++ b/examples/testapp/src/components/MethodsSection/MethodsSection.tsx
@@ -1,7 +1,7 @@
 import { Box, Grid, GridItem, Heading } from '@chakra-ui/react';
 
-import { RpcRequestInput } from '../RpcMethods/method/RpcRequestInput';
 import { RpcMethodCard } from '../RpcMethods/RpcMethodCard';
+import { RpcRequestInput } from '../RpcMethods/method/RpcRequestInput';
 import { ShortcutType } from '../RpcMethods/shortcut/ShortcutType';
 
 export function MethodsSection({

--- a/examples/testapp/src/components/MethodsSection/MethodsSection.tsx
+++ b/examples/testapp/src/components/MethodsSection/MethodsSection.tsx
@@ -9,19 +9,19 @@ export function MethodsSection({
   methods,
   shortcutsMap,
 }: {
-  title: string;
+  title?: string;
   methods: RpcRequestInput[];
   shortcutsMap?: Record<string, ShortcutType[]>;
 }) {
   return (
-    <Box mt={4}>
-      <Heading size="md">{title}</Heading>
+    <Box mt={title ? 4 : 0}>
+      {title ? <Heading size="md">{title}</Heading> : null}
       <Grid
-        mt={2}
+        mt={title ? 2 : 0}
         templateColumns={{
-          base: '100%',
-          md: 'repeat(2, 50%)',
-          xl: 'repeat(3, 33%)',
+          base: '1fr',
+          md: 'repeat(2, 1fr)',
+          xl: 'repeat(1, 1fr)',
         }}
         gap={2}
       >

--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -1,25 +1,25 @@
 import { CheckIcon, CopyIcon } from '@chakra-ui/icons';
 import {
-    Accordion,
-    AccordionButton,
-    AccordionIcon,
-    AccordionItem,
-    AccordionPanel,
-    Button,
-    ButtonGroup,
-    Card,
-    CardBody,
-    Code,
-    Flex,
-    FormControl,
-    FormErrorMessage,
-    HStack,
-    Heading,
-    IconButton,
-    InputGroup,
-    InputLeftAddon,
-    Textarea,
-    VStack,
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Button,
+  ButtonGroup,
+  Card,
+  CardBody,
+  Code,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  HStack,
+  Heading,
+  IconButton,
+  InputGroup,
+  InputLeftAddon,
+  Textarea,
+  VStack,
 } from '@chakra-ui/react';
 import React, { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
@@ -59,21 +59,18 @@ const replaceAddressInValue = async (value: any, getCurrentAddress: () => Promis
   return value;
 };
 
-export function RpcMethodCard({format, method, params, shortcuts, children = null }) {
+export function RpcMethodCard({ format, method, params, shortcuts, children = null }) {
   const [response, setResponse] = React.useState<Response | null>(null);
   const [verifyResult, setVerifyResult] = React.useState<string | null>(null);
-  const [error, setError] = React.useState<Record<string, unknown> | string | number | null >(null);
+  const [error, setError] = React.useState<Record<string, unknown> | string | number | null>(null);
   const [copiedShortcut, setCopiedShortcut] = React.useState<string | null>(null);
   const { provider } = useEIP1193Provider();
 
-  const copyShortcutMessage = useCallback(
-    async (key: string, message: unknown) => {
-      await navigator.clipboard.writeText(JSON.stringify(message, null, 2));
-      setCopiedShortcut(key);
-      window.setTimeout(() => setCopiedShortcut(null), 1500);
-    },
-    [],
-  );
+  const copyShortcutMessage = useCallback(async (key: string, message: unknown) => {
+    await navigator.clipboard.writeText(JSON.stringify(message, null, 2));
+    setCopiedShortcut(key);
+    window.setTimeout(() => setCopiedShortcut(null), 1500);
+  }, []);
 
   const {
     handleSubmit,
@@ -119,10 +116,7 @@ export function RpcMethodCard({format, method, params, shortcuts, children = nul
 
         for (const key in dataToSubmit) {
           if (Object.prototype.hasOwnProperty.call(data, key)) {
-            dataToSubmit[key] = await replaceAddressInValue(
-              dataToSubmit[key],
-              getCurrentAddress,
-            );
+            dataToSubmit[key] = await replaceAddressInValue(dataToSubmit[key], getCurrentAddress);
 
             if (dataToSubmit[key] === CHAIN_ID_TO_FILL) {
               const chainId = (await provider.request({ method: 'eth_chainId' })) as string;
@@ -145,7 +139,7 @@ export function RpcMethodCard({format, method, params, shortcuts, children = nul
         setError({ code, message, data });
       }
     },
-    [format, method, provider, verify],
+    [format, method, provider, verify]
   );
 
   return (
@@ -217,26 +211,13 @@ export function RpcMethodCard({format, method, params, shortcuts, children = nul
                   <HStack spacing={2} flexWrap="wrap">
                     {shortcuts.map((shortcut) => (
                       <ButtonGroup key={shortcut.key} size="sm" isAttached>
-                        <Button onClick={() => submit(shortcut.data)}>
-                          {shortcut.key}
-                        </Button>
+                        <Button onClick={() => submit(shortcut.data)}>{shortcut.key}</Button>
                         {shortcut.data.message && (
                           <IconButton
                             aria-label="Copy message payload"
                             title="Copy message payload"
-                            icon={
-                              copiedShortcut === shortcut.key ? (
-                                <CheckIcon />
-                              ) : (
-                                <CopyIcon />
-                              )
-                            }
-                            onClick={() =>
-                              copyShortcutMessage(
-                                shortcut.key,
-                                shortcut.data.message,
-                              )
-                            }
+                            icon={copiedShortcut === shortcut.key ? <CheckIcon /> : <CopyIcon />}
+                            onClick={() => copyShortcutMessage(shortcut.key, shortcut.data.message)}
                           />
                         )}
                       </ButtonGroup>

--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -1,22 +1,25 @@
+import { CheckIcon, CopyIcon } from '@chakra-ui/icons';
 import {
-  Accordion,
-  AccordionButton,
-  AccordionIcon,
-  AccordionItem,
-  AccordionPanel,
-  Button,
-  Card,
-  CardBody,
-  Code,
-  Flex,
-  FormControl,
-  FormErrorMessage,
-  HStack,
-  Heading,
-  InputGroup,
-  InputLeftAddon,
-  Textarea,
-  VStack,
+    Accordion,
+    AccordionButton,
+    AccordionIcon,
+    AccordionItem,
+    AccordionPanel,
+    Button,
+    ButtonGroup,
+    Card,
+    CardBody,
+    Code,
+    Flex,
+    FormControl,
+    FormErrorMessage,
+    HStack,
+    Heading,
+    IconButton,
+    InputGroup,
+    InputLeftAddon,
+    Textarea,
+    VStack,
 } from '@chakra-ui/react';
 import React, { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
@@ -56,11 +59,21 @@ const replaceAddressInValue = async (value: any, getCurrentAddress: () => Promis
   return value;
 };
 
-export function RpcMethodCard({ format, method, params, shortcuts, children = null }) {
+export function RpcMethodCard({format, method, params, shortcuts, children = null }) {
   const [response, setResponse] = React.useState<Response | null>(null);
   const [verifyResult, setVerifyResult] = React.useState<string | null>(null);
-  const [error, setError] = React.useState<Record<string, unknown> | string | number | null>(null);
+  const [error, setError] = React.useState<Record<string, unknown> | string | number | null >(null);
+  const [copiedShortcut, setCopiedShortcut] = React.useState<string | null>(null);
   const { provider } = useEIP1193Provider();
+
+  const copyShortcutMessage = useCallback(
+    async (key: string, message: unknown) => {
+      await navigator.clipboard.writeText(JSON.stringify(message, null, 2));
+      setCopiedShortcut(key);
+      window.setTimeout(() => setCopiedShortcut(null), 1500);
+    },
+    [],
+  );
 
   const {
     handleSubmit,
@@ -106,7 +119,10 @@ export function RpcMethodCard({ format, method, params, shortcuts, children = nu
 
         for (const key in dataToSubmit) {
           if (Object.prototype.hasOwnProperty.call(data, key)) {
-            dataToSubmit[key] = await replaceAddressInValue(dataToSubmit[key], getCurrentAddress);
+            dataToSubmit[key] = await replaceAddressInValue(
+              dataToSubmit[key],
+              getCurrentAddress,
+            );
 
             if (dataToSubmit[key] === CHAIN_ID_TO_FILL) {
               const chainId = (await provider.request({ method: 'eth_chainId' })) as string;
@@ -129,7 +145,7 @@ export function RpcMethodCard({ format, method, params, shortcuts, children = nu
         setError({ code, message, data });
       }
     },
-    [format, method, provider, verify]
+    [format, method, provider, verify],
   );
 
   return (
@@ -198,24 +214,32 @@ export function RpcMethodCard({ format, method, params, shortcuts, children = nu
                   <AccordionIcon />
                 </AccordionButton>
                 <AccordionPanel pb={4}>
-                  <HStack spacing={2}>
+                  <HStack spacing={2} flexWrap="wrap">
                     {shortcuts.map((shortcut) => (
-                      <VStack key={shortcut.key} spacing={1}>
-                        <Button onClick={() => submit(shortcut.data)}>{shortcut.key}</Button>
+                      <ButtonGroup key={shortcut.key} size="sm" isAttached>
+                        <Button onClick={() => submit(shortcut.data)}>
+                          {shortcut.key}
+                        </Button>
                         {shortcut.data.message && (
-                          <Button
-                            onClick={() =>
-                              navigator.clipboard.writeText(
-                                JSON.stringify(shortcut.data.message, null, 2)
+                          <IconButton
+                            aria-label="Copy message payload"
+                            title="Copy message payload"
+                            icon={
+                              copiedShortcut === shortcut.key ? (
+                                <CheckIcon />
+                              ) : (
+                                <CopyIcon />
                               )
                             }
-                            variant="outline"
-                            size="sm"
-                          >
-                            Copy
-                          </Button>
+                            onClick={() =>
+                              copyShortcutMessage(
+                                shortcut.key,
+                                shortcut.data.message,
+                              )
+                            }
+                          />
                         )}
-                      </VStack>
+                      </ButtonGroup>
                     ))}
                   </HStack>
                 </AccordionPanel>

--- a/examples/testapp/src/pages/index.page.tsx
+++ b/examples/testapp/src/pages/index.page.tsx
@@ -1,69 +1,64 @@
 import {
-    Box,
-    Container,
-    Flex,
-    Grid,
-    GridItem,
-    Heading,
-    Switch,
-    Tab,
-    TabList,
-    TabPanel,
-    TabPanels,
-    Tabs,
-    Text,
-} from "@chakra-ui/react";
-import React, { useCallback, useEffect } from "react";
+  Box,
+  Container,
+  Flex,
+  Grid,
+  GridItem,
+  Heading,
+  Switch,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+} from '@chakra-ui/react';
+import React, { useCallback, useEffect } from 'react';
 
-import { EventListenersCard } from "../components/EventListeners/EventListenersCard";
-import { WIDTH_2XL } from "../components/Layout";
-import { MethodsSection } from "../components/MethodsSection/MethodsSection";
-import { connectionMethods } from "../components/RpcMethods/method/connectionMethods";
-import { ephemeralMethods } from "../components/RpcMethods/method/ephemeralMethods";
-import { multiChainMethods } from "../components/RpcMethods/method/multiChainMethods";
-import { readonlyJsonRpcMethods } from "../components/RpcMethods/method/readonlyJsonRpcMethods";
-import { sendMethods } from "../components/RpcMethods/method/sendMethods";
-import { signMessageMethods } from "../components/RpcMethods/method/signMessageMethods";
-import { walletTxMethods } from "../components/RpcMethods/method/walletTxMethods";
-import { RpcMethodCard } from "../components/RpcMethods/RpcMethodCard";
-import { connectionMethodShortcutsMap } from "../components/RpcMethods/shortcut/connectionMethodShortcuts";
-import { ephemeralMethodShortcutsMap } from "../components/RpcMethods/shortcut/ephemeralMethodShortcuts";
-import { multiChainShortcutsMap } from "../components/RpcMethods/shortcut/multipleChainShortcuts";
-import { readonlyJsonRpcShortcutsMap } from "../components/RpcMethods/shortcut/readonlyJsonRpcShortcuts";
-import { sendShortcutsMap } from "../components/RpcMethods/shortcut/sendShortcuts";
-import { signMessageShortcutsMap } from "../components/RpcMethods/shortcut/signMessageShortcuts";
-import { walletTxShortcutsMap } from "../components/RpcMethods/shortcut/walletTxShortcuts";
-import { SDKConfig } from "../components/SDKConfig/SDKConfig";
-import { useConfig } from "../context/ConfigContextProvider";
-import { useEIP1193Provider } from "../context/EIP1193ProviderContextProvider";
-import { scwUrls } from "../store/config";
+import { EventListenersCard } from '../components/EventListeners/EventListenersCard';
+import { WIDTH_2XL } from '../components/Layout';
+import { MethodsSection } from '../components/MethodsSection/MethodsSection';
+import { RpcMethodCard } from '../components/RpcMethods/RpcMethodCard';
+import { connectionMethods } from '../components/RpcMethods/method/connectionMethods';
+import { ephemeralMethods } from '../components/RpcMethods/method/ephemeralMethods';
+import { multiChainMethods } from '../components/RpcMethods/method/multiChainMethods';
+import { readonlyJsonRpcMethods } from '../components/RpcMethods/method/readonlyJsonRpcMethods';
+import { sendMethods } from '../components/RpcMethods/method/sendMethods';
+import { signMessageMethods } from '../components/RpcMethods/method/signMessageMethods';
+import { walletTxMethods } from '../components/RpcMethods/method/walletTxMethods';
+import { connectionMethodShortcutsMap } from '../components/RpcMethods/shortcut/connectionMethodShortcuts';
+import { ephemeralMethodShortcutsMap } from '../components/RpcMethods/shortcut/ephemeralMethodShortcuts';
+import { multiChainShortcutsMap } from '../components/RpcMethods/shortcut/multipleChainShortcuts';
+import { readonlyJsonRpcShortcutsMap } from '../components/RpcMethods/shortcut/readonlyJsonRpcShortcuts';
+import { sendShortcutsMap } from '../components/RpcMethods/shortcut/sendShortcuts';
+import { signMessageShortcutsMap } from '../components/RpcMethods/shortcut/signMessageShortcuts';
+import { walletTxShortcutsMap } from '../components/RpcMethods/shortcut/walletTxShortcuts';
+import { SDKConfig } from '../components/SDKConfig/SDKConfig';
+import { useConfig } from '../context/ConfigContextProvider';
+import { useEIP1193Provider } from '../context/EIP1193ProviderContextProvider';
+import { scwUrls } from '../store/config';
 
 export default function Home() {
   const { provider } = useEIP1193Provider();
   const { scwUrl, setScwUrlAndSave } = useConfig();
 
   const resolvedScwUrl = scwUrl ?? scwUrls[0];
-  const simulateCoop =
-    new URL(resolvedScwUrl).searchParams.get("coop") === "same-origin";
+  const simulateCoop = new URL(resolvedScwUrl).searchParams.get('coop') === 'same-origin';
 
   const handleSimulateCoopToggle = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const url = new URL(scwUrl);
       if (e.target.checked) {
-        url.searchParams.set("coop", "same-origin");
+        url.searchParams.set('coop', 'same-origin');
       } else {
-        url.searchParams.delete("coop");
+        url.searchParams.delete('coop');
       }
-      setScwUrlAndSave(
-        url.toString() as Parameters<typeof setScwUrlAndSave>[0],
-      );
+      setScwUrlAndSave(url.toString() as Parameters<typeof setScwUrlAndSave>[0]);
     },
-    [scwUrl, setScwUrlAndSave],
+    [scwUrl, setScwUrlAndSave]
   );
   // @ts-expect-error refactor soon
-  const [connected, setConnected] = React.useState(
-    Boolean(provider?.connected),
-  );
+  const [connected, setConnected] = React.useState(Boolean(provider?.connected));
   const [chainId, setChainId] = React.useState<number | undefined>(undefined);
   // This is for Extension compatibility, Extension with SDK3.9 does not emit connect event
   // correctly, so we manually check if the extension is connected, and set the connected state
@@ -75,10 +70,10 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    provider?.on("connect", () => {
+    provider?.on('connect', () => {
       setConnected(true);
     });
-    provider?.on("chainChanged", (newChainId) => {
+    provider?.on('chainChanged', (newChainId) => {
       // @ts-expect-error refactor soon
       setChainId(newChainId);
     });
@@ -86,7 +81,7 @@ export default function Home() {
 
   useEffect(() => {
     if (connected) {
-      provider?.request({ method: "eth_chainId" }).then((chainId) => {
+      provider?.request({ method: 'eth_chainId' }).then((chainId) => {
         // @ts-expect-error refactor soon
         setChainId(Number.parseInt(chainId, 16));
       });
@@ -103,12 +98,12 @@ export default function Home() {
 
   return (
     <Container maxW={WIDTH_2XL} mb={8}>
-      <Grid templateColumns={{ base: "1fr", xl: "1fr 1fr" }} gap={4}>
+      <Grid templateColumns={{ base: '1fr', xl: '1fr 1fr' }} gap={4}>
         <GridItem>
-          <Box position={{ base: "static", xl: "sticky" }} top={{ xl: 6 }}>
+          <Box position={{ base: 'static', xl: 'sticky' }} top={{ xl: 6 }}>
             <Box>
               <Heading size="md">Event Listeners</Heading>
-              <Grid mt={2} templateColumns={{ base: "100%" }} gap={2}>
+              <Grid mt={2} templateColumns={{ base: '100%' }} gap={2}>
                 <EventListenersCard />
               </Grid>
             </Box>
@@ -125,17 +120,15 @@ export default function Home() {
             <TabList>
               <Tab>Wallet Connection</Tab>
               <Tab>Ephemeral Methods</Tab>
-              {shouldShowMethodsRequiringConnection && (
-                <Tab>Methods Requiring Connection</Tab>
-              )}
+              {shouldShowMethodsRequiringConnection && <Tab>Methods Requiring Connection</Tab>}
             </TabList>
             <TabPanels>
               <TabPanel px={0}>
                 <Grid
                   templateColumns={{
-                    base: "1fr",
-                    md: "repeat(2, 1fr)",
-                    xl: "repeat(1, 1fr)",
+                    base: '1fr',
+                    md: 'repeat(2, 1fr)',
+                    xl: 'repeat(1, 1fr)',
                   }}
                   gap={2}
                 >
@@ -144,29 +137,18 @@ export default function Home() {
                       method="eth_requestAccounts"
                       params={[]}
                       format={undefined}
-                      shortcuts={
-                        connectionMethodShortcutsMap?.["eth_requestAccounts"]
-                      }
+                      shortcuts={connectionMethodShortcutsMap?.['eth_requestAccounts']}
                     >
-                      <Flex
-                        align="center"
-                        justify="space-between"
-                        mt={4}
-                        pt={3}
-                        borderTopWidth={1}
-                      >
+                      <Flex align="center" justify="space-between" mt={4} pt={3} borderTopWidth={1}>
                         <Text fontSize="sm" fontWeight="medium">
                           Simulate COOP
                         </Text>
-                        <Switch
-                          isChecked={simulateCoop}
-                          onChange={handleSimulateCoopToggle}
-                        />
+                        <Switch isChecked={simulateCoop} onChange={handleSimulateCoopToggle} />
                       </Flex>
                     </RpcMethodCard>
                   </GridItem>
                   {connectionMethods
-                    .filter((rpc) => rpc.method !== "eth_requestAccounts")
+                    .filter((rpc) => rpc.method !== 'eth_requestAccounts')
                     .map((rpc) => (
                       <GridItem w="100%" key={rpc.method}>
                         <RpcMethodCard

--- a/examples/testapp/src/pages/index.page.tsx
+++ b/examples/testapp/src/pages/index.page.tsx
@@ -1,48 +1,69 @@
-import { Box, Container, Flex, Grid, GridItem, Heading, Switch, Text } from '@chakra-ui/react';
-import React, { useCallback, useEffect } from 'react';
+import {
+    Box,
+    Container,
+    Flex,
+    Grid,
+    GridItem,
+    Heading,
+    Switch,
+    Tab,
+    TabList,
+    TabPanel,
+    TabPanels,
+    Tabs,
+    Text,
+} from "@chakra-ui/react";
+import React, { useCallback, useEffect } from "react";
 
-import { EventListenersCard } from '../components/EventListeners/EventListenersCard';
-import { WIDTH_2XL } from '../components/Layout';
-import { MethodsSection } from '../components/MethodsSection/MethodsSection';
-import { RpcMethodCard } from '../components/RpcMethods/RpcMethodCard';
-import { useConfig } from '../context/ConfigContextProvider';
-import { connectionMethods } from '../components/RpcMethods/method/connectionMethods';
-import { ephemeralMethods } from '../components/RpcMethods/method/ephemeralMethods';
-import { multiChainMethods } from '../components/RpcMethods/method/multiChainMethods';
-import { readonlyJsonRpcMethods } from '../components/RpcMethods/method/readonlyJsonRpcMethods';
-import { sendMethods } from '../components/RpcMethods/method/sendMethods';
-import { signMessageMethods } from '../components/RpcMethods/method/signMessageMethods';
-import { walletTxMethods } from '../components/RpcMethods/method/walletTxMethods';
-import { connectionMethodShortcutsMap } from '../components/RpcMethods/shortcut/connectionMethodShortcuts';
-import { ephemeralMethodShortcutsMap } from '../components/RpcMethods/shortcut/ephemeralMethodShortcuts';
-import { multiChainShortcutsMap } from '../components/RpcMethods/shortcut/multipleChainShortcuts';
-import { readonlyJsonRpcShortcutsMap } from '../components/RpcMethods/shortcut/readonlyJsonRpcShortcuts';
-import { sendShortcutsMap } from '../components/RpcMethods/shortcut/sendShortcuts';
-import { signMessageShortcutsMap } from '../components/RpcMethods/shortcut/signMessageShortcuts';
-import { walletTxShortcutsMap } from '../components/RpcMethods/shortcut/walletTxShortcuts';
-import { SDKConfig } from '../components/SDKConfig/SDKConfig';
-import { useEIP1193Provider } from '../context/EIP1193ProviderContextProvider';
+import { EventListenersCard } from "../components/EventListeners/EventListenersCard";
+import { WIDTH_2XL } from "../components/Layout";
+import { MethodsSection } from "../components/MethodsSection/MethodsSection";
+import { connectionMethods } from "../components/RpcMethods/method/connectionMethods";
+import { ephemeralMethods } from "../components/RpcMethods/method/ephemeralMethods";
+import { multiChainMethods } from "../components/RpcMethods/method/multiChainMethods";
+import { readonlyJsonRpcMethods } from "../components/RpcMethods/method/readonlyJsonRpcMethods";
+import { sendMethods } from "../components/RpcMethods/method/sendMethods";
+import { signMessageMethods } from "../components/RpcMethods/method/signMessageMethods";
+import { walletTxMethods } from "../components/RpcMethods/method/walletTxMethods";
+import { RpcMethodCard } from "../components/RpcMethods/RpcMethodCard";
+import { connectionMethodShortcutsMap } from "../components/RpcMethods/shortcut/connectionMethodShortcuts";
+import { ephemeralMethodShortcutsMap } from "../components/RpcMethods/shortcut/ephemeralMethodShortcuts";
+import { multiChainShortcutsMap } from "../components/RpcMethods/shortcut/multipleChainShortcuts";
+import { readonlyJsonRpcShortcutsMap } from "../components/RpcMethods/shortcut/readonlyJsonRpcShortcuts";
+import { sendShortcutsMap } from "../components/RpcMethods/shortcut/sendShortcuts";
+import { signMessageShortcutsMap } from "../components/RpcMethods/shortcut/signMessageShortcuts";
+import { walletTxShortcutsMap } from "../components/RpcMethods/shortcut/walletTxShortcuts";
+import { SDKConfig } from "../components/SDKConfig/SDKConfig";
+import { useConfig } from "../context/ConfigContextProvider";
+import { useEIP1193Provider } from "../context/EIP1193ProviderContextProvider";
+import { scwUrls } from "../store/config";
 
 export default function Home() {
   const { provider } = useEIP1193Provider();
   const { scwUrl, setScwUrlAndSave } = useConfig();
 
-  const simulateCoop = new URL(scwUrl).searchParams.get('coop') === 'same-origin';
+  const resolvedScwUrl = scwUrl ?? scwUrls[0];
+  const simulateCoop =
+    new URL(resolvedScwUrl).searchParams.get("coop") === "same-origin";
 
   const handleSimulateCoopToggle = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const url = new URL(scwUrl);
       if (e.target.checked) {
-        url.searchParams.set('coop', 'same-origin');
+        url.searchParams.set("coop", "same-origin");
       } else {
-        url.searchParams.delete('coop');
+        url.searchParams.delete("coop");
       }
-      setScwUrlAndSave(url.toString() as Parameters<typeof setScwUrlAndSave>[0]);
+      setScwUrlAndSave(
+        url.toString() as Parameters<typeof setScwUrlAndSave>[0],
+      );
     },
-    [scwUrl, setScwUrlAndSave]
+    [scwUrl, setScwUrlAndSave],
   );
   // @ts-expect-error refactor soon
-  const [connected, setConnected] = React.useState(Boolean(provider?.connected));
+  const [connected, setConnected] = React.useState(
+    Boolean(provider?.connected),
+  );
   const [chainId, setChainId] = React.useState<number | undefined>(undefined);
   // This is for Extension compatibility, Extension with SDK3.9 does not emit connect event
   // correctly, so we manually check if the extension is connected, and set the connected state
@@ -54,10 +75,10 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    provider?.on('connect', () => {
+    provider?.on("connect", () => {
       setConnected(true);
     });
-    provider?.on('chainChanged', (newChainId) => {
+    provider?.on("chainChanged", (newChainId) => {
       // @ts-expect-error refactor soon
       setChainId(newChainId);
     });
@@ -65,7 +86,7 @@ export default function Home() {
 
   useEffect(() => {
     if (connected) {
-      provider?.request({ method: 'eth_chainId' }).then((chainId) => {
+      provider?.request({ method: "eth_chainId" }).then((chainId) => {
         // @ts-expect-error refactor soon
         setChainId(Number.parseInt(chainId, 16));
       });
@@ -82,82 +103,123 @@ export default function Home() {
 
   return (
     <Container maxW={WIDTH_2XL} mb={8}>
-      <Box>
-        <Heading size="md">Event Listeners</Heading>
-        <Grid mt={2} templateColumns={{ base: '100%' }} gap={2}>
-          <EventListenersCard />
-        </Grid>
-      </Box>
-      <Heading size="md" mt={4}>
-        SDK Configuration (Optional)
-      </Heading>
-      <Box mt={4}>
-        <SDKConfig />
-      </Box>
-      <Box mt={4}>
-        <Heading size="md">Wallet Connection</Heading>
-        <Grid
-          mt={2}
-          templateColumns={{ base: '100%', md: 'repeat(2, 50%)', xl: 'repeat(3, 33%)' }}
-          gap={2}
-        >
-          <GridItem w="100%" key="eth_requestAccounts">
-            <RpcMethodCard
-              method="eth_requestAccounts"
-              params={[]}
-              format={undefined}
-              shortcuts={connectionMethodShortcutsMap?.['eth_requestAccounts']}
-            >
-              <Flex align="center" justify="space-between" mt={4} pt={3} borderTopWidth={1}>
-                <Text fontSize="sm" fontWeight="medium">Simulate COOP</Text>
-                <Switch isChecked={simulateCoop} onChange={handleSimulateCoopToggle} />
-              </Flex>
-            </RpcMethodCard>
-          </GridItem>
-          {connectionMethods
-            .filter((rpc) => rpc.method !== 'eth_requestAccounts')
-            .map((rpc) => (
-              <GridItem w="100%" key={rpc.method}>
-                <RpcMethodCard
-                  method={rpc.method}
-                  params={rpc.params}
-                  format={rpc.format}
-                  shortcuts={connectionMethodShortcutsMap?.[rpc.method]}
+      <Grid templateColumns={{ base: "1fr", xl: "1fr 1fr" }} gap={4}>
+        <GridItem>
+          <Box position={{ base: "static", xl: "sticky" }} top={{ xl: 6 }}>
+            <Box>
+              <Heading size="md">Event Listeners</Heading>
+              <Grid mt={2} templateColumns={{ base: "100%" }} gap={2}>
+                <EventListenersCard />
+              </Grid>
+            </Box>
+            <Heading size="md" mt={4}>
+              SDK Configuration (Optional)
+            </Heading>
+            <Box mt={4}>
+              <SDKConfig />
+            </Box>
+          </Box>
+        </GridItem>
+        <GridItem minW={0} alignSelf="start">
+          <Tabs variant="enclosed" isLazy>
+            <TabList>
+              <Tab>Wallet Connection</Tab>
+              <Tab>Ephemeral Methods</Tab>
+              {shouldShowMethodsRequiringConnection && (
+                <Tab>Methods Requiring Connection</Tab>
+              )}
+            </TabList>
+            <TabPanels>
+              <TabPanel px={0}>
+                <Grid
+                  templateColumns={{
+                    base: "1fr",
+                    md: "repeat(2, 1fr)",
+                    xl: "repeat(1, 1fr)",
+                  }}
+                  gap={2}
+                >
+                  <GridItem w="100%" key="eth_requestAccounts">
+                    <RpcMethodCard
+                      method="eth_requestAccounts"
+                      params={[]}
+                      format={undefined}
+                      shortcuts={
+                        connectionMethodShortcutsMap?.["eth_requestAccounts"]
+                      }
+                    >
+                      <Flex
+                        align="center"
+                        justify="space-between"
+                        mt={4}
+                        pt={3}
+                        borderTopWidth={1}
+                      >
+                        <Text fontSize="sm" fontWeight="medium">
+                          Simulate COOP
+                        </Text>
+                        <Switch
+                          isChecked={simulateCoop}
+                          onChange={handleSimulateCoopToggle}
+                        />
+                      </Flex>
+                    </RpcMethodCard>
+                  </GridItem>
+                  {connectionMethods
+                    .filter((rpc) => rpc.method !== "eth_requestAccounts")
+                    .map((rpc) => (
+                      <GridItem w="100%" key={rpc.method}>
+                        <RpcMethodCard
+                          method={rpc.method}
+                          params={rpc.params}
+                          format={rpc.format}
+                          shortcuts={connectionMethodShortcutsMap?.[rpc.method]}
+                        />
+                      </GridItem>
+                    ))}
+                </Grid>
+              </TabPanel>
+              <TabPanel px={0}>
+                <MethodsSection
+                  methods={ephemeralMethods}
+                  shortcutsMap={ephemeralMethodShortcutsMap}
                 />
-              </GridItem>
-            ))}
-        </Grid>
-      </Box>
-      <MethodsSection
-        title="Ephemeral Methods"
-        methods={ephemeralMethods}
-        shortcutsMap={ephemeralMethodShortcutsMap}
-      />
-      {shouldShowMethodsRequiringConnection && (
-        <>
-          <MethodsSection
-            title="Switch/Add Chain"
-            methods={multiChainMethods}
-            shortcutsMap={multiChainShortcutsMap}
-          />
-          <MethodsSection
-            title="Sign Message"
-            methods={signMessageMethods}
-            shortcutsMap={signMessageShortcutsMap(chainId)}
-          />
-          <MethodsSection title="Send" methods={sendMethods} shortcutsMap={sendShortcutsMap} />
-          <MethodsSection
-            title="Wallet Tx"
-            methods={walletTxMethods}
-            shortcutsMap={walletTxShortcutsMap}
-          />
-          <MethodsSection
-            title="Read-only JSON-RPC Requests"
-            methods={readonlyJsonRpcMethods}
-            shortcutsMap={readonlyJsonRpcShortcutsMap}
-          />
-        </>
-      )}
+              </TabPanel>
+              <TabPanel px={0}>
+                {shouldShowMethodsRequiringConnection && (
+                  <>
+                    <MethodsSection
+                      title="Switch/Add Chain"
+                      methods={multiChainMethods}
+                      shortcutsMap={multiChainShortcutsMap}
+                    />
+                    <MethodsSection
+                      title="Sign Message"
+                      methods={signMessageMethods}
+                      shortcutsMap={signMessageShortcutsMap(chainId)}
+                    />
+                    <MethodsSection
+                      title="Send"
+                      methods={sendMethods}
+                      shortcutsMap={sendShortcutsMap}
+                    />
+                    <MethodsSection
+                      title="Wallet Tx"
+                      methods={walletTxMethods}
+                      shortcutsMap={walletTxShortcutsMap}
+                    />
+                    <MethodsSection
+                      title="Read-only JSON-RPC Requests"
+                      methods={readonlyJsonRpcMethods}
+                      shortcutsMap={readonlyJsonRpcShortcutsMap}
+                    />
+                  </>
+                )}
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </GridItem>
+      </Grid>
     </Container>
   );
 }


### PR DESCRIPTION
### _Summary_

Improves the SDK playground (`examples/testapp`) UX and layout:

- Reorganize the home page into a two-column layout with sticky Event Listeners / SDK Config
- Add tabs for **Wallet Connection**, **Ephemeral Methods**, and **Methods Requiring Connection** (shown when connected)
- Make `MethodsSection` title optional and align method card grid widths
- Add an attached copy-icon control on RPC shortcut buttons (with brief “copied” feedback) for message payloads
- Guard `scwUrl` with a fallback so hard-refresh on `/` no longer crashes before config hydrates

### _How did you test your changes?_

- [ ] Ran `yarn dev` and opened `http://localhost:3001/` (hard refresh) — page and navbar load without visiting a 404 first
- [ ] Verified tabs: Connect, Ephemeral, and Methods Requiring Connection (after wallet connect)
- [ ] Verified sticky left column while scrolling method cards on desktop
- [ ] Verified shortcut copy icon copies message payload and shows check feedback
- [ ] Verified Simulate COOP toggle still updates SCW URL query param
- [ ] Added before/after screenshots below

**Screenshots**
**Before**
<img width="1865" height="1720" alt="screencapture-coinbase-github-io-coinbase-wallet-sdk-2026-07-25-07_22_33" src="https://github.com/user-attachments/assets/ee640dae-59ce-4cdf-8ab7-f6b9e147e579" />


**After**
<img width="1857" height="1033" alt="image" src="https://github.com/user-attachments/assets/172d205c-9b9f-4e90-a7ad-64ac6ef5f50f" />


**GIF**
<img width="1858" height="1078" alt="Recording2026-07-25140109-ezgif com-optimize" src="https://github.com/user-attachments/assets/6d575caf-978e-4bdc-8c65-d3340df637c7" />
