### PR TITLE
fix(provider): clear accounts on disconnect

### DIFF
--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.test.ts
@@ -54,6 +54,35 @@ describe('Event handling', () => {
     );
   });
 
+  it('does not clear accounts when disconnected before connecting', async () => {
+    const accountsChangedListener = vi.fn();
+    provider.on('accountsChanged', accountsChangedListener);
+
+    await provider.disconnect();
+
+    expect(accountsChangedListener).not.toHaveBeenCalled();
+  });
+
+  it('clears accounts once before disconnecting a connected provider', async () => {
+    const accountsChangedListener = vi.fn();
+    const eventOrder: string[] = [];
+    provider.on('accountsChanged', (...args) => {
+      accountsChangedListener(...args);
+      eventOrder.push('accountsChanged');
+    });
+    provider.on('disconnect', () => eventOrder.push('disconnect'));
+
+    await provider.request({ method: 'eth_requestAccounts' });
+    await provider.disconnect();
+
+    expect(accountsChangedListener).toHaveBeenCalledOnce();
+    expect(accountsChangedListener).toHaveBeenCalledWith([]);
+    expect(eventOrder).toEqual(['accountsChanged', 'disconnect']);
+
+    await provider.disconnect();
+    expect(accountsChangedListener).toHaveBeenCalledOnce();
+  });
+
   it('should emit chainChanged event on chainId change', async () => {
     const chainChangedListener = vi.fn();
     provider.on('chainChanged', chainChangedListener);

--- a/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
+++ b/packages/wallet-sdk/src/CoinbaseWalletProvider.ts
@@ -171,10 +171,14 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Prov
   }
 
   async disconnect() {
+    const wasConnected = this.signer !== null;
     await this.signer?.cleanup();
     this.signer = null;
     ScopedLocalStorage.clearAll();
     correlationIds.clear();
+    if (wasConnected) {
+      this.emit('accountsChanged', []);
+    }
     this.emit('disconnect', standardErrors.provider.disconnected('User initiated disconnection'));
   }
 


### PR DESCRIPTION
### _Summary_

- emit `accountsChanged([])` for a real connected-to-disconnected transition
- emit it before `disconnect` so consumers clear stale account state first
- avoid emitting it for a never-connected provider or repeated disconnects

Fixes #1857

### _How did you test your changes?_

- focused provider suite: 21/21 tests passed
- TypeScript typecheck
- Biome lint on both changed files
- `git diff --check`