### PR TITLE
docs: note Coinbase Wallet rebrand; Base Account SDK remains recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@coinbase/wallet-sdk.svg)](https://www.npmjs.com/package/@coinbase/wallet-sdk)
 
-> **Rebrand:** Base Account is now Coinbase Wallet. The npm package remains `@coinbase/wallet-sdk` — it has not been renamed or merged. Keep using `@coinbase/wallet-sdk` until the next-generation Coinbase Wallet SDK is ready. For new integrations, `@base-org/account` (Base Account SDK) is the current recommended SDK.
+> **Rebrand:** Base Account is now Coinbase Wallet. The npm package remains `@coinbase/wallet-sdk` — it has not been renamed or merged. `@coinbase/wallet-sdk` is **not** the current recommended SDK. Use `@base-org/account` (Base Account SDK) until the next-generation Coinbase Wallet SDK is ready. Existing `@coinbase/wallet-sdk` integrations continue to work.
 
 ## Coinbase Wallet SDK allows dapps to connect to Coinbase Wallet
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![npm](https://img.shields.io/npm/v/@coinbase/wallet-sdk.svg)](https://www.npmjs.com/package/@coinbase/wallet-sdk)
 
+> **Rebrand:** Base Account is now Coinbase Wallet. The npm package remains `@coinbase/wallet-sdk` — it has not been renamed or merged. Keep using `@coinbase/wallet-sdk` until the next-generation Coinbase Wallet SDK is ready. For new integrations, `@base-org/account` (Base Account SDK) is the current recommended SDK.
+
 ## Coinbase Wallet SDK allows dapps to connect to Coinbase Wallet
 
-1. [Coinbase Smart Wallet](https://keys.coinbase.com/onboarding)
+1. [Coinbase Wallet](https://keys.coinbase.com/onboarding)
    - [Docs](https://www.smartwallet.dev/)
 1. Coinbase Wallet mobile for [Android](https://play.google.com/store/apps/details?id=org.toshi&referrer=utm_source%3DWallet_LP) and [iOS](https://apps.apple.com/app/apple-store/id1278383455?pt=118788940&ct=Wallet_LP&mt=8)
    - Desktop: Users can connect to your dapp by scanning a QR code

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Coinbase Wallet SDK allows dapps to connect to Coinbase Wallet
 
 1. [Coinbase Wallet](https://wallet.coinbase.com)
-   - [Docs](https://www.smartwallet.dev/)
+   - [Docs](https://docs.cdp.coinbase.com/coinbase-wallet/overview)
 1. Coinbase Wallet mobile for [Android](https://play.google.com/store/apps/details?id=org.toshi&referrer=utm_source%3DWallet_LP) and [iOS](https://apps.apple.com/app/apple-store/id1278383455?pt=118788940&ct=Wallet_LP&mt=8)
    - Desktop: Users can connect to your dapp by scanning a QR code
    - Mobile: Users can connect to your mobile dapp through a deeplink to the dapp browser

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Coinbase Wallet SDK allows dapps to connect to Coinbase Wallet
 
-1. [Coinbase Wallet](https://keys.coinbase.com/onboarding)
+1. [Coinbase Wallet](https://wallet.coinbase.com)
    - [Docs](https://www.smartwallet.dev/)
 1. Coinbase Wallet mobile for [Android](https://play.google.com/store/apps/details?id=org.toshi&referrer=utm_source%3DWallet_LP) and [iOS](https://apps.apple.com/app/apple-store/id1278383455?pt=118788940&ct=Wallet_LP&mt=8)
    - Desktop: Users can connect to your dapp by scanning a QR code

--- a/packages/wallet-sdk/README.md
+++ b/packages/wallet-sdk/README.md
@@ -1,6 +1,6 @@
 # Coinbase Wallet SDK
 
-> **Rebrand:** Base Account is now Coinbase Wallet. The npm package remains `@coinbase/wallet-sdk` — it has not been renamed or merged. Keep using `@coinbase/wallet-sdk` until the next-generation Coinbase Wallet SDK is ready. For new integrations, `@base-org/account` (Base Account SDK) is the current recommended SDK.
+> **Rebrand:** Base Account is now Coinbase Wallet. The npm package remains `@coinbase/wallet-sdk` — it has not been renamed or merged. `@coinbase/wallet-sdk` is **not** the current recommended SDK. Use `@base-org/account` (Base Account SDK) until the next-generation Coinbase Wallet SDK is ready. Existing `@coinbase/wallet-sdk` integrations continue to work.
 
 ## Coinbase Wallet SDK lets developers connect their dapps to Coinbase Wallet in the following ways:
 

--- a/packages/wallet-sdk/README.md
+++ b/packages/wallet-sdk/README.md
@@ -5,7 +5,7 @@
 ## Coinbase Wallet SDK lets developers connect their dapps to Coinbase Wallet in the following ways:
 
 1. [Coinbase Wallet](https://wallet.coinbase.com)
-   - [Docs](https://www.smartwallet.dev/)
+   - [Docs](https://docs.cdp.coinbase.com/coinbase-wallet/overview)
 1. Coinbase Wallet mobile for [Android](https://play.google.com/store/apps/details?id=org.toshi&referrer=utm_source%3DWallet_LP) and [iOS](https://apps.apple.com/app/apple-store/id1278383455?pt=118788940&ct=Wallet_LP&mt=8)
    - Desktop: Users can connect to your dapp by scanning a QR code
    - Mobile: Users can connect to your mobile dapp through a deeplink to the dapp browser

--- a/packages/wallet-sdk/README.md
+++ b/packages/wallet-sdk/README.md
@@ -4,7 +4,7 @@
 
 ## Coinbase Wallet SDK lets developers connect their dapps to Coinbase Wallet in the following ways:
 
-1. [Coinbase Wallet](https://keys.coinbase.com/onboarding)
+1. [Coinbase Wallet](https://wallet.coinbase.com)
    - [Docs](https://www.smartwallet.dev/)
 1. Coinbase Wallet mobile for [Android](https://play.google.com/store/apps/details?id=org.toshi&referrer=utm_source%3DWallet_LP) and [iOS](https://apps.apple.com/app/apple-store/id1278383455?pt=118788940&ct=Wallet_LP&mt=8)
    - Desktop: Users can connect to your dapp by scanning a QR code

--- a/packages/wallet-sdk/README.md
+++ b/packages/wallet-sdk/README.md
@@ -1,8 +1,10 @@
 # Coinbase Wallet SDK
 
+> **Rebrand:** Base Account is now Coinbase Wallet. The npm package remains `@coinbase/wallet-sdk` — it has not been renamed or merged. Keep using `@coinbase/wallet-sdk` until the next-generation Coinbase Wallet SDK is ready. For new integrations, `@base-org/account` (Base Account SDK) is the current recommended SDK.
+
 ## Coinbase Wallet SDK lets developers connect their dapps to Coinbase Wallet in the following ways:
 
-1. [Coinbase Smart Wallet](https://keys.coinbase.com/onboarding)
+1. [Coinbase Wallet](https://keys.coinbase.com/onboarding)
    - [Docs](https://www.smartwallet.dev/)
 1. Coinbase Wallet mobile for [Android](https://play.google.com/store/apps/details?id=org.toshi&referrer=utm_source%3DWallet_LP) and [iOS](https://apps.apple.com/app/apple-store/id1278383455?pt=118788940&ct=Wallet_LP&mt=8)
    - Desktop: Users can connect to your dapp by scanning a QR code


### PR DESCRIPTION
### _Summary_

https://linear.app/coinbase/issue/CBW-357/update-npm-readmes-examples-screenshots-and-changelog-after-rebrand

Base Account is now Coinbase Wallet. This README update states that the npm package remains `@coinbase/wallet-sdk` (not renamed or merged) and that it stays supported until the next-generation Coinbase Wallet SDK is ready. For new integrations, `@base-org/account` is the current recommended SDK.

### _How did you test your changes?_

README-only. Confirmed install snippets still name `@coinbase/wallet-sdk`.


Made with [Cursor](https://cursor.com)