### PR TITLE
fix: improve WalletLink snackbar and redirect dialog accessibility

### DIFF
--- a/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/RedirectDialog/RedirectDialog.scss
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/RedirectDialog/RedirectDialog.scss
@@ -29,7 +29,16 @@ $black: #0a0b0d;
       border-radius: 8px;
       background-color: $white;
       color: $black;
-    
+
+      &:focus {
+        outline: none;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $primary;
+        outline-offset: 2px;
+      }
+
       p {
         display: block;
         font-weight: 400;
@@ -38,7 +47,7 @@ $black: #0a0b0d;
         padding-bottom: 12px;
         color: $foreground-muted;
       }
-    
+
       button {
         appearance: none;
         border: none;
@@ -50,6 +59,17 @@ $black: #0a0b0d;
         font-weight: 600;
         font-size: 16px;
         line-height: 24px;
+        cursor: pointer;
+
+        &:focus {
+          outline: none;
+        }
+
+        &:focus-visible {
+          outline: 2px solid $primary;
+          outline-offset: 2px;
+          border-radius: 2px;
+        }
       }
 
       &.dark {

--- a/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/RedirectDialog/RedirectDialog.tsx
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/RedirectDialog/RedirectDialog.tsx
@@ -2,9 +2,10 @@ import { clsx } from 'clsx';
 import { FunctionComponent, render } from 'preact';
 // biome-ignore lint/correctness/noUnusedImports: preact
 import { h } from 'preact';
+import { useEffect, useId, useRef } from 'preact/hooks';
 
-import { injectCssReset } from '../cssReset/cssReset.js';
 import { SnackbarContainer } from '../Snackbar/Snackbar.js';
+import { injectCssReset } from '../cssReset/cssReset.js';
 import { isDarkMode } from '../util.js';
 import css from './RedirectDialog-css.js';
 
@@ -56,6 +57,9 @@ export class RedirectDialog {
   }
 }
 
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 const RedirectDialogContent: FunctionComponent<
   RedirectDialogProps & {
     onDismiss: () => void;
@@ -63,15 +67,84 @@ const RedirectDialogContent: FunctionComponent<
   }
 > = ({ title, buttonText, darkMode, onButtonClick, onDismiss }) => {
   const theme = darkMode ? 'dark' : 'light';
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+
+    const dialogEl = dialogRef.current;
+    if (!dialogEl) {
+      return;
+    }
+
+    const focusables = () =>
+      Array.from(dialogEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => !el.hasAttribute('disabled') && el.tabIndex !== -1
+      );
+
+    const initialFocus = focusables()[0] ?? dialogEl;
+    initialFocus.focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onDismiss();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const items = focusables();
+      if (items.length === 0) {
+        event.preventDefault();
+        dialogEl.focus();
+        return;
+      }
+
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (active === first || !dialogEl.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !dialogEl.contains(active)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      previouslyFocusedRef.current?.focus?.();
+    };
+  }, [onDismiss]);
 
   return (
     <SnackbarContainer darkMode={darkMode}>
       <div class="-cbwsdk-redirect-dialog">
         <style>{css}</style>
-        <div class="-cbwsdk-redirect-dialog-backdrop" onClick={onDismiss} />
-        <div class={clsx('-cbwsdk-redirect-dialog-box', theme)}>
-          <p>{title}</p>
-          <button onClick={onButtonClick}>{buttonText}</button>
+        <div class="-cbwsdk-redirect-dialog-backdrop" onClick={onDismiss} aria-hidden="true" />
+        <div
+          ref={dialogRef}
+          class={clsx('-cbwsdk-redirect-dialog-box', theme)}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          tabIndex={-1}
+        >
+          <p id={titleId}>{title}</p>
+          <button type="button" onClick={onButtonClick}>
+            {buttonText}
+          </button>
         </div>
       </div>
     </SnackbarContainer>

--- a/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/Snackbar/Snackbar.scss
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/Snackbar/Snackbar.scss
@@ -56,15 +56,31 @@
       }
 
       &-header {
+        appearance: none;
         display: flex;
         align-items: center;
         background: #ffffff;
         overflow: hidden;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        font: inherit;
+        text-align: left;
+        color: inherit;
 
         border: 1px solid #e7ebee;
         box-sizing: border-box;
         border-radius: 8px;
         cursor: pointer;
+
+        &:focus {
+          outline: none;
+        }
+
+        &:focus-visible {
+          outline: 2px solid #1652f0;
+          outline-offset: 2px;
+        }
 
         &-cblogo {
           margin: 8px 8px 8px 8px;
@@ -119,6 +135,7 @@
         }
 
         &-item {
+          appearance: none;
           visibility: inherit;
           height: 35px;
           margin-top: 8px;
@@ -127,7 +144,23 @@
           flex-direction: row;
           align-items: center;
           padding: 8px;
+          width: 100%;
+          border: none;
+          background: transparent;
+          font: inherit;
+          text-align: left;
+          color: inherit;
           cursor: pointer;
+
+          &:focus {
+            outline: none;
+          }
+
+          &:focus-visible {
+            outline: 2px solid #1652f0;
+            outline-offset: 2px;
+            border-radius: 6px;
+          }
 
           * {
             visibility: inherit;

--- a/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/Snackbar/Snackbar.test.tsx
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/Snackbar/Snackbar.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
 
 import { render, screen, waitFor } from '@testing-library/preact';
-import { vi } from 'vitest';
 // biome-ignore lint/correctness/noUnusedImports: preact
 import { h } from 'preact';
+import { vi } from 'vitest';
 
 import { Snackbar } from './Snackbar.js';
 
@@ -59,6 +59,15 @@ describe('Snackbar', () => {
           document.getElementsByClassName('-cbwsdk-snackbar-instance-menu-item-info-is-red').length
         ).toEqual(2);
       });
+
+      const header = document.querySelector(
+        'button.-cbwsdk-snackbar-instance-header'
+      ) as HTMLButtonElement;
+      expect(header).toBeTruthy();
+      expect(header.getAttribute('aria-expanded')).toBeTruthy();
+
+      const menuItems = document.querySelectorAll('button.-cbwsdk-snackbar-instance-menu-item');
+      expect(menuItems.length).toEqual(2);
     });
 
     test('@clear', () => {

--- a/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/Snackbar/Snackbar.tsx
+++ b/packages/wallet-sdk/src/sign/walletlink/relay/ui/components/Snackbar/Snackbar.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent, render } from 'preact';
 // biome-ignore lint/correctness/noUnusedImports: preact
 import { h } from 'preact';
 
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useId, useState } from 'preact/hooks';
 
 import { isDarkMode } from '../util.js';
 import css from './Snackbar-css.js';
@@ -99,6 +99,7 @@ export const SnackbarInstance: FunctionComponent<SnackbarInstanceProps> = ({
 }) => {
   const [hidden, setHidden] = useState(true);
   const [expanded, setExpanded] = useState(autoExpand ?? false);
+  const menuId = useId();
 
   useEffect(() => {
     const timers = [
@@ -119,6 +120,12 @@ export const SnackbarInstance: FunctionComponent<SnackbarInstanceProps> = ({
     setExpanded(!expanded);
   };
 
+  const headerLabel = message
+    ? `${message}. ${expanded ? 'Collapse' : 'Expand'} menu`
+    : expanded
+      ? 'Collapse menu'
+      : 'Expand menu';
+
   return (
     <div
       class={clsx(
@@ -127,10 +134,24 @@ export const SnackbarInstance: FunctionComponent<SnackbarInstanceProps> = ({
         expanded && '-cbwsdk-snackbar-instance-expanded'
       )}
     >
-      <div class="-cbwsdk-snackbar-instance-header" onClick={toggleExpanded}>
-        <img src={cblogo} class="-cbwsdk-snackbar-instance-header-cblogo" />{' '}
-        <div class="-cbwsdk-snackbar-instance-header-message">{message}</div>
-        <div class="-gear-container">
+      <button
+        type="button"
+        class="-cbwsdk-snackbar-instance-header"
+        onClick={toggleExpanded}
+        aria-expanded={expanded}
+        aria-controls={menuItems && menuItems.length > 0 ? menuId : undefined}
+        aria-label={headerLabel}
+      >
+        <img
+          src={cblogo}
+          class="-cbwsdk-snackbar-instance-header-cblogo"
+          alt=""
+          aria-hidden="true"
+        />{' '}
+        <span class="-cbwsdk-snackbar-instance-header-message" aria-hidden="true">
+          {message}
+        </span>
+        <span class="-gear-container" aria-hidden="true">
           {!expanded && (
             <svg
               width="24"
@@ -142,18 +163,27 @@ export const SnackbarInstance: FunctionComponent<SnackbarInstanceProps> = ({
               <circle cx="12" cy="12" r="12" fill="#F5F7F8" />
             </svg>
           )}
-          <img src={gearIcon} class="-gear-icon" title="Expand" />
-        </div>
-      </div>
+          <img src={gearIcon} class="-gear-icon" alt="" />
+        </span>
+      </button>
       {menuItems && menuItems.length > 0 && (
-        <div class="-cbwsdk-snackbar-instance-menu">
+        <div
+          id={menuId}
+          class="-cbwsdk-snackbar-instance-menu"
+          role="menu"
+          aria-label="Snackbar actions"
+          aria-hidden={!expanded}
+        >
           {menuItems.map((action, i) => (
-            <div
+            <button
+              type="button"
+              role="menuitem"
               class={clsx(
                 '-cbwsdk-snackbar-instance-menu-item',
                 action.isRed && '-cbwsdk-snackbar-instance-menu-item-is-red'
               )}
               onClick={action.onClick}
+              tabIndex={expanded ? 0 : -1}
               key={i}
             >
               <svg
@@ -162,6 +192,8 @@ export const SnackbarInstance: FunctionComponent<SnackbarInstanceProps> = ({
                 viewBox="0 0 10 11"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                focusable="false"
               >
                 <path
                   fill-rule={action.defaultFillRule}
@@ -178,7 +210,7 @@ export const SnackbarInstance: FunctionComponent<SnackbarInstanceProps> = ({
               >
                 {action.info}
               </span>
-            </div>
+            </button>
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary

Addresses keyboard and screen-reader gaps in the WalletLink injected UI reported in #1909.

### Snackbar (`Snackbar.tsx` / `Snackbar.scss`)
- Convert the header toggle and menu actions (for example Cancel transaction / Reset connection) from clickable `div`s to real `button` elements so they are reachable and activatable from the keyboard.
- Add accessible naming and state (`aria-label`, `aria-expanded`, `aria-controls`) on the header control.
- Expose the action list with `role="menu"` / `role="menuitem"`, hide it from assistive tech when collapsed (`aria-hidden`), and keep collapsed items out of the tab order (`tabIndex={-1}`).
- Mark decorative images/icons as decorative (`alt=""`, `aria-hidden`).
- Preserve the existing look with button resets and add `:focus-visible` outlines so keyboard focus is visible.

### RedirectDialog (`RedirectDialog.tsx` / `RedirectDialog.scss`)
- Expose dialog semantics with `role="dialog"`, `aria-modal="true"`, and `aria-labelledby`.
- Move focus into the dialog when it opens, keep Tab focus inside while it is open, support Escape to dismiss, and restore focus when it closes.
- Add `:focus-visible` styles for the dialog surface and action button.

This is intentionally a focused semantics/keyboard pass rather than a full UI rewrite. Visual behavior should stay the same aside from clearer keyboard focus indication.

Fixes #1909

## Test plan
- [x] `yarn vitest run` for Snackbar unit tests (including checks that header/menu actions render as buttons with `aria-expanded`)
- [ ] Manually: open a WalletLink desktop snackbar, Tab to the header and menu actions, activate with Enter/Space
- [ ] Manually: confirm Cancel transaction / Reset connection work from the keyboard
- [ ] Manually: open RedirectDialog on the mobile-web relay path, confirm focus lands in the dialog, Tab cycles inside it, Escape dismisses, and focus returns to the prior control
- [ ] Spot-check with a screen reader (VoiceOver / NVDA) that the header announces expand/collapse state and menu actions have clear names